### PR TITLE
Fix duplicate assistant message bubbles during streaming

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -921,7 +921,7 @@ async function chatSendMessage() {
     const state = chatStreamingState.get(targetConvId);
     if (!state) return; // cleaned up before stream started
 
-    if (chatActiveConvId === targetConvId) {
+    if (chatActiveConvId === targetConvId && !state.streamingMsgEl) {
       state.streamingMsgEl = chatAppendStreamingMessage();
     }
 
@@ -996,19 +996,21 @@ async function chatSendMessage() {
               }
             }
           } else if (event.type === 'assistant_message') {
-            if (isStillActive && chatActiveConv) {
-              chatActiveConv.messages.push(event.message);
-              chatRenderMessages();
-              chatUpdateHeader();
-              // chatRenderMessages will re-create streaming bubble via state check
-            }
-            chatLoadConversations();
+            // Reset streaming state before re-render so the restored bubble
+            // shows typing dots instead of stale content duplicating the
+            // completed message that chatRenderMessages is about to display.
             st.assistantContent = '';
             st.assistantThinking = '';
             st.activeTools = [];
             st.activeAgents = [];
             st.planModeActive = false;
             st.pendingInteraction = null;
+            if (isStillActive && chatActiveConv) {
+              chatActiveConv.messages.push(event.message);
+              chatRenderMessages();
+              chatUpdateHeader();
+            }
+            chatLoadConversations();
           } else if (event.type === 'error') {
             st.pendingInteraction = null;
             if (isStillActive) chatAppendError(event.error);


### PR DESCRIPTION
## Summary
- Fix orphaned streaming bubble caused by `chatRenderMessages()` and `chatSendMessage()` both creating a typing indicator element — the first was never updated or removed
- Move streaming state reset before `chatRenderMessages()` in the `assistant_message` handler so the restored bubble shows typing dots instead of stale content duplicating the completed message

Fixes #13

## Test plan
- [x] Send a message and verify only one assistant bubble appears during streaming
- [x] Confirm the typing dots transition into real content within the same bubble
- [x] Send a multi-turn tool-use message and verify no duplicate bubbles appear between turns
- [x] Switch conversations during streaming and switch back — verify single bubble with correct state