### PR TITLE
Move uploaded files from workspace to conversation artifacts directory

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -868,10 +868,10 @@ async function chatSendMessage() {
   if (filesToUpload.length) {
     try {
       const uploadResult = await chatUploadFiles(chatActiveConvId, filesToUpload);
-      const names = uploadResult.files.map(f => f.name).join(', ');
+      const paths = uploadResult.files.map(f => f.path).join(', ');
       content = content
-        ? content + '\n\n[Uploaded files: ' + names + ']'
-        : '[Uploaded files: ' + names + ']';
+        ? content + '\n\n[Uploaded files: ' + paths + ']'
+        : '[Uploaded files: ' + paths + ']';
     } catch (err) {
       alert('File upload failed: ' + err.message);
       return;

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -345,8 +345,8 @@ function createChatRouter({ chatService, cliBackend }) {
   const upload = multer({
     storage: multer.diskStorage({
       destination: async (req, file, cb) => {
-        const conv = await chatService.getConversation(req.params.id);
-        const dir = conv?.workingDir || cliBackend.workingDir;
+        const dir = path.join(chatService.artifactsDir, req.params.id);
+        await fs.promises.mkdir(dir, { recursive: true });
         cb(null, dir);
       },
       filename: (req, file, cb) => {

--- a/src/services/chatService.js
+++ b/src/services/chatService.js
@@ -114,11 +114,18 @@ class ChatService {
     const p = this._convPath(id);
     try {
       await fsp.unlink(p);
-      return true;
     } catch (err) {
       if (err.code === 'ENOENT') return false;
       throw err;
     }
+    // Clean up uploaded artifacts for this conversation
+    const artifactDir = path.join(this.artifactsDir, id);
+    try {
+      await fsp.rm(artifactDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors — directory may not exist
+    }
+    return true;
   }
 
   // ── Messages ───────────────────────────────────────────────────────────────

--- a/test/chatService.test.js
+++ b/test/chatService.test.js
@@ -108,6 +108,16 @@ describe('deleteConversation', () => {
   test('returns false for non-existent id', async () => {
     expect(await service.deleteConversation('nope')).toBe(false);
   });
+
+  test('cleans up artifacts directory on delete', async () => {
+    const conv = await service.createConversation('Artifact Cleanup');
+    const artifactDir = path.join(tmpDir, 'data', 'chat', 'artifacts', conv.id);
+    fs.mkdirSync(artifactDir, { recursive: true });
+    fs.writeFileSync(path.join(artifactDir, 'test.txt'), 'hello');
+
+    expect(await service.deleteConversation(conv.id)).toBe(true);
+    expect(fs.existsSync(artifactDir)).toBe(false);
+  });
 });
 
 // ── Messages ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Redirect Multer uploads from `conv.workingDir` to `data/chat/artifacts/{conversationId}/`, keeping the project workspace clean
- Pass absolute file paths in message text so Claude Code CLI can read uploaded files regardless of its working directory
- Clean up per-conversation artifacts subdirectory when a conversation is deleted

Fixes #12

## Test plan
- [ ] Upload a file in chat — confirm it lands in `data/chat/artifacts/{convId}/`
- [ ] Send a message with an uploaded file — confirm the absolute path appears in the message and Claude Code can read it
- [ ] Delete a conversation that has uploaded files — confirm the artifacts subdirectory is removed
- [ ] Run `npm test` — all tests pass including new artifact cleanup test