### PR TITLE
Add file-based session store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "multer": "^1.4.5-lts.1",
         "on-headers": "^1.0.2",
         "passport": "^0.7.0",
-        "passport-google-oauth20": "^2.0.0"
+        "passport-google-oauth20": "^2.0.0",
+        "session-file-store": "^1.5.0"
       },
       "devDependencies": {
         "jest": "^30.3.0"
@@ -1601,6 +1602,18 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
@@ -1700,6 +1713,12 @@
         "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
       }
     },
+    "node_modules/bagpipe": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/bagpipe/-/bagpipe-0.3.5.tgz",
+      "integrity": "sha512-42sAlmPDKes1nLm/aly+0VdaopSU9br+jkRELedhQxI5uXHgtk47I83Mpmf4zoNTRMASdLFtUkimlu/Z9zQ8+g==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1728,6 +1747,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -2612,6 +2637,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2761,7 +2800,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -2880,7 +2918,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -2961,6 +2998,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -3746,6 +3789,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kruptein": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/kruptein/-/kruptein-2.2.3.tgz",
+      "integrity": "sha512-BTwprBPTzkFT9oTugxKd3WnWrX630MqUDsnmBuoa98eQs12oD4n4TeI0GbpdGcYn/73Xueg2rfnw+oK4dovnJg==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1.js": "^5.4.1"
+      },
+      "engines": {
+        "node": ">6"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -3910,6 +3974,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
@@ -4555,6 +4625,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4634,6 +4713,41 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/session-file-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/session-file-store/-/session-file-store-1.5.0.tgz",
+      "integrity": "sha512-60IZaJNzyu2tIeHutkYE8RiXVx3KRvacOxfLr2Mj92SIsRIroDsH0IlUUR6fJAjoTW4RQISbaOApa2IZpIwFdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bagpipe": "^0.3.5",
+        "fs-extra": "^8.0.1",
+        "kruptein": "^2.0.4",
+        "object-assign": "^4.1.1",
+        "retry": "^0.12.0",
+        "write-file-atomic": "3.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/session-file-store/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/session-file-store/node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
       }
     },
     "node_modules/setprototypeof": {
@@ -5163,6 +5277,15 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
     },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "node_modules/uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -5187,6 +5310,15 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "multer": "^1.4.5-lts.1",
     "on-headers": "^1.0.2",
     "passport": "^0.7.0",
-    "passport-google-oauth20": "^2.0.0"
+    "passport-google-oauth20": "^2.0.0",
+    "session-file-store": "^1.5.0"
   },
   "devDependencies": {
     "jest": "^30.3.0"

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const express = require('express');
 const session = require('express-session');
+const FileStore = require('session-file-store')(session);
 const config = require('./src/config');
 const { setupAuth, requireAuth } = require('./src/middleware/auth');
 const { ensureCsrfToken } = require('./src/middleware/csrf');
@@ -16,6 +17,11 @@ app.set('trust proxy', 1);
 applySecurity(app);
 
 app.use(session({
+  store: new FileStore({
+    path: path.join(__dirname, 'data', 'sessions'),
+    ttl: 24 * 60 * 60,
+    retries: 0,
+  }),
   secret: config.SESSION_SECRET,
   resave: false,
   saveUninitialized: false,

--- a/test/sessionStore.test.js
+++ b/test/sessionStore.test.js
@@ -1,0 +1,89 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const session = require('express-session');
+const FileStore = require('session-file-store')(session);
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-store-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function createStore() {
+  return new FileStore({
+    path: tmpDir,
+    ttl: 60,
+    retries: 0,
+  });
+}
+
+describe('file session store', () => {
+  test('persists session to disk', (done) => {
+    const store = createStore();
+    const sessionData = { cookie: { maxAge: 60000 }, user: 'test@test.com', csrfToken: 'abc123' };
+
+    store.set('test-session-1', sessionData, (err) => {
+      expect(err).toBeFalsy();
+
+      const files = fs.readdirSync(tmpDir).filter(f => f.endsWith('.json'));
+      expect(files.length).toBeGreaterThanOrEqual(1);
+      done();
+    });
+  });
+
+  test('retrieves session from disk', (done) => {
+    const store = createStore();
+    const sessionData = { cookie: { maxAge: 60000 }, user: 'test@test.com', csrfToken: 'abc123' };
+
+    store.set('test-session-2', sessionData, (err) => {
+      expect(err).toBeFalsy();
+
+      store.get('test-session-2', (err, data) => {
+        expect(err).toBeFalsy();
+        expect(data.user).toBe('test@test.com');
+        expect(data.csrfToken).toBe('abc123');
+        done();
+      });
+    });
+  });
+
+  test('survives store recreation (simulates restart)', (done) => {
+    const store1 = createStore();
+    const sessionData = { cookie: { maxAge: 60000 }, user: 'test@test.com' };
+
+    store1.set('test-session-3', sessionData, (err) => {
+      expect(err).toBeFalsy();
+
+      // Create a new store pointing to the same directory (simulates server restart)
+      const store2 = createStore();
+      store2.get('test-session-3', (err, data) => {
+        expect(err).toBeFalsy();
+        expect(data.user).toBe('test@test.com');
+        done();
+      });
+    });
+  });
+
+  test('destroy removes session from disk', (done) => {
+    const store = createStore();
+    const sessionData = { cookie: { maxAge: 60000 }, user: 'test@test.com' };
+
+    store.set('test-session-4', sessionData, (err) => {
+      expect(err).toBeFalsy();
+
+      store.destroy('test-session-4', (err) => {
+        expect(err).toBeFalsy();
+
+        store.get('test-session-4', (err, data) => {
+          expect(data).toBeFalsy();
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Replace default in-memory session store with `session-file-store`
- Sessions persist to `data/sessions/` (already gitignored) and survive server restarts
- TTL matches cookie maxAge (24 hours), expired sessions auto-pruned

## Test plan
- [x] 4 new tests: persist to disk, retrieve from disk, survive store recreation (restart), destroy removes file
- [x] All 42 tests pass locally
- [ ] CI passes