### PR TITLE
Convert file I/O to async fs.promises

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -56,10 +56,10 @@ function createChatRouter({ chatService, cliBackend }) {
   });
 
   // ── List conversations ─────────────────────────────────────────────────────
-  router.get('/conversations', (req, res) => {
+  router.get('/conversations', async (req, res) => {
     try {
       const q = req.query.q || '';
-      const convs = q ? chatService.searchConversations(q) : chatService.listConversations();
+      const convs = q ? await chatService.searchConversations(q) : await chatService.listConversations();
       res.json({ conversations: convs });
     } catch (err) {
       res.status(500).json({ error: err.message });
@@ -67,9 +67,9 @@ function createChatRouter({ chatService, cliBackend }) {
   });
 
   // ── Get single conversation ────────────────────────────────────────────────
-  router.get('/conversations/:id', (req, res) => {
+  router.get('/conversations/:id', async (req, res) => {
     try {
-      const conv = chatService.getConversation(req.params.id);
+      const conv = await chatService.getConversation(req.params.id);
       if (!conv) return res.status(404).json({ error: 'Conversation not found' });
       res.json(conv);
     } catch (err) {
@@ -78,9 +78,9 @@ function createChatRouter({ chatService, cliBackend }) {
   });
 
   // ── Create conversation ────────────────────────────────────────────────────
-  router.post('/conversations', csrfGuard, (req, res) => {
+  router.post('/conversations', csrfGuard, async (req, res) => {
     try {
-      const conv = chatService.createConversation(req.body.title, req.body.workingDir);
+      const conv = await chatService.createConversation(req.body.title, req.body.workingDir);
       res.json(conv);
     } catch (err) {
       res.status(500).json({ error: err.message });
@@ -88,9 +88,9 @@ function createChatRouter({ chatService, cliBackend }) {
   });
 
   // ── Rename conversation ────────────────────────────────────────────────────
-  router.put('/conversations/:id', csrfGuard, (req, res) => {
+  router.put('/conversations/:id', csrfGuard, async (req, res) => {
     try {
-      const conv = chatService.renameConversation(req.params.id, req.body.title);
+      const conv = await chatService.renameConversation(req.params.id, req.body.title);
       if (!conv) return res.status(404).json({ error: 'Conversation not found' });
       res.json(conv);
     } catch (err) {
@@ -99,7 +99,7 @@ function createChatRouter({ chatService, cliBackend }) {
   });
 
   // ── Delete conversation ────────────────────────────────────────────────────
-  router.delete('/conversations/:id', csrfGuard, (req, res) => {
+  router.delete('/conversations/:id', csrfGuard, async (req, res) => {
     try {
       // Abort any active stream
       const entry = activeStreams.get(req.params.id);
@@ -107,7 +107,7 @@ function createChatRouter({ chatService, cliBackend }) {
         entry.abort();
         activeStreams.delete(req.params.id);
       }
-      const ok = chatService.deleteConversation(req.params.id);
+      const ok = await chatService.deleteConversation(req.params.id);
       if (!ok) return res.status(404).json({ error: 'Conversation not found' });
       res.json({ ok: true });
     } catch (err) {
@@ -116,11 +116,11 @@ function createChatRouter({ chatService, cliBackend }) {
   });
 
   // ── Download conversation as markdown ──────────────────────────────────────
-  router.get('/conversations/:id/download', (req, res) => {
+  router.get('/conversations/:id/download', async (req, res) => {
     try {
-      const md = chatService.conversationToMarkdown(req.params.id);
+      const md = await chatService.conversationToMarkdown(req.params.id);
       if (!md) return res.status(404).json({ error: 'Conversation not found' });
-      const conv = chatService.getConversation(req.params.id);
+      const conv = await chatService.getConversation(req.params.id);
       const filename = (conv.title || 'conversation').replace(/[^a-zA-Z0-9-_ ]/g, '').substring(0, 50).trim() + '.md';
       res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
       res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
@@ -131,9 +131,9 @@ function createChatRouter({ chatService, cliBackend }) {
   });
 
   // ── Session history ────────────────────────────────────────────────────────
-  router.get('/conversations/:id/sessions', (req, res) => {
+  router.get('/conversations/:id/sessions', async (req, res) => {
     try {
-      const sessions = chatService.getSessionHistory(req.params.id);
+      const sessions = await chatService.getSessionHistory(req.params.id);
       if (!sessions) return res.status(404).json({ error: 'Conversation not found' });
       res.json({ sessions });
     } catch (err) {
@@ -142,13 +142,13 @@ function createChatRouter({ chatService, cliBackend }) {
   });
 
   // ── Reset session ──────────────────────────────────────────────────────────
-  router.post('/conversations/:id/reset', csrfGuard, (req, res) => {
+  router.post('/conversations/:id/reset', csrfGuard, async (req, res) => {
     try {
       // Block if streaming
       if (activeStreams.has(req.params.id)) {
         return res.status(409).json({ error: 'Cannot reset session while streaming' });
       }
-      const result = chatService.resetSession(req.params.id);
+      const result = await chatService.resetSession(req.params.id);
       if (!result) return res.status(404).json({ error: 'Conversation not found' });
       res.json(result);
     } catch (err) {
@@ -165,17 +165,17 @@ function createChatRouter({ chatService, cliBackend }) {
       return res.status(400).json({ error: 'Message content required' });
     }
 
-    const conv = chatService.getConversation(convId);
+    const conv = await chatService.getConversation(convId);
     if (!conv) return res.status(404).json({ error: 'Conversation not found' });
 
     // Update backend if changed
     if (backend && backend !== conv.backend) {
       conv.backend = backend;
-      chatService.saveConversation(conv);
+      await chatService.saveConversation(conv);
     }
 
     // Add user message
-    const userMsg = chatService.addMessage(convId, 'user', content.trim(), backend || conv.backend);
+    const userMsg = await chatService.addMessage(convId, 'user', content.trim(), backend || conv.backend);
 
     // Determine if this is the first message in the current Claude Code session
     const currentSession = conv.sessions[conv.sessions.length - 1];
@@ -249,7 +249,7 @@ function createChatRouter({ chatService, cliBackend }) {
             const finalContent = resultText || fullResponse;
             console.log(`[chat] Stream done for conv=${convId}, responseLen=${finalContent.length}`);
             if (finalContent.trim()) {
-              const assistantMsg = chatService.addMessage(convId, 'assistant', finalContent.trim(), backend);
+              const assistantMsg = await chatService.addMessage(convId, 'assistant', finalContent.trim(), backend);
               res.write(`data: ${JSON.stringify({ type: 'assistant_message', message: assistantMsg })}\n\n`);
             }
             res.write(`data: ${JSON.stringify({ type: 'done' })}\n\n`);
@@ -284,8 +284,8 @@ function createChatRouter({ chatService, cliBackend }) {
   // ── File upload ─────────────────────────────────────────────────────────────
   const upload = multer({
     storage: multer.diskStorage({
-      destination: (req, file, cb) => {
-        const conv = chatService.getConversation(req.params.id);
+      destination: async (req, file, cb) => {
+        const conv = await chatService.getConversation(req.params.id);
         const dir = conv?.workingDir || cliBackend.workingDir;
         cb(null, dir);
       },
@@ -307,17 +307,17 @@ function createChatRouter({ chatService, cliBackend }) {
   });
 
   // ── Settings ───────────────────────────────────────────────────────────────
-  router.get('/settings', (req, res) => {
+  router.get('/settings', async (req, res) => {
     try {
-      res.json(chatService.getSettings());
+      res.json(await chatService.getSettings());
     } catch (err) {
       res.status(500).json({ error: err.message });
     }
   });
 
-  router.put('/settings', csrfGuard, (req, res) => {
+  router.put('/settings', csrfGuard, async (req, res) => {
     try {
-      const settings = chatService.saveSettings(req.body);
+      const settings = await chatService.saveSettings(req.body);
       res.json(settings);
     } catch (err) {
       res.status(500).json({ error: err.message });

--- a/src/services/chatService.js
+++ b/src/services/chatService.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const fsp = fs.promises;
 const path = require('path');
 const crypto = require('crypto');
 
@@ -10,7 +11,7 @@ class ChatService {
     this.artifactsDir = path.join(this.baseDir, 'artifacts');
     this.settingsFile = path.join(this.baseDir, 'settings.json');
 
-    // Ensure directories exist
+    // Ensure directories exist (sync in constructor only — runs once at startup)
     for (const dir of [this.conversationsDir, this.archivesDir, this.artifactsDir]) {
       if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
     }
@@ -26,7 +27,7 @@ class ChatService {
     return crypto.randomUUID();
   }
 
-  createConversation(title, workingDir) {
+  async createConversation(title, workingDir) {
     const id = this._newId();
     const now = new Date().toISOString();
     const sessionId = this._newId();
@@ -48,28 +49,40 @@ class ChatService {
         messageCount: 0,
       }],
     };
-    fs.writeFileSync(this._convPath(id), JSON.stringify(conv, null, 2), 'utf8');
+    await fsp.writeFile(this._convPath(id), JSON.stringify(conv, null, 2), 'utf8');
     return conv;
   }
 
-  getConversation(id) {
+  async getConversation(id) {
     const p = this._convPath(id);
-    if (!fs.existsSync(p)) return null;
-    return JSON.parse(fs.readFileSync(p, 'utf8'));
+    try {
+      const data = await fsp.readFile(p, 'utf8');
+      return JSON.parse(data);
+    } catch (err) {
+      if (err.code === 'ENOENT') return null;
+      throw err;
+    }
   }
 
-  saveConversation(conv) {
+  async saveConversation(conv) {
     conv.updatedAt = new Date().toISOString();
-    fs.writeFileSync(this._convPath(conv.id), JSON.stringify(conv, null, 2), 'utf8');
+    await fsp.writeFile(this._convPath(conv.id), JSON.stringify(conv, null, 2), 'utf8');
   }
 
-  listConversations() {
-    if (!fs.existsSync(this.conversationsDir)) return [];
-    const files = fs.readdirSync(this.conversationsDir).filter(f => f.endsWith('.json'));
+  async listConversations() {
+    let files;
+    try {
+      files = await fsp.readdir(this.conversationsDir);
+    } catch (err) {
+      if (err.code === 'ENOENT') return [];
+      throw err;
+    }
+    files = files.filter(f => f.endsWith('.json'));
     const convs = [];
     for (const f of files) {
       try {
-        const conv = JSON.parse(fs.readFileSync(path.join(this.conversationsDir, f), 'utf8'));
+        const data = await fsp.readFile(path.join(this.conversationsDir, f), 'utf8');
+        const conv = JSON.parse(data);
         convs.push({
           id: conv.id,
           title: conv.title,
@@ -89,27 +102,29 @@ class ChatService {
     return convs;
   }
 
-  renameConversation(id, newTitle) {
-    const conv = this.getConversation(id);
+  async renameConversation(id, newTitle) {
+    const conv = await this.getConversation(id);
     if (!conv) return null;
     conv.title = newTitle;
-    this.saveConversation(conv);
+    await this.saveConversation(conv);
     return conv;
   }
 
-  deleteConversation(id) {
+  async deleteConversation(id) {
     const p = this._convPath(id);
-    if (fs.existsSync(p)) {
-      fs.unlinkSync(p);
+    try {
+      await fsp.unlink(p);
       return true;
+    } catch (err) {
+      if (err.code === 'ENOENT') return false;
+      throw err;
     }
-    return false;
   }
 
   // ── Messages ───────────────────────────────────────────────────────────────
 
-  addMessage(convId, role, content, backend) {
-    const conv = this.getConversation(convId);
+  async addMessage(convId, role, content, backend) {
+    const conv = await this.getConversation(convId);
     if (!conv) return null;
 
     const msg = {
@@ -131,12 +146,12 @@ class ChatService {
     const currentSession = conv.sessions[conv.sessions.length - 1];
     if (currentSession) currentSession.messageCount++;
 
-    this.saveConversation(conv);
+    await this.saveConversation(conv);
     return msg;
   }
 
-  updateMessageContent(convId, messageId, newContent) {
-    const conv = this.getConversation(convId);
+  async updateMessageContent(convId, messageId, newContent) {
+    const conv = await this.getConversation(convId);
     if (!conv) return null;
 
     const msgIndex = conv.messages.findIndex(m => m.id === messageId);
@@ -154,14 +169,14 @@ class ChatService {
       timestamp: new Date().toISOString(),
     };
     conv.messages.push(msg);
-    this.saveConversation(conv);
+    await this.saveConversation(conv);
     return { conversation: conv, message: msg };
   }
 
   // ── Session Management ─────────────────────────────────────────────────────
 
-  resetSession(convId) {
-    const conv = this.getConversation(convId);
+  async resetSession(convId) {
+    const conv = await this.getConversation(convId);
     if (!conv) return null;
 
     const now = new Date();
@@ -170,7 +185,7 @@ class ChatService {
     // Archive current session to markdown
     const archiveContent = this._sessionToMarkdown(conv, currentSession);
     const archiveFilename = `${conv.id}_${currentSession.number}_${now.toISOString().replace(/[:.]/g, '-')}.md`;
-    fs.writeFileSync(
+    await fsp.writeFile(
       path.join(this.archivesDir, archiveFilename),
       archiveContent,
       'utf8'
@@ -202,7 +217,7 @@ class ChatService {
       messageCount: 0,
     });
 
-    this.saveConversation(conv);
+    await this.saveConversation(conv);
     return {
       conversation: conv,
       archiveFilename,
@@ -210,8 +225,8 @@ class ChatService {
     };
   }
 
-  getSessionHistory(convId) {
-    const conv = this.getConversation(convId);
+  async getSessionHistory(convId) {
+    const conv = await this.getConversation(convId);
     if (!conv) return null;
     return conv.sessions.map(s => ({
       ...s,
@@ -263,8 +278,8 @@ class ChatService {
 
   // ── Download entire conversation as Markdown ───────────────────────────────
 
-  conversationToMarkdown(convId) {
-    const conv = this.getConversation(convId);
+  async conversationToMarkdown(convId) {
+    const conv = await this.getConversation(convId);
     if (!conv) return null;
 
     const lines = [
@@ -300,37 +315,44 @@ class ChatService {
 
   // ── Search ─────────────────────────────────────────────────────────────────
 
-  searchConversations(query) {
+  async searchConversations(query) {
     if (!query) return this.listConversations();
     const q = query.toLowerCase();
-    const all = this.listConversations();
-    return all.filter(c => {
-      if (c.title.toLowerCase().includes(q)) return true;
-      if (c.lastMessage && c.lastMessage.toLowerCase().includes(q)) return true;
+    const all = await this.listConversations();
+    const results = [];
+    for (const c of all) {
+      if (c.title.toLowerCase().includes(q)) { results.push(c); continue; }
+      if (c.lastMessage && c.lastMessage.toLowerCase().includes(q)) { results.push(c); continue; }
       // Deep search: load full conversation
-      const conv = this.getConversation(c.id);
-      if (!conv) return false;
-      return conv.messages.some(m => m.content.toLowerCase().includes(q));
-    });
+      const conv = await this.getConversation(c.id);
+      if (!conv) continue;
+      if (conv.messages.some(m => m.content.toLowerCase().includes(q))) results.push(c);
+    }
+    return results;
   }
 
   // ── Settings ───────────────────────────────────────────────────────────────
 
-  getSettings() {
-    if (!fs.existsSync(this.settingsFile)) {
-      return {
-        theme: 'system',
-        sendBehavior: 'enter',
-        customInstructions: { aboutUser: '', responseStyle: '' },
-        defaultBackend: 'claude-code',
-        workingDirectory: '',
-      };
+  async getSettings() {
+    try {
+      const data = await fsp.readFile(this.settingsFile, 'utf8');
+      return JSON.parse(data);
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        return {
+          theme: 'system',
+          sendBehavior: 'enter',
+          customInstructions: { aboutUser: '', responseStyle: '' },
+          defaultBackend: 'claude-code',
+          workingDirectory: '',
+        };
+      }
+      throw err;
     }
-    return JSON.parse(fs.readFileSync(this.settingsFile, 'utf8'));
   }
 
-  saveSettings(settings) {
-    fs.writeFileSync(this.settingsFile, JSON.stringify(settings, null, 2), 'utf8');
+  async saveSettings(settings) {
+    await fsp.writeFile(this.settingsFile, JSON.stringify(settings, null, 2), 'utf8');
     return settings;
   }
 }

--- a/test/chatService.test.js
+++ b/test/chatService.test.js
@@ -18,8 +18,8 @@ afterEach(() => {
 // ── Conversation CRUD ────────────────────────────────────────────────────────
 
 describe('createConversation', () => {
-  test('creates with default title', () => {
-    const conv = service.createConversation();
+  test('creates with default title', async () => {
+    const conv = await service.createConversation();
     expect(conv.title).toBe('New Chat');
     expect(conv.messages).toEqual([]);
     expect(conv.sessions).toHaveLength(1);
@@ -27,14 +27,14 @@ describe('createConversation', () => {
     expect(conv.backend).toBe('claude-code');
   });
 
-  test('creates with custom title and working dir', () => {
-    const conv = service.createConversation('My Chat', '/tmp/work');
+  test('creates with custom title and working dir', async () => {
+    const conv = await service.createConversation('My Chat', '/tmp/work');
     expect(conv.title).toBe('My Chat');
     expect(conv.workingDir).toBe('/tmp/work');
   });
 
-  test('persists to disk', () => {
-    const conv = service.createConversation('Disk Test');
+  test('persists to disk', async () => {
+    const conv = await service.createConversation('Disk Test');
     const file = path.join(tmpDir, 'data', 'chat', 'conversations', `${conv.id}.json`);
     expect(fs.existsSync(file)).toBe(true);
     const loaded = JSON.parse(fs.readFileSync(file, 'utf8'));
@@ -43,38 +43,38 @@ describe('createConversation', () => {
 });
 
 describe('getConversation', () => {
-  test('returns null for non-existent id', () => {
-    expect(service.getConversation('does-not-exist')).toBeNull();
+  test('returns null for non-existent id', async () => {
+    expect(await service.getConversation('does-not-exist')).toBeNull();
   });
 
-  test('returns the saved conversation', () => {
-    const conv = service.createConversation('Get Test');
-    const loaded = service.getConversation(conv.id);
+  test('returns the saved conversation', async () => {
+    const conv = await service.createConversation('Get Test');
+    const loaded = await service.getConversation(conv.id);
     expect(loaded.id).toBe(conv.id);
     expect(loaded.title).toBe('Get Test');
   });
 });
 
 describe('listConversations', () => {
-  test('returns empty array when no conversations', () => {
-    expect(service.listConversations()).toEqual([]);
+  test('returns empty array when no conversations', async () => {
+    expect(await service.listConversations()).toEqual([]);
   });
 
-  test('returns summaries with most recently updated first', () => {
-    const c1 = service.createConversation('First');
-    const c2 = service.createConversation('Second');
+  test('returns summaries with most recently updated first', async () => {
+    const c1 = await service.createConversation('First');
+    const c2 = await service.createConversation('Second');
 
     // Force c1 to have an older updatedAt
-    const conv1 = service.getConversation(c1.id);
+    const conv1 = await service.getConversation(c1.id);
     conv1.updatedAt = '2020-01-01T00:00:00.000Z';
     fs.writeFileSync(
       path.join(tmpDir, 'data', 'chat', 'conversations', `${c1.id}.json`),
       JSON.stringify(conv1, null, 2), 'utf8'
     );
 
-    service.addMessage(c2.id, 'user', 'hello');
+    await service.addMessage(c2.id, 'user', 'hello');
 
-    const list = service.listConversations();
+    const list = await service.listConversations();
     expect(list).toHaveLength(2);
     expect(list[0].id).toBe(c2.id);
     expect(list[0].messageCount).toBe(1);
@@ -84,110 +84,110 @@ describe('listConversations', () => {
 });
 
 describe('renameConversation', () => {
-  test('renames and persists', () => {
-    const conv = service.createConversation('Old Name');
-    const updated = service.renameConversation(conv.id, 'New Name');
+  test('renames and persists', async () => {
+    const conv = await service.createConversation('Old Name');
+    const updated = await service.renameConversation(conv.id, 'New Name');
     expect(updated.title).toBe('New Name');
 
-    const loaded = service.getConversation(conv.id);
+    const loaded = await service.getConversation(conv.id);
     expect(loaded.title).toBe('New Name');
   });
 
-  test('returns null for non-existent id', () => {
-    expect(service.renameConversation('nope', 'Name')).toBeNull();
+  test('returns null for non-existent id', async () => {
+    expect(await service.renameConversation('nope', 'Name')).toBeNull();
   });
 });
 
 describe('deleteConversation', () => {
-  test('deletes existing conversation', () => {
-    const conv = service.createConversation('Delete Me');
-    expect(service.deleteConversation(conv.id)).toBe(true);
-    expect(service.getConversation(conv.id)).toBeNull();
+  test('deletes existing conversation', async () => {
+    const conv = await service.createConversation('Delete Me');
+    expect(await service.deleteConversation(conv.id)).toBe(true);
+    expect(await service.getConversation(conv.id)).toBeNull();
   });
 
-  test('returns false for non-existent id', () => {
-    expect(service.deleteConversation('nope')).toBe(false);
+  test('returns false for non-existent id', async () => {
+    expect(await service.deleteConversation('nope')).toBe(false);
   });
 });
 
 // ── Messages ─────────────────────────────────────────────────────────────────
 
 describe('addMessage', () => {
-  test('appends message to conversation', () => {
-    const conv = service.createConversation();
-    const msg = service.addMessage(conv.id, 'user', 'Hello');
+  test('appends message to conversation', async () => {
+    const conv = await service.createConversation();
+    const msg = await service.addMessage(conv.id, 'user', 'Hello');
     expect(msg.role).toBe('user');
     expect(msg.content).toBe('Hello');
     expect(msg.id).toBeDefined();
 
-    const loaded = service.getConversation(conv.id);
+    const loaded = await service.getConversation(conv.id);
     expect(loaded.messages).toHaveLength(1);
   });
 
-  test('auto-titles from first user message', () => {
-    const conv = service.createConversation();
-    service.addMessage(conv.id, 'user', 'What is the meaning of life?');
-    const loaded = service.getConversation(conv.id);
+  test('auto-titles from first user message', async () => {
+    const conv = await service.createConversation();
+    await service.addMessage(conv.id, 'user', 'What is the meaning of life?');
+    const loaded = await service.getConversation(conv.id);
     expect(loaded.title).toBe('What is the meaning of life?');
   });
 
-  test('does not re-title on second user message', () => {
-    const conv = service.createConversation();
-    service.addMessage(conv.id, 'user', 'First question');
-    service.addMessage(conv.id, 'assistant', 'Answer');
-    service.addMessage(conv.id, 'user', 'Second question');
-    const loaded = service.getConversation(conv.id);
+  test('does not re-title on second user message', async () => {
+    const conv = await service.createConversation();
+    await service.addMessage(conv.id, 'user', 'First question');
+    await service.addMessage(conv.id, 'assistant', 'Answer');
+    await service.addMessage(conv.id, 'user', 'Second question');
+    const loaded = await service.getConversation(conv.id);
     expect(loaded.title).toBe('First question');
   });
 
-  test('increments session message count', () => {
-    const conv = service.createConversation();
-    service.addMessage(conv.id, 'user', 'msg1');
-    service.addMessage(conv.id, 'assistant', 'msg2');
-    const loaded = service.getConversation(conv.id);
+  test('increments session message count', async () => {
+    const conv = await service.createConversation();
+    await service.addMessage(conv.id, 'user', 'msg1');
+    await service.addMessage(conv.id, 'assistant', 'msg2');
+    const loaded = await service.getConversation(conv.id);
     expect(loaded.sessions[0].messageCount).toBe(2);
   });
 
-  test('returns null for non-existent conversation', () => {
-    expect(service.addMessage('nope', 'user', 'hi')).toBeNull();
+  test('returns null for non-existent conversation', async () => {
+    expect(await service.addMessage('nope', 'user', 'hi')).toBeNull();
   });
 });
 
 describe('updateMessageContent', () => {
-  test('forks conversation at edited message', () => {
-    const conv = service.createConversation();
-    const m1 = service.addMessage(conv.id, 'user', 'Original');
-    service.addMessage(conv.id, 'assistant', 'Response');
-    service.addMessage(conv.id, 'user', 'Follow-up');
+  test('forks conversation at edited message', async () => {
+    const conv = await service.createConversation();
+    const m1 = await service.addMessage(conv.id, 'user', 'Original');
+    await service.addMessage(conv.id, 'assistant', 'Response');
+    await service.addMessage(conv.id, 'user', 'Follow-up');
 
-    const result = service.updateMessageContent(conv.id, m1.id, 'Edited');
+    const result = await service.updateMessageContent(conv.id, m1.id, 'Edited');
     expect(result.message.content).toBe('Edited');
     expect(result.conversation.messages).toHaveLength(1);
     expect(result.conversation.messages[0].content).toBe('Edited');
   });
 
-  test('returns null for non-existent conversation', () => {
-    expect(service.updateMessageContent('nope', 'mid', 'text')).toBeNull();
+  test('returns null for non-existent conversation', async () => {
+    expect(await service.updateMessageContent('nope', 'mid', 'text')).toBeNull();
   });
 
-  test('returns null for non-existent message', () => {
-    const conv = service.createConversation();
-    expect(service.updateMessageContent(conv.id, 'nope', 'text')).toBeNull();
+  test('returns null for non-existent message', async () => {
+    const conv = await service.createConversation();
+    expect(await service.updateMessageContent(conv.id, 'nope', 'text')).toBeNull();
   });
 });
 
 // ── Session Management ───────────────────────────────────────────────────────
 
 describe('resetSession', () => {
-  test('creates new session and archives current', () => {
-    const conv = service.createConversation();
-    service.addMessage(conv.id, 'user', 'Hello');
-    service.addMessage(conv.id, 'assistant', 'Hi');
+  test('creates new session and archives current', async () => {
+    const conv = await service.createConversation();
+    await service.addMessage(conv.id, 'user', 'Hello');
+    await service.addMessage(conv.id, 'assistant', 'Hi');
 
-    const result = service.resetSession(conv.id);
+    const result = await service.resetSession(conv.id);
     expect(result.newSessionNumber).toBe(2);
 
-    const loaded = service.getConversation(conv.id);
+    const loaded = await service.getConversation(conv.id);
     expect(loaded.sessions).toHaveLength(2);
     expect(loaded.sessions[0].endedAt).not.toBeNull();
     expect(loaded.sessions[1].endedAt).toBeNull();
@@ -199,44 +199,44 @@ describe('resetSession', () => {
     expect(archives[0]).toContain(conv.id);
   });
 
-  test('adds session divider message', () => {
-    const conv = service.createConversation();
-    service.addMessage(conv.id, 'user', 'Hello');
-    service.resetSession(conv.id);
+  test('adds session divider message', async () => {
+    const conv = await service.createConversation();
+    await service.addMessage(conv.id, 'user', 'Hello');
+    await service.resetSession(conv.id);
 
-    const loaded = service.getConversation(conv.id);
+    const loaded = await service.getConversation(conv.id);
     const divider = loaded.messages.find(m => m.isSessionDivider);
     expect(divider).toBeDefined();
     expect(divider.role).toBe('system');
   });
 
-  test('returns null for non-existent conversation', () => {
-    expect(service.resetSession('nope')).toBeNull();
+  test('returns null for non-existent conversation', async () => {
+    expect(await service.resetSession('nope')).toBeNull();
   });
 });
 
 describe('getSessionHistory', () => {
-  test('returns sessions with isCurrent flag', () => {
-    const conv = service.createConversation();
-    const sessions = service.getSessionHistory(conv.id);
+  test('returns sessions with isCurrent flag', async () => {
+    const conv = await service.createConversation();
+    const sessions = await service.getSessionHistory(conv.id);
     expect(sessions).toHaveLength(1);
     expect(sessions[0].isCurrent).toBe(true);
   });
 
-  test('returns null for non-existent conversation', () => {
-    expect(service.getSessionHistory('nope')).toBeNull();
+  test('returns null for non-existent conversation', async () => {
+    expect(await service.getSessionHistory('nope')).toBeNull();
   });
 });
 
 // ── Markdown Export ──────────────────────────────────────────────────────────
 
 describe('conversationToMarkdown', () => {
-  test('exports conversation as markdown', () => {
-    const conv = service.createConversation('Export Test');
-    service.addMessage(conv.id, 'user', 'Hello');
-    service.addMessage(conv.id, 'assistant', 'Hi there');
+  test('exports conversation as markdown', async () => {
+    const conv = await service.createConversation('Export Test');
+    await service.addMessage(conv.id, 'user', 'Hello');
+    await service.addMessage(conv.id, 'assistant', 'Hi there');
 
-    const md = service.conversationToMarkdown(conv.id);
+    const md = await service.conversationToMarkdown(conv.id);
     // Title is auto-set to first user message
     expect(md).toContain('# Hello');
     expect(md).toContain('Hello');
@@ -245,46 +245,46 @@ describe('conversationToMarkdown', () => {
     expect(md).toContain('Assistant');
   });
 
-  test('includes session dividers', () => {
-    const conv = service.createConversation('Session Test');
-    service.addMessage(conv.id, 'user', 'Before reset');
-    service.resetSession(conv.id);
-    service.addMessage(conv.id, 'user', 'After reset');
+  test('includes session dividers', async () => {
+    const conv = await service.createConversation('Session Test');
+    await service.addMessage(conv.id, 'user', 'Before reset');
+    await service.resetSession(conv.id);
+    await service.addMessage(conv.id, 'user', 'After reset');
 
-    const md = service.conversationToMarkdown(conv.id);
+    const md = await service.conversationToMarkdown(conv.id);
     expect(md).toContain('Session reset');
   });
 
-  test('returns null for non-existent conversation', () => {
-    expect(service.conversationToMarkdown('nope')).toBeNull();
+  test('returns null for non-existent conversation', async () => {
+    expect(await service.conversationToMarkdown('nope')).toBeNull();
   });
 });
 
 // ── Search ───────────────────────────────────────────────────────────────────
 
 describe('searchConversations', () => {
-  test('finds by title', () => {
-    service.createConversation('Unique Alpha Title');
-    service.createConversation('Other');
+  test('finds by title', async () => {
+    await service.createConversation('Unique Alpha Title');
+    await service.createConversation('Other');
 
-    const results = service.searchConversations('alpha');
+    const results = await service.searchConversations('alpha');
     expect(results).toHaveLength(1);
     expect(results[0].title).toBe('Unique Alpha Title');
   });
 
-  test('finds by message content', () => {
-    const conv = service.createConversation('Chat');
-    service.addMessage(conv.id, 'user', 'The zebra crossed the road');
+  test('finds by message content', async () => {
+    const conv = await service.createConversation('Chat');
+    await service.addMessage(conv.id, 'user', 'The zebra crossed the road');
 
-    const results = service.searchConversations('zebra');
+    const results = await service.searchConversations('zebra');
     expect(results).toHaveLength(1);
   });
 
-  test('returns all when query is empty', () => {
-    service.createConversation('A');
-    service.createConversation('B');
+  test('returns all when query is empty', async () => {
+    await service.createConversation('A');
+    await service.createConversation('B');
 
-    const results = service.searchConversations('');
+    const results = await service.searchConversations('');
     expect(results).toHaveLength(2);
   });
 });
@@ -292,18 +292,18 @@ describe('searchConversations', () => {
 // ── Settings ─────────────────────────────────────────────────────────────────
 
 describe('settings', () => {
-  test('returns defaults when no settings file', () => {
-    const settings = service.getSettings();
+  test('returns defaults when no settings file', async () => {
+    const settings = await service.getSettings();
     expect(settings.theme).toBe('system');
     expect(settings.sendBehavior).toBe('enter');
     expect(settings.defaultBackend).toBe('claude-code');
   });
 
-  test('saves and retrieves settings', () => {
+  test('saves and retrieves settings', async () => {
     const input = { theme: 'dark', sendBehavior: 'ctrl-enter' };
-    service.saveSettings(input);
+    await service.saveSettings(input);
 
-    const loaded = service.getSettings();
+    const loaded = await service.getSettings();
     expect(loaded.theme).toBe('dark');
     expect(loaded.sendBehavior).toBe('ctrl-enter');
   });


### PR DESCRIPTION
## Summary
- Replace synchronous `fs` calls in `chatService.js` with async `fs.promises` (`fsp`) to avoid blocking the event loop during file read/write operations
- Update all route handlers in `chat.js` to properly `await` the now-async service methods
- Update tests to use `async`/`await` for all service calls

## Test plan
- [x] All 84 existing tests pass
- [x] Verify conversation CRUD works end-to-end in the UI
- [x] Verify SSE streaming still functions correctly