### PR TITLE
Update README with remote access use case and architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # Agent Cockpit
 
-A web-based chat interface for interacting with Claude Code CLI sessions. Provides Google OAuth authentication, conversation management, file uploads, and real-time streaming responses.
+A web-based chat interface for interacting with Claude Code CLI sessions. Agent Cockpit runs on the same machine as your CLI tools, giving you remote browser-based access to them. Install it on your own machine, expose it through a tunnel like [ngrok](https://ngrok.com/), and you can interact with your local Claude Code CLI from anywhere — your phone, a tablet, or another computer.
+
+## How It Works
+
+Agent Cockpit is a thin web layer that sits in front of the Claude Code CLI installed on your machine. When you send a message through the browser, the server spawns a `claude` CLI process locally, streams the response back over Server-Sent Events, and stores the conversation as a JSON file on disk. The CLI runs with full access to your local filesystem and tools, just as it would in your terminal.
+
+This means:
+- **The CLI and the web interface must run on the same machine.** Agent Cockpit does not connect to a remote API — it spawns local processes.
+- **Exposing the server (e.g., via ngrok) gives you remote access to your local CLIs.** You can chat with Claude Code from any browser, anywhere, while it operates on your local files and environment.
+- **Google OAuth protects access.** Only the email address you configure in `ALLOWED_EMAIL` can log in, so your CLI sessions stay private even when exposed over the internet.
 
 ## Prerequisites
 
 - Node.js 18+
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated
+- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated on the same machine
 - A Google Cloud project with OAuth 2.0 credentials
+- (Optional) [ngrok](https://ngrok.com/) or a similar tunnel for remote access
 
 ## Quick Start
 
@@ -29,6 +39,16 @@ npm start
 ```
 
 4. Open `http://localhost:3334` in your browser.
+
+### Remote Access with ngrok
+
+To access Agent Cockpit from outside your local network:
+
+```bash
+ngrok http 3334
+```
+
+Use the ngrok-provided URL to reach your local Agent Cockpit from any device. Make sure to update your Google OAuth **Authorized JavaScript origins** and **Authorized redirect URIs** to include the ngrok URL.
 
 ## Google OAuth Setup
 


### PR DESCRIPTION
Explain that Agent Cockpit runs on the same machine as the CLI tools and can be exposed via ngrok for remote browser-based access. Add "How It Works" section and ngrok setup instructions.