### PR TITLE
Refactor storage to workspace-based architecture

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -82,19 +82,19 @@ agent-cockpit/
 │   ├── app.js                          # All frontend JavaScript (~1560 lines)
 │   └── styles.css                      # All CSS with light/dark theme (~1400 lines)
 ├── test/
-│   ├── chat.test.js                    # Chat route tests — /input, SSE forwarding, turn boundaries, session messages, mkdir, rmdir (36 tests)
-│   ├── chatService.test.js             # ChatService unit tests — CRUD, messages, sessions, archives, migration, markdown export (86 tests)
+│   ├── chat.test.js                    # Chat route tests — /input, SSE forwarding, turn boundaries, session messages, workspace injection, mkdir, rmdir (39 tests)
+│   ├── chatService.test.js             # ChatService unit tests — CRUD, messages, sessions, workspace storage, migration, markdown export, workspace context (93 tests)
 │   ├── cliBackend.test.js              # CLIBackend + extractToolDetails unit tests (33 tests)
 │   ├── graceful-shutdown.test.js       # Server shutdown tests (2 tests)
 │   └── sessionStore.test.js            # Session file-store tests (4 tests)
 └── data/                               # Runtime data (gitignored, created at startup)
     ├── chat/
-    │   ├── conversations/              # JSON files, one per conversation (current session only)
-    │   ├── archives/                   # Per-conversation archive folders
-    │   │   └── {convId}/
-    │   │       ├── index.json          # Session index with summaries
-    │   │       ├── session-1.json      # Archived session data
-    │   │       └── session-N.json
+    │   ├── workspaces/                 # Workspace-based storage
+    │   │   └── {workspace-hash}/       # SHA-256(workspacePath).substring(0,16)
+    │   │       ├── index.json          # Source of truth: all conversations + session metadata
+    │   │       └── {convId}/
+    │   │           ├── session-1.json  # Archived session
+    │   │           └── session-N.json  # Active session (updated every message)
     │   ├── artifacts/                  # Per-conversation upload directory
     │   └── settings.json               # User settings
     └── sessions/                       # Express session JSON files
@@ -156,12 +156,12 @@ The server initializes in this exact order:
 7. **Apply `ensureCsrfToken` middleware** globally
 8. **Parse JSON bodies** with `express.json()`
 9. **Mount CSRF token endpoint** at `GET /api/csrf-token`
-10. **Initialize ChatService** with `__dirname` as app root
+10. **Initialize ChatService** with `__dirname` as app root and `{ defaultWorkspace: config.DEFAULT_WORKSPACE }` options
 11. **Initialize CLIBackend** with `DEFAULT_WORKSPACE`
 12. **Mount chat router** at `/api/chat`
 13. **Serve static files** from `public/`
-14. **Run migrations** via `chatService.migrateAllConversations()` — converts legacy conversations (with `sessions` array and divider messages) to the new archive format. Idempotent; skips already-migrated conversations.
-15. **Listen** on configured PORT (inside migration `.then()` callback)
+14. **Initialize ChatService** via `chatService.initialize()` — migrates legacy `conversations/` and `archives/` directories to workspace format if present (renames old dirs to `_backup`), then builds the in-memory convId→workspace lookup map.
+15. **Listen** on configured PORT (inside `initialize().then()` callback)
 
 ### Graceful Shutdown
 
@@ -367,7 +367,7 @@ Returns updated conversation. `404` if not found.
 ```
 DELETE /api/chat/conversations/:id  [CSRF]
 ```
-Aborts any active stream for this conversation first. Deletes the conversation JSON file and cleans up the per-conversation artifacts subdirectory. Returns `{ ok: true }`. `404` if not found.
+Aborts any active stream for this conversation first. Removes the conversation from its workspace index, deletes the conversation's session folder (`workspaces/{hash}/{convId}/`), and cleans up the per-conversation artifacts subdirectory. Returns `{ ok: true }`. `404` if not found.
 
 ### 9.3 Download
 
@@ -401,7 +401,7 @@ Returns `{ messages: Message[] }` for the specified session number. Loads from a
 ```
 POST /api/chat/conversations/:id/reset  [CSRF]
 ```
-Returns `409` if conversation is currently streaming. Archives current session to JSON in `archives/{convId}/`, generates LLM summary, clears conversation messages, starts a new session with a fresh UUID. Returns `{ conversation, newSessionNumber, archivedSession }` where `archivedSession` includes `summary`, `messageCount`, etc.
+Returns `409` if conversation is currently streaming. Marks the active session as inactive in the workspace index (sets summary, endedAt), creates a new session entry + file, generates LLM summary. Returns `{ conversation, newSessionNumber, archivedSession }` where `archivedSession` includes `summary`, `messageCount`, etc.
 
 ### 9.5 Messaging and Streaming
 
@@ -411,9 +411,10 @@ POST /api/chat/conversations/:id/message  [CSRF]
 Body: { content: string, backend?: string }
 ```
 - Validates content is a non-empty string
-- Saves user message to conversation
-- Updates conversation backend if changed
+- Saves user message to conversation (raw content, no injection)
+- Updates conversation backend if changed via `chatService.updateConversationBackend()`
 - Determines if this is a new CLI session (first message in current session) or a resume
+- On new sessions: prepends workspace context injection prompt to the CLI message (not stored in messages)
 - Spawns CLI process via `cliBackend.sendMessage()`
 - Stores stream reference in `activeStreams` map
 - Returns `{ userMessage: Message, streamReady: true }`
@@ -541,31 +542,68 @@ Writes the full body to `data/chat/settings.json`.
 
 **File:** `src/services/chatService.js`
 
-**Constructor:** `new ChatService(appRoot)`
+**Constructor:** `new ChatService(appRoot, options)`
 - Sets `baseDir` to `<appRoot>/data/chat`
-- Creates directories synchronously at startup (only time sync I/O is used): `conversations/`, `archives/`, `artifacts/`
+- `options.defaultWorkspace` — fallback workspace path when `workingDir` is not provided (defaults to `/tmp/default-workspace`)
+- Creates directories synchronously at startup (only time sync I/O is used): `workspaces/`, `artifacts/`
+- Initializes `_convWorkspaceMap` (in-memory `Map<convId, workspaceHash>`)
 
-**All methods are `async`** and use `fs.promises` for file I/O.
+**All methods are `async`** (except `getWorkspaceContext()`) and use `fs.promises` for file I/O.
 
-#### Data Model: Conversation
+#### Storage Architecture
 
-The conversation JSON file contains only the **current session's** messages. Past sessions are stored in per-conversation archive folders.
+All data is organized by **workspace**. A workspace corresponds to a `workingDir` — all conversations sharing the same working directory live under one workspace folder. The workspace `index.json` is the single source of truth for conversation metadata. Session files hold messages.
+
+```
+data/chat/workspaces/{workspace-hash}/
+├── index.json              # All conversations + session metadata
+├── {convId-1}/
+│   ├── session-1.json      # Archived
+│   └── session-2.json      # Active (updated every message)
+└── {convId-2}/
+    └── session-1.json
+```
+
+**Workspace hash:** `SHA-256(workspacePath).substring(0, 16)` — deterministic mapping from path to hash.
+
+**ConvId → workspace lookup:** In-memory `Map`, built on startup by scanning all workspace indexes. Avoids filesystem scans on every operation.
+
+#### Data Model: Workspace Index (`workspaces/{hash}/index.json`)
 
 ```javascript
 {
-  id: string,              // UUIDv4
-  title: string,           // Auto-set from first user message (max 80 chars)
-  createdAt: string,       // ISO 8601
-  updatedAt: string,       // ISO 8601, updated on every save
-  backend: string,         // 'claude-code'
-  workingDir: string|null, // Filesystem path for CLI working directory
-  currentSessionId: string,// UUID of the active CLI session
-  sessionNumber: number,   // Current session number (1-based)
-  messages: Message[]      // ONLY current session messages (no dividers)
+  workspacePath: string,        // Absolute path to the workspace directory
+  conversations: [{
+    id: string,                 // UUIDv4
+    title: string,              // Auto-set from first user message (max 80 chars)
+    backend: string,            // 'claude-code'
+    currentSessionId: string,   // UUID of the active CLI session
+    lastActivity: string,       // ISO 8601, updated on every message
+    lastMessage: string|null,   // First 100 chars of last message content
+    sessions: [{
+      number: number,           // 1-based session number
+      sessionId: string,        // UUID passed to CLI
+      summary: string|null,     // LLM-generated summary (null for active session)
+      active: boolean,          // true for current session, false for archived
+      messageCount: number,     // Messages in this session
+      startedAt: string,        // ISO 8601
+      endedAt: string|null      // ISO 8601 (null for active session)
+    }]
+  }]
 }
 ```
 
-No `sessions` array — session history lives in `archives/{convId}/index.json`.
+#### Data Model: Session File (`workspaces/{hash}/{convId}/session-N.json`)
+
+```javascript
+{
+  sessionNumber: number,        // 1-based session number
+  sessionId: string,            // UUID passed to CLI
+  startedAt: string,            // ISO 8601
+  endedAt: string|null,         // ISO 8601 (null for active session)
+  messages: Message[]           // Full message array for this session
+}
+```
 
 #### Data Model: Message
 
@@ -580,34 +618,19 @@ No `sessions` array — session history lives in `archives/{convId}/index.json`.
 }
 ```
 
-#### Data Model: Archive Index (`archives/{convId}/index.json`)
+#### Data Model: API Response (getConversation)
+
+Assembles a flat object from workspace index + active session file for API compatibility:
 
 ```javascript
 {
-  conversationId: string,       // UUID matching conversation
-  conversationTitle: string,    // Conversation title at time of last archive
-  sessions: [{
-    number: number,             // 1-based session number
-    file: string,               // Filename: "session-N.json"
-    sessionId: string,          // UUID passed to CLI
-    startedAt: string,          // ISO 8601
-    endedAt: string,            // ISO 8601
-    messageCount: number,       // Messages in this session
-    summary: string             // LLM-generated one-line summary (100-150 chars)
-  }]
-}
-```
-
-#### Data Model: Session Archive (`archives/{convId}/session-N.json`)
-
-```javascript
-{
-  sessionNumber: number,        // 1-based session number
-  sessionId: string,            // UUID passed to CLI
-  startedAt: string,            // ISO 8601
-  endedAt: string,              // ISO 8601
-  messageCount: number,         // Messages in this session
-  messages: Message[]           // Full message array for this session
+  id: string,
+  title: string,
+  backend: string,
+  workingDir: string,           // The workspace path
+  currentSessionId: string,
+  sessionNumber: number,        // Active session number
+  messages: Message[]           // Active session messages
 }
 ```
 
@@ -615,26 +638,48 @@ No `sessions` array — session history lives in `archives/{convId}/index.json`.
 
 | Method | Description |
 |--------|-------------|
-| `createConversation(title, workingDir)` | Creates conversation with `currentSessionId`, `sessionNumber: 1`, empty `messages[]`. No `sessions` array. Title defaults to 'New Chat'. |
-| `getConversation(id)` | Reads JSON from disk. Returns `null` if file not found (ENOENT). |
-| `saveConversation(conv)` | Updates `updatedAt`, writes JSON to disk with 2-space indentation. |
-| `listConversations()` | Reads all `.json` files in conversations dir. Returns summaries sorted by `updatedAt` desc. Each summary: `{ id, title, createdAt, updatedAt, backend, workingDir, messageCount, lastMessage }` where `lastMessage` is first 100 chars of last message content. |
-| `renameConversation(id, newTitle)` | Updates title and saves. Returns `null` if not found. |
-| `deleteConversation(id)` | Deletes the JSON file, the per-conversation artifacts subdirectory (`artifacts/{id}/`), and the archive directory (`archives/{id}/`). Returns `true`/`false`. |
-| `addMessage(convId, role, content, backend, thinking)` | Appends message to `conv.messages`. Auto-titles when `conv.title === 'New Chat'` (80 chars, newlines→spaces). Optional `thinking` parameter stores extended thinking text (omitted if falsy). |
-| `updateMessageContent(convId, messageId, newContent)` | Forks conversation: truncates all messages after the target message, adds edited content as a new message. Returns `{ conversation, message }`. |
-| `resetSession(convId)` | Archives current session to `archives/{convId}/session-N.json`. Generates LLM summary via `_generateSessionSummary()`. Updates `archives/{convId}/index.json`. Clears `conv.messages`, increments `sessionNumber`, sets new `currentSessionId`. Removes legacy `sessions` array if present. Returns `{ conversation, newSessionNumber, archivedSession }`. |
-| `getSessionHistory(convId)` | Reads from archive `index.json` + appends current session with `isCurrent: true`. Returns array with `summary` field for archived sessions. |
-| `getSessionMessages(convId, sessionNumber)` | Returns messages from archive file for past sessions, or from `conv.messages` for current session. |
-| `sessionToMarkdown(convId, sessionNumber)` | Loads from archive file for past sessions, from `conv.messages` for current. Uses `_messagesToMarkdown()` shared helper. |
-| `_messagesToMarkdown(title, convId, sessionMeta, messages)` | Generates Markdown for a single session. Format: title, session metadata, then each message with role, timestamp, backend, and content. |
-| `conversationToMarkdown(convId)` | Stitches all archived sessions + current session into a single Markdown document. |
-| `_generateSessionSummary(messages, fallback)` | Spawns `claude --print -p "<prompt>"` for a one-line summary (100-150 chars). 30s timeout. Falls back gracefully to `fallback` string on failure. |
-| `migrateConversation(convId)` | Converts legacy format (with `sessions` array and divider messages) to new archive format. Extracts old sessions using divider counting, writes archive files with `"(Migrated session)"` summary. Idempotent — skips if no `sessions` array. |
-| `migrateAllConversations()` | Iterates all conversation files, calls `migrateConversation()`. Logs count of migrated conversations. |
-| `searchConversations(query)` | Case-insensitive search. First checks title and last message from summaries, then deep-searches full message content for remaining conversations. |
+| `initialize()` | Runs migration if legacy `conversations/` dir exists, then builds the in-memory convId→workspace lookup map. Called once at server startup. |
+| `createConversation(title, workingDir)` | Creates conversation entry in workspace index + empty session-1.json file. Falls back to `_defaultWorkspace` if no workingDir. Returns API-compatible conversation object. |
+| `getConversation(id)` | Looks up workspace via in-memory map, reads index + active session file. Returns API-compatible object with messages. Returns `null` if not found. |
+| `listConversations()` | Scans all workspace indexes. Returns summaries sorted by `lastActivity` desc. Each summary: `{ id, title, updatedAt, backend, workingDir, messageCount, lastMessage }`. |
+| `renameConversation(id, newTitle)` | Updates title in workspace index. Returns full conversation via `getConversation()`. Returns `null` if not found. |
+| `deleteConversation(id)` | Removes from workspace index, deletes `{convId}/` session folder and `artifacts/{id}/`. Removes from lookup map. Returns `true`/`false`. |
+| `updateConversationBackend(convId, backend)` | Updates backend field in workspace index. |
+| `addMessage(convId, role, content, backend, thinking)` | Appends message to active session file + updates workspace index (`lastActivity`, `lastMessage`, `messageCount`). Auto-titles when title is 'New Chat'. Optional `thinking` parameter (omitted if falsy). |
+| `updateMessageContent(convId, messageId, newContent)` | Forks: truncates messages in active session file after target, adds edited content as new message. Returns `{ conversation, message }`. |
+| `resetSession(convId)` | Marks active session as inactive (sets summary, endedAt), creates new session entry + file. Generates LLM summary via `_generateSessionSummary()`. Returns `{ conversation, newSessionNumber, archivedSession }`. |
+| `getSessionHistory(convId)` | Reads sessions array from workspace index. Returns array with `isCurrent` flag and `summary` field. |
+| `getSessionMessages(convId, sessionNumber)` | Reads session file directly. Returns messages array or `null`. |
+| `sessionToMarkdown(convId, sessionNumber)` | Reads session file, uses `_messagesToMarkdown()` helper. |
+| `conversationToMarkdown(convId)` | Reads all session files for a conversation, stitches into single Markdown document. |
+| `getWorkspaceContext(convId)` | **Synchronous.** Returns 4-line injection prompt string with absolute path to workspace folder, or `null` if convId not found. |
+| `_generateSessionSummary(messages, fallback)` | Spawns `claude --print -p "<prompt>"` for a one-line summary (100-150 chars). 30s timeout. Falls back gracefully. |
+| `searchConversations(query)` | Case-insensitive search. Checks title and lastMessage first, then deep-searches all session files for remaining conversations. |
 | `getSettings()` | Returns settings from disk or defaults. |
 | `saveSettings(settings)` | Writes settings to disk. |
+
+#### Workspace Context Injection
+
+When a new CLI session starts (first message in a session), the router prepends a context prompt to the CLI message (not stored in conversation messages):
+
+```
+[Workspace discussion history is available at {abs_workspace_path}/
+Read index.json for all past and current conversations in this workspace with per-session summaries.
+Each conversation subfolder contains session-N.json files with full message histories.
+When the user references previous work, decisions, or discussions, consult the relevant session files for context.]
+```
+
+This gives Claude Code access to all past conversations and sessions in the workspace without requiring any file copying or workspace pollution.
+
+#### Migration
+
+On first startup after upgrade, `initialize()` detects the legacy `conversations/` directory and runs `_migrateToWorkspaces()`:
+
+1. Reads all conversation JSON files from `conversations/`
+2. Groups conversations by workspace (using `workingDir` or default)
+3. For each conversation: reads any existing `archives/{convId}/` data, handles legacy `sessions` array with dividers
+4. Writes workspace index + session files to new `workspaces/{hash}/` structure
+5. Renames `conversations/` → `conversations_backup/` and `archives/` → `archives_backup/`
 
 ### 10.2 CLIBackend
 

--- a/server.js
+++ b/server.js
@@ -55,15 +55,15 @@ app.get('/api/csrf-token', (req, res) => {
   res.json({ csrfToken: req.session.csrfToken });
 });
 
-const chatService = new ChatService(__dirname);
+const chatService = new ChatService(__dirname, { defaultWorkspace: config.DEFAULT_WORKSPACE });
 const cliBackend = new CLIBackend({ workingDir: config.DEFAULT_WORKSPACE });
 const { router: chatRouter, shutdown: chatShutdown } = createChatRouter({ chatService, cliBackend });
 app.use('/api/chat', chatRouter);
 
 app.use(express.static(path.join(__dirname, 'public')));
 
-// Run migrations before starting the server
-chatService.migrateAllConversations().then(() => {
+// Initialize workspace storage and run any pending migrations
+chatService.initialize().then(() => {
   const server = app.listen(config.PORT, () => {
     console.log(`Agent Cockpit running on port ${config.PORT}`);
   });
@@ -87,6 +87,6 @@ chatService.migrateAllConversations().then(() => {
   process.on('SIGTERM', () => shutdown('SIGTERM'));
   process.on('SIGINT', () => shutdown('SIGINT'));
 }).catch(err => {
-  console.error('[migration] Fatal migration error:', err);
+  console.error('[startup] Fatal initialization error:', err);
   process.exit(1);
 });

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -261,8 +261,7 @@ function createChatRouter({ chatService, cliBackend }) {
 
     // Update backend if changed
     if (backend && backend !== conv.backend) {
-      conv.backend = backend;
-      await chatService.saveConversation(conv);
+      await chatService.updateConversationBackend(convId, backend);
     }
 
     // Add user message
@@ -271,9 +270,16 @@ function createChatRouter({ chatService, cliBackend }) {
     // Determine if this is the first message in the current Claude Code session
     const isNewSession = conv.messages.length === 0;
 
+    // Build CLI message — inject workspace context on new sessions
+    let cliMessage = content.trim();
+    if (isNewSession) {
+      const ctx = chatService.getWorkspaceContext(convId);
+      if (ctx) cliMessage = ctx + '\n\n' + cliMessage;
+    }
+
     // Start CLI streaming — store stream reference for the GET SSE endpoint
     console.log(`[chat] Starting CLI stream for conv=${convId} session=${conv.currentSessionId} isNew=${isNewSession} workingDir=${conv.workingDir || 'default'}`);
-    const { stream, abort, sendInput } = cliBackend.sendMessage(content.trim(), {
+    const { stream, abort, sendInput } = cliBackend.sendMessage(cliMessage, {
       sessionId: conv.currentSessionId,
       isNewSession,
       workingDir: conv.workingDir || null,

--- a/src/services/chatService.js
+++ b/src/services/chatService.js
@@ -4,69 +4,81 @@ const path = require('path');
 const crypto = require('crypto');
 const { execFile } = require('child_process');
 
+const DEFAULT_WORKSPACE_FALLBACK = '/tmp/default-workspace';
+
 class ChatService {
-  constructor(appRoot) {
+  constructor(appRoot, options = {}) {
     this.baseDir = path.join(appRoot, 'data', 'chat');
-    this.conversationsDir = path.join(this.baseDir, 'conversations');
-    this.archivesDir = path.join(this.baseDir, 'archives');
+    this.workspacesDir = path.join(this.baseDir, 'workspaces');
     this.artifactsDir = path.join(this.baseDir, 'artifacts');
     this.settingsFile = path.join(this.baseDir, 'settings.json');
+    this._defaultWorkspace = options.defaultWorkspace || DEFAULT_WORKSPACE_FALLBACK;
+    this._convWorkspaceMap = new Map(); // convId -> workspaceHash
+
+    // Old dirs — kept as properties for migration detection
+    this._legacyConversationsDir = path.join(this.baseDir, 'conversations');
+    this._legacyArchivesDir = path.join(this.baseDir, 'archives');
 
     // Ensure directories exist (sync in constructor only — runs once at startup)
-    for (const dir of [this.conversationsDir, this.archivesDir, this.artifactsDir]) {
+    for (const dir of [this.workspacesDir, this.artifactsDir]) {
       if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
     }
   }
 
-  // ── Conversation CRUD ──────────────────────────────────────────────────────
+  // ── Startup ────────────────────────────────────────────────────────────────
 
-  _convPath(id) {
-    return path.join(this.conversationsDir, `${id}.json`);
+  async initialize() {
+    // Run migration if old format exists
+    if (fs.existsSync(this._legacyConversationsDir)) {
+      await this._migrateToWorkspaces();
+    }
+    // Build convId -> workspaceHash lookup map
+    await this._buildLookupMap();
   }
+
+  async _buildLookupMap() {
+    this._convWorkspaceMap.clear();
+    let dirs;
+    try {
+      dirs = await fsp.readdir(this.workspacesDir);
+    } catch (err) {
+      if (err.code === 'ENOENT') return;
+      throw err;
+    }
+    for (const hash of dirs) {
+      const index = await this._readWorkspaceIndex(hash);
+      if (!index || !index.conversations) continue;
+      for (const conv of index.conversations) {
+        this._convWorkspaceMap.set(conv.id, hash);
+      }
+    }
+  }
+
+  // ── Workspace helpers ──────────────────────────────────────────────────────
 
   _newId() {
     return crypto.randomUUID();
   }
 
-  // ── Archive helpers ────────────────────────────────────────────────────────
-
-  _archiveDir(convId) {
-    return path.join(this.archivesDir, convId);
+  _workspaceHash(workspacePath) {
+    return crypto.createHash('sha256').update(workspacePath).digest('hex').substring(0, 16);
   }
 
-  _archiveIndexPath(convId) {
-    return path.join(this._archiveDir(convId), 'index.json');
+  _workspaceDir(hash) {
+    return path.join(this.workspacesDir, hash);
   }
 
-  _sessionArchivePath(convId, sessionNumber) {
-    return path.join(this._archiveDir(convId), `session-${sessionNumber}.json`);
+  _workspaceIndexPath(hash) {
+    return path.join(this._workspaceDir(hash), 'index.json');
   }
 
-  async _readArchiveIndex(convId) {
+  _sessionFilePath(hash, convId, sessionNumber) {
+    return path.join(this._workspaceDir(hash), convId, `session-${sessionNumber}.json`);
+  }
+
+  async _readWorkspaceIndex(hash) {
     try {
-      const data = await fsp.readFile(this._archiveIndexPath(convId), 'utf8');
-      return JSON.parse(data);
-    } catch (err) {
-      if (err.code === 'ENOENT') return { conversationId: convId, conversationTitle: '', sessions: [] };
-      throw err;
-    }
-  }
-
-  async _writeArchiveIndex(convId, index) {
-    const dir = this._archiveDir(convId);
-    await fsp.mkdir(dir, { recursive: true });
-    await fsp.writeFile(this._archiveIndexPath(convId), JSON.stringify(index, null, 2), 'utf8');
-  }
-
-  async _writeSessionArchive(convId, sessionNumber, sessionData) {
-    const dir = this._archiveDir(convId);
-    await fsp.mkdir(dir, { recursive: true });
-    await fsp.writeFile(this._sessionArchivePath(convId, sessionNumber), JSON.stringify(sessionData, null, 2), 'utf8');
-  }
-
-  async _readSessionArchive(convId, sessionNumber) {
-    try {
-      const data = await fsp.readFile(this._sessionArchivePath(convId, sessionNumber), 'utf8');
+      const data = await fsp.readFile(this._workspaceIndexPath(hash), 'utf8');
       return JSON.parse(data);
     } catch (err) {
       if (err.code === 'ENOENT') return null;
@@ -74,22 +86,52 @@ class ChatService {
     }
   }
 
+  async _writeWorkspaceIndex(hash, index) {
+    const dir = this._workspaceDir(hash);
+    await fsp.mkdir(dir, { recursive: true });
+    await fsp.writeFile(this._workspaceIndexPath(hash), JSON.stringify(index, null, 2), 'utf8');
+  }
+
+  async _readSessionFile(hash, convId, sessionNumber) {
+    try {
+      const data = await fsp.readFile(this._sessionFilePath(hash, convId, sessionNumber), 'utf8');
+      return JSON.parse(data);
+    } catch (err) {
+      if (err.code === 'ENOENT') return null;
+      throw err;
+    }
+  }
+
+  async _writeSessionFile(hash, convId, sessionNumber, data) {
+    const filePath = this._sessionFilePath(hash, convId, sessionNumber);
+    await fsp.mkdir(path.dirname(filePath), { recursive: true });
+    await fsp.writeFile(filePath, JSON.stringify(data, null, 2), 'utf8');
+  }
+
+  async _getConvFromIndex(convId) {
+    const hash = this._convWorkspaceMap.get(convId);
+    if (!hash) return null;
+    const index = await this._readWorkspaceIndex(hash);
+    if (!index) return null;
+    const convEntry = index.conversations.find(c => c.id === convId);
+    if (!convEntry) return null;
+    return { hash, index, convEntry };
+  }
+
   async _generateSessionSummary(messages, fallback) {
     if (!messages || messages.length === 0) return fallback || 'Empty session';
     try {
-      // Build a condensed version of the session for summarization
       let sessionText = '';
       for (const msg of messages) {
-        if (msg.isSessionDivider) continue;
         const role = msg.role === 'user' ? 'User' : 'Assistant';
         const content = msg.content.substring(0, 500);
         sessionText += `${role}: ${content}\n\n`;
-        if (sessionText.length > 4000) break; // Cap context size
+        if (sessionText.length > 4000) break;
       }
       const prompt = `Summarize the following chat session in one concise sentence (100-150 characters max). Only output the summary, nothing else:\n\n${sessionText}`;
 
       return await new Promise((resolve) => {
-        const proc = execFile('claude', ['--print', '-p', prompt], { timeout: 30000 }, (err, stdout) => {
+        execFile('claude', ['--print', '-p', prompt], { timeout: 30000 }, (err, stdout) => {
           if (err || !stdout.trim()) {
             resolve(fallback || `Session (${messages.length} messages)`);
           } else {
@@ -102,118 +144,183 @@ class ChatService {
     }
   }
 
+  // ── Conversation CRUD ──────────────────────────────────────────────────────
+
   async createConversation(title, workingDir) {
     const id = this._newId();
     const now = new Date().toISOString();
     const sessionId = this._newId();
-    const conv = {
+    const workspacePath = workingDir || this._defaultWorkspace;
+    const hash = this._workspaceHash(workspacePath);
+
+    // Read or create workspace index
+    let index = await this._readWorkspaceIndex(hash);
+    if (!index) {
+      index = { workspacePath, conversations: [] };
+    }
+
+    const convEntry = {
       id,
       title: title || 'New Chat',
-      createdAt: now,
-      updatedAt: now,
       backend: 'claude-code',
-      workingDir: workingDir || null,
+      currentSessionId: sessionId,
+      lastActivity: now,
+      lastMessage: null,
+      sessions: [{
+        number: 1,
+        sessionId,
+        summary: null,
+        active: true,
+        messageCount: 0,
+        startedAt: now,
+        endedAt: null,
+      }],
+    };
+
+    index.conversations.push(convEntry);
+    await this._writeWorkspaceIndex(hash, index);
+
+    // Write empty session file
+    await this._writeSessionFile(hash, id, 1, {
+      sessionNumber: 1,
+      sessionId,
+      startedAt: now,
+      endedAt: null,
+      messages: [],
+    });
+
+    // Update lookup map
+    this._convWorkspaceMap.set(id, hash);
+
+    // Return API-compatible shape
+    return {
+      id,
+      title: convEntry.title,
+      backend: convEntry.backend,
+      workingDir: workspacePath,
       currentSessionId: sessionId,
       sessionNumber: 1,
-      messages: [],     // [{id, role, content, backend, timestamp}]
+      messages: [],
     };
-    await fsp.writeFile(this._convPath(id), JSON.stringify(conv, null, 2), 'utf8');
-    return conv;
   }
 
   async getConversation(id) {
-    const p = this._convPath(id);
-    try {
-      const data = await fsp.readFile(p, 'utf8');
-      return JSON.parse(data);
-    } catch (err) {
-      if (err.code === 'ENOENT') return null;
-      throw err;
-    }
-  }
+    const result = await this._getConvFromIndex(id);
+    if (!result) return null;
+    const { hash, index, convEntry } = result;
 
-  async saveConversation(conv) {
-    conv.updatedAt = new Date().toISOString();
-    await fsp.writeFile(this._convPath(conv.id), JSON.stringify(conv, null, 2), 'utf8');
+    // Find active session
+    const activeSession = convEntry.sessions.find(s => s.active);
+    const sessionNumber = activeSession ? activeSession.number : 1;
+
+    // Read active session file
+    const sessionFile = await this._readSessionFile(hash, id, sessionNumber);
+    const messages = sessionFile ? sessionFile.messages : [];
+
+    return {
+      id: convEntry.id,
+      title: convEntry.title,
+      backend: convEntry.backend,
+      workingDir: index.workspacePath,
+      currentSessionId: convEntry.currentSessionId,
+      sessionNumber,
+      messages,
+    };
   }
 
   async listConversations() {
-    let files;
+    const convs = [];
+    let dirs;
     try {
-      files = await fsp.readdir(this.conversationsDir);
+      dirs = await fsp.readdir(this.workspacesDir);
     } catch (err) {
       if (err.code === 'ENOENT') return [];
       throw err;
     }
-    files = files.filter(f => f.endsWith('.json'));
-    const convs = [];
-    for (const f of files) {
-      try {
-        const data = await fsp.readFile(path.join(this.conversationsDir, f), 'utf8');
-        const conv = JSON.parse(data);
+
+    for (const hash of dirs) {
+      const index = await this._readWorkspaceIndex(hash);
+      if (!index || !index.conversations) continue;
+      for (const conv of index.conversations) {
+        const activeSession = conv.sessions.find(s => s.active);
         convs.push({
           id: conv.id,
           title: conv.title,
-          createdAt: conv.createdAt,
-          updatedAt: conv.updatedAt,
+          updatedAt: conv.lastActivity,
           backend: conv.backend,
-          workingDir: conv.workingDir || null,
-          messageCount: conv.messages.length,
-          lastMessage: conv.messages.length > 0
-            ? conv.messages[conv.messages.length - 1].content.substring(0, 100)
-            : null,
+          workingDir: index.workspacePath,
+          messageCount: activeSession ? activeSession.messageCount : 0,
+          lastMessage: conv.lastMessage,
         });
-      } catch {}
+      }
     }
-    // Sort by updatedAt descending
+
     convs.sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
     return convs;
   }
 
   async renameConversation(id, newTitle) {
-    const conv = await this.getConversation(id);
-    if (!conv) return null;
-    conv.title = newTitle;
-    await this.saveConversation(conv);
-    return conv;
+    const result = await this._getConvFromIndex(id);
+    if (!result) return null;
+    const { hash, index, convEntry } = result;
+
+    convEntry.title = newTitle;
+    await this._writeWorkspaceIndex(hash, index);
+
+    return this.getConversation(id);
   }
 
   async deleteConversation(id) {
-    const p = this._convPath(id);
+    const result = await this._getConvFromIndex(id);
+    if (!result) return false;
+    const { hash, index } = result;
+
+    // Remove from workspace index
+    index.conversations = index.conversations.filter(c => c.id !== id);
+    await this._writeWorkspaceIndex(hash, index);
+
+    // Delete conversation folder (session files)
+    const convDir = path.join(this._workspaceDir(hash), id);
     try {
-      await fsp.unlink(p);
-    } catch (err) {
-      if (err.code === 'ENOENT') return false;
-      throw err;
+      await fsp.rm(convDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
     }
-    // Clean up uploaded artifacts for this conversation
+
+    // Clean up artifacts
     const artifactDir = path.join(this.artifactsDir, id);
     try {
       await fsp.rm(artifactDir, { recursive: true, force: true });
     } catch {
-      // Ignore cleanup errors — directory may not exist
+      // Ignore cleanup errors
     }
-    // Clean up session archives for this conversation
-    const archiveDir = this._archiveDir(id);
-    try {
-      await fsp.rm(archiveDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors — directory may not exist
-    }
+
+    // Remove from lookup map
+    this._convWorkspaceMap.delete(id);
+
     return true;
+  }
+
+  async updateConversationBackend(convId, backend) {
+    const result = await this._getConvFromIndex(convId);
+    if (!result) return;
+    const { hash, index, convEntry } = result;
+    convEntry.backend = backend;
+    await this._writeWorkspaceIndex(hash, index);
   }
 
   // ── Messages ───────────────────────────────────────────────────────────────
 
   async addMessage(convId, role, content, backend, thinking) {
-    const conv = await this.getConversation(convId);
-    if (!conv) return null;
+    const result = await this._getConvFromIndex(convId);
+    if (!result) return null;
+    const { hash, index, convEntry } = result;
 
     const msg = {
       id: this._newId(),
       role,
       content,
-      backend: backend || conv.backend,
+      backend: backend || convEntry.backend,
       timestamp: new Date().toISOString(),
     };
 
@@ -221,185 +328,191 @@ class ChatService {
       msg.thinking = thinking;
     }
 
-    conv.messages.push(msg);
-
     // Auto-title from first user message (only if still default title)
-    if (role === 'user' && conv.title === 'New Chat') {
-      conv.title = content.substring(0, 80).replace(/\n/g, ' ').trim() || 'New Chat';
+    if (role === 'user' && convEntry.title === 'New Chat') {
+      convEntry.title = content.substring(0, 80).replace(/\n/g, ' ').trim() || 'New Chat';
     }
 
-    await this.saveConversation(conv);
+    // Find active session
+    const activeSession = convEntry.sessions.find(s => s.active);
+    const sessionNumber = activeSession ? activeSession.number : 1;
+
+    // Read session file, add message, write back
+    let sessionFile = await this._readSessionFile(hash, convId, sessionNumber);
+    if (!sessionFile) {
+      sessionFile = {
+        sessionNumber,
+        sessionId: convEntry.currentSessionId,
+        startedAt: msg.timestamp,
+        endedAt: null,
+        messages: [],
+      };
+    }
+    sessionFile.messages.push(msg);
+    await this._writeSessionFile(hash, convId, sessionNumber, sessionFile);
+
+    // Update workspace index
+    convEntry.lastActivity = msg.timestamp;
+    convEntry.lastMessage = content.substring(0, 100);
+    if (activeSession) {
+      activeSession.messageCount = sessionFile.messages.length;
+    }
+    await this._writeWorkspaceIndex(hash, index);
+
     return msg;
   }
 
   async updateMessageContent(convId, messageId, newContent) {
-    const conv = await this.getConversation(convId);
-    if (!conv) return null;
+    const result = await this._getConvFromIndex(convId);
+    if (!result) return null;
+    const { hash, index, convEntry } = result;
 
-    const msgIndex = conv.messages.findIndex(m => m.id === messageId);
+    const activeSession = convEntry.sessions.find(s => s.active);
+    const sessionNumber = activeSession ? activeSession.number : 1;
+
+    const sessionFile = await this._readSessionFile(hash, convId, sessionNumber);
+    if (!sessionFile) return null;
+
+    const msgIndex = sessionFile.messages.findIndex(m => m.id === messageId);
     if (msgIndex === -1) return null;
 
     // Truncate messages after this one (fork conversation)
-    conv.messages = conv.messages.slice(0, msgIndex);
+    sessionFile.messages = sessionFile.messages.slice(0, msgIndex);
 
     // Add the edited message as a new one
     const msg = {
       id: this._newId(),
       role: 'user',
       content: newContent,
-      backend: conv.backend,
+      backend: convEntry.backend,
       timestamp: new Date().toISOString(),
     };
-    conv.messages.push(msg);
-    await this.saveConversation(conv);
-    return { conversation: conv, message: msg };
+    sessionFile.messages.push(msg);
+    await this._writeSessionFile(hash, convId, sessionNumber, sessionFile);
+
+    // Update index
+    if (activeSession) {
+      activeSession.messageCount = sessionFile.messages.length;
+    }
+    convEntry.lastActivity = msg.timestamp;
+    convEntry.lastMessage = newContent.substring(0, 100);
+    await this._writeWorkspaceIndex(hash, index);
+
+    const conversation = await this.getConversation(convId);
+    return { conversation, message: msg };
   }
 
   // ── Session Management ─────────────────────────────────────────────────────
 
   async resetSession(convId) {
-    const conv = await this.getConversation(convId);
-    if (!conv) return null;
+    const result = await this._getConvFromIndex(convId);
+    if (!result) return null;
+    const { hash, index, convEntry } = result;
 
     const now = new Date();
-    const currentSessionNumber = conv.sessionNumber;
-    const currentSessionId = conv.currentSessionId;
+    const activeSession = convEntry.sessions.find(s => s.active);
+    if (!activeSession) return null;
 
-    // Get current session start time (from sessions array if legacy, or from first message)
-    let startedAt;
-    if (conv.sessions && conv.sessions.length > 0) {
-      const current = conv.sessions[conv.sessions.length - 1];
-      startedAt = current.startedAt;
-    } else if (conv.messages.length > 0) {
-      startedAt = conv.messages[0].timestamp;
-    } else {
-      startedAt = conv.createdAt;
-    }
+    const currentSessionNumber = activeSession.number;
 
-    // Extract current session messages (handle both legacy and new format)
-    let currentMessages;
-    if (conv.sessions && conv.sessions.length > 0) {
-      // Legacy: find messages after the last divider
-      let lastDividerIdx = -1;
-      for (let i = conv.messages.length - 1; i >= 0; i--) {
-        if (conv.messages[i].isSessionDivider) { lastDividerIdx = i; break; }
-      }
-      currentMessages = lastDividerIdx >= 0
-        ? conv.messages.slice(lastDividerIdx + 1)
-        : conv.messages;
-    } else {
-      // New format: all messages are current session
-      currentMessages = conv.messages;
-    }
-
-    // Filter out any divider messages
-    currentMessages = currentMessages.filter(m => !m.isSessionDivider);
+    // Read current session file
+    const sessionFile = await this._readSessionFile(hash, convId, currentSessionNumber);
+    const currentMessages = sessionFile ? sessionFile.messages : [];
 
     // Generate summary via Claude Code CLI
     const fallback = `Session ${currentSessionNumber} (${currentMessages.length} messages)`;
     const summary = await this._generateSessionSummary(currentMessages, fallback);
 
-    // Write session archive file
-    const sessionData = {
-      sessionNumber: currentSessionNumber,
-      sessionId: currentSessionId,
-      startedAt,
-      endedAt: now.toISOString(),
-      messageCount: currentMessages.length,
-      messages: currentMessages,
-    };
-    await this._writeSessionArchive(convId, currentSessionNumber, sessionData);
+    // Mark current session as inactive in index
+    activeSession.active = false;
+    activeSession.summary = summary;
+    activeSession.endedAt = now.toISOString();
+    activeSession.messageCount = currentMessages.length;
 
-    // Update archive index
-    const index = await this._readArchiveIndex(convId);
-    index.conversationTitle = conv.title;
-    index.sessions.push({
-      number: currentSessionNumber,
-      file: `session-${currentSessionNumber}.json`,
-      sessionId: currentSessionId,
-      startedAt,
-      endedAt: now.toISOString(),
-      messageCount: currentMessages.length,
-      summary,
-    });
-    await this._writeArchiveIndex(convId, index);
+    // Update session file with endedAt
+    if (sessionFile) {
+      sessionFile.endedAt = now.toISOString();
+      await this._writeSessionFile(hash, convId, currentSessionNumber, sessionFile);
+    }
 
-    // Start new session — clear messages and remove legacy sessions array
+    // Create new session
     const newSessionNumber = currentSessionNumber + 1;
     const newSessionId = this._newId();
-    conv.sessionNumber = newSessionNumber;
-    conv.currentSessionId = newSessionId;
-    conv.messages = [];
-    delete conv.sessions;
 
-    await this.saveConversation(conv);
+    convEntry.currentSessionId = newSessionId;
+    convEntry.sessions.push({
+      number: newSessionNumber,
+      sessionId: newSessionId,
+      summary: null,
+      active: true,
+      messageCount: 0,
+      startedAt: now.toISOString(),
+      endedAt: null,
+    });
 
-    const archivedSession = index.sessions[index.sessions.length - 1];
+    await this._writeSessionFile(hash, convId, newSessionNumber, {
+      sessionNumber: newSessionNumber,
+      sessionId: newSessionId,
+      startedAt: now.toISOString(),
+      endedAt: null,
+      messages: [],
+    });
+
+    await this._writeWorkspaceIndex(hash, index);
+
+    // Return compatible shape
+    const conversation = await this.getConversation(convId);
     return {
-      conversation: conv,
+      conversation,
       newSessionNumber,
-      archivedSession,
+      archivedSession: {
+        number: currentSessionNumber,
+        sessionId: activeSession.sessionId || null,
+        startedAt: activeSession.startedAt,
+        endedAt: now.toISOString(),
+        messageCount: currentMessages.length,
+        summary,
+      },
     };
   }
 
   async getSessionHistory(convId) {
-    const conv = await this.getConversation(convId);
-    if (!conv) return null;
+    const result = await this._getConvFromIndex(convId);
+    if (!result) return null;
+    const { convEntry } = result;
 
-    const index = await this._readArchiveIndex(convId);
-    const sessions = index.sessions.map(s => ({
+    return convEntry.sessions.map(s => ({
       number: s.number,
-      sessionId: s.sessionId,
+      sessionId: s.active ? convEntry.currentSessionId : (s.sessionId || null),
       startedAt: s.startedAt,
       endedAt: s.endedAt,
       messageCount: s.messageCount,
       summary: s.summary || null,
-      isCurrent: false,
+      isCurrent: s.active,
     }));
-
-    // Append current session
-    const startedAt = conv.messages.length > 0
-      ? conv.messages[0].timestamp
-      : conv.updatedAt;
-    sessions.push({
-      number: conv.sessionNumber,
-      sessionId: conv.currentSessionId,
-      startedAt,
-      endedAt: null,
-      messageCount: conv.messages.filter(m => !m.isSessionDivider).length,
-      summary: null,
-      isCurrent: true,
-    });
-
-    return sessions;
   }
 
   async getSessionMessages(convId, sessionNumber) {
-    const conv = await this.getConversation(convId);
-    if (!conv) return null;
-    if (sessionNumber === conv.sessionNumber) {
-      return conv.messages.filter(m => !m.isSessionDivider);
-    }
-    const archive = await this._readSessionArchive(convId, sessionNumber);
-    return archive ? archive.messages : null;
+    const result = await this._getConvFromIndex(convId);
+    if (!result) return null;
+    const { hash } = result;
+
+    const sessionFile = await this._readSessionFile(hash, convId, sessionNumber);
+    return sessionFile ? sessionFile.messages : null;
   }
 
+  // ── Markdown Export ────────────────────────────────────────────────────────
+
   async sessionToMarkdown(convId, sessionNumber) {
-    const conv = await this.getConversation(convId);
-    if (!conv) return null;
+    const result = await this._getConvFromIndex(convId);
+    if (!result) return null;
+    const { hash, convEntry } = result;
 
-    let messages, sessionMeta;
-    if (sessionNumber === conv.sessionNumber) {
-      messages = conv.messages.filter(m => !m.isSessionDivider);
-      sessionMeta = { number: sessionNumber, startedAt: messages.length > 0 ? messages[0].timestamp : conv.updatedAt };
-    } else {
-      const archive = await this._readSessionArchive(convId, sessionNumber);
-      if (!archive) return null;
-      messages = archive.messages;
-      sessionMeta = { number: archive.sessionNumber, startedAt: archive.startedAt };
-    }
+    const sessionFile = await this._readSessionFile(hash, convId, sessionNumber);
+    if (!sessionFile) return null;
 
-    return this._messagesToMarkdown(conv.title, conv.id, sessionMeta, messages);
+    const sessionMeta = { number: sessionNumber, startedAt: sessionFile.startedAt };
+    return this._messagesToMarkdown(convEntry.title, convId, sessionMeta, sessionFile.messages);
   }
 
   _messagesToMarkdown(title, convId, sessionMeta, messages) {
@@ -414,7 +527,6 @@ class ChatService {
     ];
 
     for (const msg of messages) {
-      if (msg.isSessionDivider) continue;
       const role = msg.role === 'user' ? 'User' : 'Assistant';
       const time = new Date(msg.timestamp).toLocaleString();
       lines.push(`### ${role} — ${time}`);
@@ -429,51 +541,29 @@ class ChatService {
     return lines.join('\n');
   }
 
-  // ── Download entire conversation as Markdown ───────────────────────────────
-
   async conversationToMarkdown(convId) {
-    const conv = await this.getConversation(convId);
-    if (!conv) return null;
+    const result = await this._getConvFromIndex(convId);
+    if (!result) return null;
+    const { hash, convEntry } = result;
 
     const lines = [
-      `# ${conv.title}`,
+      `# ${convEntry.title}`,
       ``,
-      `**Created:** ${conv.createdAt}`,
-      `**Backend:** ${conv.backend}`,
+      `**Backend:** ${convEntry.backend}`,
       ``,
       `---`,
       ``,
     ];
 
-    // Include archived sessions
-    const index = await this._readArchiveIndex(convId);
-    for (const entry of index.sessions) {
-      const archive = await this._readSessionArchive(convId, entry.number);
-      if (archive) {
-        lines.push(`## Session ${entry.number}`);
-        lines.push(``);
-        for (const msg of archive.messages) {
-          const role = msg.role === 'user' ? 'User' : 'Assistant';
-          const time = new Date(msg.timestamp).toLocaleString();
-          lines.push(`### ${role} — ${time}`);
-          if (msg.backend) lines.push(`*Backend: ${msg.backend}*`);
-          lines.push(``);
-          lines.push(msg.content);
-          lines.push(``);
-        }
-        lines.push(`---`);
-        lines.push(`*Session reset — ${new Date(entry.endedAt).toLocaleString()}*`);
-        lines.push(`---`);
-        lines.push(``);
-      }
-    }
+    for (const session of convEntry.sessions) {
+      const sessionFile = await this._readSessionFile(hash, convId, session.number);
+      if (!sessionFile || !sessionFile.messages.length) continue;
 
-    // Include current session messages
-    const currentMsgs = conv.messages.filter(m => !m.isSessionDivider);
-    if (currentMsgs.length > 0) {
-      lines.push(`## Session ${conv.sessionNumber} (current)`);
+      const label = session.active ? `Session ${session.number} (current)` : `Session ${session.number}`;
+      lines.push(`## ${label}`);
       lines.push(``);
-      for (const msg of currentMsgs) {
+
+      for (const msg of sessionFile.messages) {
         const role = msg.role === 'user' ? 'User' : 'Assistant';
         const time = new Date(msg.timestamp).toLocaleString();
         lines.push(`### ${role} — ${time}`);
@@ -482,116 +572,30 @@ class ChatService {
         lines.push(msg.content);
         lines.push(``);
       }
+
+      if (!session.active) {
+        lines.push(`---`);
+        lines.push(`*Session reset — ${new Date(session.endedAt).toLocaleString()}*`);
+        lines.push(`---`);
+        lines.push(``);
+      }
     }
 
     return lines.join('\n');
   }
 
-  // ── Migration ──────────────────────────────────────────────────────────────
+  // ── Workspace Context ──────────────────────────────────────────────────────
 
-  async migrateConversation(convId) {
-    const conv = await this.getConversation(convId);
-    if (!conv) return false;
-
-    // Skip if already migrated (no sessions array)
-    if (!conv.sessions) return false;
-
-    // Skip if only one session with no dividers (nothing to migrate)
-    const hasDividers = conv.messages.some(m => m.isSessionDivider);
-    if (conv.sessions.length <= 1 && !hasDividers) {
-      // Just remove the sessions array and save
-      delete conv.sessions;
-      await this.saveConversation(conv);
-      return true;
-    }
-
-    // Extract messages per session using divider counting
-    const dividerIndices = [];
-    for (let i = 0; i < conv.messages.length; i++) {
-      if (conv.messages[i].isSessionDivider) dividerIndices.push(i);
-    }
-
-    const index = await this._readArchiveIndex(convId);
-    index.conversationTitle = conv.title;
-
-    for (const session of conv.sessions) {
-      if (!session.endedAt) continue; // Skip active session
-
-      // Already archived? Skip
-      if (index.sessions.some(s => s.number === session.number)) continue;
-
-      let start, end;
-      if (session.number === 1) {
-        start = 0;
-        end = dividerIndices.length > 0 ? dividerIndices[0] : conv.messages.length;
-      } else {
-        const divIdx = dividerIndices[session.number - 2];
-        if (divIdx === undefined) continue;
-        start = divIdx + 1;
-        const nextDiv = dividerIndices[session.number - 1];
-        end = nextDiv !== undefined ? nextDiv : conv.messages.length;
-      }
-
-      const sessionMessages = conv.messages.slice(start, end).filter(m => !m.isSessionDivider);
-
-      const sessionData = {
-        sessionNumber: session.number,
-        sessionId: session.sessionId,
-        startedAt: session.startedAt,
-        endedAt: session.endedAt,
-        messageCount: sessionMessages.length,
-        messages: sessionMessages,
-      };
-      await this._writeSessionArchive(convId, session.number, sessionData);
-
-      index.sessions.push({
-        number: session.number,
-        file: `session-${session.number}.json`,
-        sessionId: session.sessionId,
-        startedAt: session.startedAt,
-        endedAt: session.endedAt,
-        messageCount: sessionMessages.length,
-        summary: '(Migrated session)',
-      });
-    }
-
-    // Sort index sessions by number
-    index.sessions.sort((a, b) => a.number - b.number);
-    await this._writeArchiveIndex(convId, index);
-
-    // Keep only current session messages
-    const lastDividerIdx = dividerIndices.length > 0 ? dividerIndices[dividerIndices.length - 1] : -1;
-    conv.messages = lastDividerIdx >= 0
-      ? conv.messages.slice(lastDividerIdx + 1).filter(m => !m.isSessionDivider)
-      : conv.messages.filter(m => !m.isSessionDivider);
-
-    delete conv.sessions;
-    await this.saveConversation(conv);
-    return true;
-  }
-
-  async migrateAllConversations() {
-    let files;
-    try {
-      files = await fsp.readdir(this.conversationsDir);
-    } catch (err) {
-      if (err.code === 'ENOENT') return;
-      throw err;
-    }
-    files = files.filter(f => f.endsWith('.json'));
-    let migrated = 0;
-    for (const f of files) {
-      const convId = f.replace('.json', '');
-      try {
-        const result = await this.migrateConversation(convId);
-        if (result) migrated++;
-      } catch (err) {
-        console.error(`[migration] Failed to migrate conversation ${convId}:`, err.message);
-      }
-    }
-    if (migrated > 0) {
-      console.log(`[migration] Migrated ${migrated} conversation(s) to new archive format`);
-    }
+  getWorkspaceContext(convId) {
+    const hash = this._convWorkspaceMap.get(convId);
+    if (!hash) return null;
+    const absPath = path.resolve(this._workspaceDir(hash));
+    return [
+      `[Workspace discussion history is available at ${absPath}/`,
+      `Read index.json for all past and current conversations in this workspace with per-session summaries.`,
+      `Each conversation subfolder contains session-N.json files with full message histories.`,
+      `When the user references previous work, decisions, or discussions, consult the relevant session files for context.]`,
+    ].join('\n');
   }
 
   // ── Search ─────────────────────────────────────────────────────────────────
@@ -601,15 +605,233 @@ class ChatService {
     const q = query.toLowerCase();
     const all = await this.listConversations();
     const results = [];
+
     for (const c of all) {
       if (c.title.toLowerCase().includes(q)) { results.push(c); continue; }
       if (c.lastMessage && c.lastMessage.toLowerCase().includes(q)) { results.push(c); continue; }
-      // Deep search: load full conversation
-      const conv = await this.getConversation(c.id);
-      if (!conv) continue;
-      if (conv.messages.some(m => m.content.toLowerCase().includes(q))) results.push(c);
+      // Deep search: load all session files
+      const result = await this._getConvFromIndex(c.id);
+      if (!result) continue;
+      const { hash, convEntry } = result;
+      let found = false;
+      for (const session of convEntry.sessions) {
+        const sessionFile = await this._readSessionFile(hash, c.id, session.number);
+        if (!sessionFile) continue;
+        if (sessionFile.messages.some(m => m.content.toLowerCase().includes(q))) {
+          found = true;
+          break;
+        }
+      }
+      if (found) results.push(c);
     }
+
     return results;
+  }
+
+  // ── Migration ──────────────────────────────────────────────────────────────
+
+  async _migrateToWorkspaces() {
+    let files;
+    try {
+      files = await fsp.readdir(this._legacyConversationsDir);
+    } catch (err) {
+      if (err.code === 'ENOENT') return;
+      throw err;
+    }
+    files = files.filter(f => f.endsWith('.json'));
+    if (files.length === 0) {
+      await this._renameLegacyDirs();
+      return;
+    }
+
+    // Group conversations by workspace
+    const workspaceGroups = new Map(); // hash -> { workspacePath, convs: [] }
+
+    for (const f of files) {
+      const convId = f.replace('.json', '');
+      try {
+        const data = await fsp.readFile(path.join(this._legacyConversationsDir, f), 'utf8');
+        const conv = JSON.parse(data);
+        const workspacePath = conv.workingDir || this._defaultWorkspace;
+        const hash = this._workspaceHash(workspacePath);
+
+        if (!workspaceGroups.has(hash)) {
+          workspaceGroups.set(hash, { workspacePath, convs: [] });
+        }
+        workspaceGroups.get(hash).convs.push(conv);
+      } catch (err) {
+        console.error(`[migration] Failed to read conversation ${convId}:`, err.message);
+      }
+    }
+
+    // Process each workspace group
+    for (const [hash, group] of workspaceGroups) {
+      const index = {
+        workspacePath: group.workspacePath,
+        conversations: [],
+      };
+
+      for (const conv of group.convs) {
+        const convId = conv.id;
+        const sessions = [];
+
+        // Read old archive index if exists
+        let oldArchiveIndex = { sessions: [] };
+        try {
+          const archiveIndexPath = path.join(this._legacyArchivesDir, convId, 'index.json');
+          const data = await fsp.readFile(archiveIndexPath, 'utf8');
+          oldArchiveIndex = JSON.parse(data);
+        } catch {
+          // No archive — that's fine
+        }
+
+        // Copy archived sessions
+        for (const oldSession of oldArchiveIndex.sessions) {
+          let sessionData;
+          try {
+            const oldPath = path.join(this._legacyArchivesDir, convId, `session-${oldSession.number}.json`);
+            const data = await fsp.readFile(oldPath, 'utf8');
+            sessionData = JSON.parse(data);
+          } catch {
+            continue;
+          }
+
+          await this._writeSessionFile(hash, convId, oldSession.number, sessionData);
+
+          sessions.push({
+            number: oldSession.number,
+            sessionId: oldSession.sessionId || sessionData.sessionId || null,
+            summary: oldSession.summary || '(Migrated session)',
+            active: false,
+            messageCount: oldSession.messageCount || (sessionData.messages ? sessionData.messages.length : 0),
+            startedAt: oldSession.startedAt || sessionData.startedAt,
+            endedAt: oldSession.endedAt || sessionData.endedAt,
+          });
+        }
+
+        // Handle legacy sessions array with dividers (pre-archive migration)
+        if (conv.sessions && conv.sessions.length > 0) {
+          const hasDividers = conv.messages.some(m => m.isSessionDivider);
+          if (hasDividers) {
+            const dividerIndices = [];
+            for (let i = 0; i < conv.messages.length; i++) {
+              if (conv.messages[i].isSessionDivider) dividerIndices.push(i);
+            }
+
+            for (const session of conv.sessions) {
+              if (!session.endedAt) continue;
+              if (sessions.some(s => s.number === session.number)) continue;
+
+              let start, end;
+              if (session.number === 1) {
+                start = 0;
+                end = dividerIndices.length > 0 ? dividerIndices[0] : conv.messages.length;
+              } else {
+                const divIdx = dividerIndices[session.number - 2];
+                if (divIdx === undefined) continue;
+                start = divIdx + 1;
+                const nextDiv = dividerIndices[session.number - 1];
+                end = nextDiv !== undefined ? nextDiv : conv.messages.length;
+              }
+
+              const sessionMessages = conv.messages.slice(start, end).filter(m => !m.isSessionDivider);
+              const sessionData = {
+                sessionNumber: session.number,
+                sessionId: session.sessionId,
+                startedAt: session.startedAt,
+                endedAt: session.endedAt,
+                messages: sessionMessages,
+              };
+              await this._writeSessionFile(hash, convId, session.number, sessionData);
+
+              sessions.push({
+                number: session.number,
+                sessionId: session.sessionId || null,
+                summary: '(Migrated session)',
+                active: false,
+                messageCount: sessionMessages.length,
+                startedAt: session.startedAt,
+                endedAt: session.endedAt,
+              });
+            }
+          }
+        }
+
+        // Current session messages
+        let currentMessages;
+        if (conv.sessions && conv.sessions.length > 0) {
+          const lastDividerIdx = conv.messages.reduce((acc, m, i) => m.isSessionDivider ? i : acc, -1);
+          currentMessages = lastDividerIdx >= 0
+            ? conv.messages.slice(lastDividerIdx + 1).filter(m => !m.isSessionDivider)
+            : conv.messages.filter(m => !m.isSessionDivider);
+        } else {
+          currentMessages = (conv.messages || []).filter(m => !m.isSessionDivider);
+        }
+
+        const sessionNumber = conv.sessionNumber || 1;
+        const currentSessionId = conv.currentSessionId || this._newId();
+
+        // Write current session file
+        const currentStartedAt = currentMessages.length > 0
+          ? currentMessages[0].timestamp
+          : (conv.updatedAt || new Date().toISOString());
+        await this._writeSessionFile(hash, convId, sessionNumber, {
+          sessionNumber,
+          sessionId: currentSessionId,
+          startedAt: currentStartedAt,
+          endedAt: null,
+          messages: currentMessages,
+        });
+
+        sessions.push({
+          number: sessionNumber,
+          sessionId: currentSessionId,
+          summary: null,
+          active: true,
+          messageCount: currentMessages.length,
+          startedAt: currentStartedAt,
+          endedAt: null,
+        });
+
+        // Sort sessions by number
+        sessions.sort((a, b) => a.number - b.number);
+
+        // Compute lastMessage
+        const lastMsg = currentMessages.length > 0
+          ? currentMessages[currentMessages.length - 1].content.substring(0, 100)
+          : null;
+
+        index.conversations.push({
+          id: convId,
+          title: conv.title,
+          backend: conv.backend || 'claude-code',
+          currentSessionId,
+          lastActivity: conv.updatedAt || new Date().toISOString(),
+          lastMessage: lastMsg,
+          sessions,
+        });
+      }
+
+      await this._writeWorkspaceIndex(hash, index);
+    }
+
+    await this._renameLegacyDirs();
+    console.log(`[migration] Migrated ${files.length} conversation(s) to workspace format`);
+  }
+
+  async _renameLegacyDirs() {
+    for (const [oldName, backupName] of [
+      [this._legacyConversationsDir, this._legacyConversationsDir + '_backup'],
+      [this._legacyArchivesDir, this._legacyArchivesDir + '_backup'],
+    ]) {
+      try {
+        if (fs.existsSync(oldName)) {
+          await fsp.rename(oldName, backupName);
+        }
+      } catch (err) {
+        console.error(`[migration] Failed to rename ${oldName}:`, err.message);
+      }
+    }
   }
 
   // ── Settings ───────────────────────────────────────────────────────────────

--- a/test/chat.test.js
+++ b/test/chat.test.js
@@ -8,6 +8,7 @@ const { createChatRouter } = require('../src/routes/chat');
 
 // ── Test helpers ────────────────────────────────────────────────────────────
 
+const DEFAULT_WORKSPACE = '/tmp/test-workspace';
 let tmpDir, chatService, app, server, baseUrl;
 const CSRF_TOKEN = 'test-csrf-token';
 
@@ -98,9 +99,10 @@ function readSSE(urlPath) {
 
 let mockBackend;
 
-beforeEach((done) => {
+beforeEach(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chatroute-'));
-  chatService = new ChatService(tmpDir);
+  chatService = new ChatService(tmpDir, { defaultWorkspace: DEFAULT_WORKSPACE });
+  await chatService.initialize();
   mockBackend = createMockCLIBackend();
 
   app = express();
@@ -115,10 +117,12 @@ beforeEach((done) => {
   const { router } = createChatRouter({ chatService, cliBackend: mockBackend });
   app.use('/api/chat', router);
 
-  server = app.listen(0, () => {
-    const port = server.address().port;
-    baseUrl = `http://127.0.0.1:${port}`;
-    done();
+  await new Promise((resolve) => {
+    server = app.listen(0, () => {
+      const port = server.address().port;
+      baseUrl = `http://127.0.0.1:${port}`;
+      resolve();
+    });
   });
 });
 
@@ -427,6 +431,65 @@ describe('Turn boundary intermediate messages', () => {
     const assistantMessages = events.filter(e => e.type === 'assistant_message');
     expect(assistantMessages).toHaveLength(1);
     expect(assistantMessages[0].message.content).toBe('The final result');
+  });
+});
+
+// ── Workspace context injection ──────────────────────────────────────────────
+
+describe('Workspace context injection', () => {
+  test('injects workspace context on new session message', async () => {
+    const conv = await chatService.createConversation('Test', '/tmp/inject-test');
+
+    mockBackend.setMockEvents([
+      { type: 'text', content: 'Response', streaming: true },
+      { type: 'done' },
+    ]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'Hello',
+      backend: 'claude-code',
+    });
+
+    // The CLI should receive the injected message
+    expect(mockBackend._lastMessage).toContain('Workspace discussion history');
+    expect(mockBackend._lastMessage).toContain('Hello');
+  });
+
+  test('does not inject context on subsequent messages', async () => {
+    const conv = await chatService.createConversation('Test', '/tmp/inject-test');
+    // Add a message first so it's not a new session
+    await chatService.addMessage(conv.id, 'user', 'First msg');
+
+    mockBackend.setMockEvents([
+      { type: 'text', content: 'Response', streaming: true },
+      { type: 'done' },
+    ]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'Second msg',
+      backend: 'claude-code',
+    });
+
+    // The CLI should receive just the message, no injection
+    expect(mockBackend._lastMessage).toBe('Second msg');
+    expect(mockBackend._lastMessage).not.toContain('Workspace discussion history');
+  });
+
+  test('stores user message without injection in conversation', async () => {
+    const conv = await chatService.createConversation('Test', '/tmp/inject-test');
+
+    mockBackend.setMockEvents([
+      { type: 'text', content: 'Response', streaming: true },
+      { type: 'done' },
+    ]);
+
+    const res = await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'Hello',
+      backend: 'claude-code',
+    });
+
+    // The stored message should NOT contain the injection
+    expect(res.body.userMessage.content).toBe('Hello');
   });
 });
 

--- a/test/chatService.test.js
+++ b/test/chatService.test.js
@@ -1,14 +1,22 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const crypto = require('crypto');
 const { ChatService } = require('../src/services/chatService');
+
+const DEFAULT_WORKSPACE = '/tmp/test-workspace';
 
 let tmpDir;
 let service;
 
-beforeEach(() => {
+function workspaceHash(p) {
+  return crypto.createHash('sha256').update(p).digest('hex').substring(0, 16);
+}
+
+beforeEach(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chatservice-'));
-  service = new ChatService(tmpDir);
+  service = new ChatService(tmpDir, { defaultWorkspace: DEFAULT_WORKSPACE });
+  await service.initialize();
 });
 
 afterEach(() => {
@@ -25,7 +33,6 @@ describe('createConversation', () => {
     expect(conv.sessionNumber).toBe(1);
     expect(conv.currentSessionId).toBeDefined();
     expect(conv.backend).toBe('claude-code');
-    expect(conv.sessions).toBeUndefined();
   });
 
   test('creates with custom title and working dir', async () => {
@@ -34,12 +41,34 @@ describe('createConversation', () => {
     expect(conv.workingDir).toBe('/tmp/work');
   });
 
-  test('persists to disk', async () => {
-    const conv = await service.createConversation('Disk Test');
-    const file = path.join(tmpDir, 'data', 'chat', 'conversations', `${conv.id}.json`);
-    expect(fs.existsSync(file)).toBe(true);
-    const loaded = JSON.parse(fs.readFileSync(file, 'utf8'));
-    expect(loaded.title).toBe('Disk Test');
+  test('uses default workspace when no workingDir given', async () => {
+    const conv = await service.createConversation('Test');
+    expect(conv.workingDir).toBe(DEFAULT_WORKSPACE);
+  });
+
+  test('persists workspace index and session file to disk', async () => {
+    const conv = await service.createConversation('Disk Test', '/tmp/work');
+    const hash = workspaceHash('/tmp/work');
+    const indexPath = path.join(tmpDir, 'data', 'chat', 'workspaces', hash, 'index.json');
+    expect(fs.existsSync(indexPath)).toBe(true);
+    const index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+    expect(index.workspacePath).toBe('/tmp/work');
+    expect(index.conversations).toHaveLength(1);
+    expect(index.conversations[0].title).toBe('Disk Test');
+
+    const sessionPath = path.join(tmpDir, 'data', 'chat', 'workspaces', hash, conv.id, 'session-1.json');
+    expect(fs.existsSync(sessionPath)).toBe(true);
+  });
+
+  test('two conversations with same workingDir share workspace', async () => {
+    const c1 = await service.createConversation('First', '/tmp/shared');
+    const c2 = await service.createConversation('Second', '/tmp/shared');
+    const hash = workspaceHash('/tmp/shared');
+    const index = JSON.parse(fs.readFileSync(
+      path.join(tmpDir, 'data', 'chat', 'workspaces', hash, 'index.json'), 'utf8'
+    ));
+    expect(index.conversations).toHaveLength(2);
+    expect(index.conversations.map(c => c.id).sort()).toEqual([c1.id, c2.id].sort());
   });
 });
 
@@ -48,11 +77,12 @@ describe('getConversation', () => {
     expect(await service.getConversation('does-not-exist')).toBeNull();
   });
 
-  test('returns the saved conversation', async () => {
+  test('returns the saved conversation with messages', async () => {
     const conv = await service.createConversation('Get Test');
     const loaded = await service.getConversation(conv.id);
     expect(loaded.id).toBe(conv.id);
     expect(loaded.title).toBe('Get Test');
+    expect(loaded.messages).toEqual([]);
   });
 });
 
@@ -65,14 +95,6 @@ describe('listConversations', () => {
     const c1 = await service.createConversation('First');
     const c2 = await service.createConversation('Second');
 
-    // Force c1 to have an older updatedAt
-    const conv1 = await service.getConversation(c1.id);
-    conv1.updatedAt = '2020-01-01T00:00:00.000Z';
-    fs.writeFileSync(
-      path.join(tmpDir, 'data', 'chat', 'conversations', `${c1.id}.json`),
-      JSON.stringify(conv1, null, 2), 'utf8'
-    );
-
     await service.addMessage(c2.id, 'user', 'hello');
 
     const list = await service.listConversations();
@@ -81,6 +103,12 @@ describe('listConversations', () => {
     expect(list[0].messageCount).toBe(1);
     expect(list[0].lastMessage).toBe('hello');
     expect(list[1].id).toBe(c1.id);
+  });
+
+  test('includes workingDir in listing', async () => {
+    await service.createConversation('Test', '/tmp/myproject');
+    const list = await service.listConversations();
+    expect(list[0].workingDir).toBe('/tmp/myproject');
   });
 });
 
@@ -120,19 +148,43 @@ describe('deleteConversation', () => {
     expect(fs.existsSync(artifactDir)).toBe(false);
   });
 
-  test('cleans up archives directory on delete', async () => {
-    const conv = await service.createConversation('Archive Cleanup');
+  test('cleans up session files on delete', async () => {
+    const conv = await service.createConversation('Session Cleanup', '/tmp/work');
     await service.addMessage(conv.id, 'user', 'Hello');
 
-    // Mock _generateSessionSummary to avoid CLI calls in tests
     service._generateSessionSummary = async (msgs, fallback) => fallback;
     await service.resetSession(conv.id);
 
-    const archiveDir = path.join(tmpDir, 'data', 'chat', 'archives', conv.id);
-    expect(fs.existsSync(archiveDir)).toBe(true);
+    const hash = workspaceHash('/tmp/work');
+    const convDir = path.join(tmpDir, 'data', 'chat', 'workspaces', hash, conv.id);
+    expect(fs.existsSync(convDir)).toBe(true);
 
     expect(await service.deleteConversation(conv.id)).toBe(true);
-    expect(fs.existsSync(archiveDir)).toBe(false);
+    expect(fs.existsSync(convDir)).toBe(false);
+  });
+
+  test('removes conversation from workspace index', async () => {
+    const c1 = await service.createConversation('Keep', '/tmp/shared');
+    const c2 = await service.createConversation('Delete', '/tmp/shared');
+
+    await service.deleteConversation(c2.id);
+
+    const hash = workspaceHash('/tmp/shared');
+    const index = JSON.parse(fs.readFileSync(
+      path.join(tmpDir, 'data', 'chat', 'workspaces', hash, 'index.json'), 'utf8'
+    ));
+    expect(index.conversations).toHaveLength(1);
+    expect(index.conversations[0].id).toBe(c1.id);
+  });
+});
+
+describe('updateConversationBackend', () => {
+  test('updates backend in workspace index', async () => {
+    const conv = await service.createConversation('Test');
+    await service.updateConversationBackend(conv.id, 'openai');
+
+    const loaded = await service.getConversation(conv.id);
+    expect(loaded.backend).toBe('openai');
   });
 });
 
@@ -170,7 +222,6 @@ describe('addMessage', () => {
     const conv = await service.createConversation();
     await service.addMessage(conv.id, 'user', 'First question');
 
-    // After rename to a non-default title, second message shouldn't change it
     await service.renameConversation(conv.id, 'Custom Title');
     await service.addMessage(conv.id, 'user', 'Another question');
     const loaded = await service.getConversation(conv.id);
@@ -195,7 +246,8 @@ describe('addMessage', () => {
     await service.addMessage(conv.id, 'assistant', 'Answer', 'claude-code', 'Thinking deeply');
 
     // Re-read from disk via a fresh service instance
-    const service2 = new ChatService(tmpDir);
+    const service2 = new ChatService(tmpDir, { defaultWorkspace: DEFAULT_WORKSPACE });
+    await service2.initialize();
     const loaded = await service2.getConversation(conv.id);
     expect(loaded.messages[0].thinking).toBe('Thinking deeply');
   });
@@ -219,6 +271,18 @@ describe('addMessage', () => {
     const conv = await service.createConversation();
     const msg = await service.addMessage(conv.id, 'assistant', 'Empty thinking', 'claude-code', '');
     expect(msg.thinking).toBeUndefined();
+  });
+
+  test('updates lastActivity and lastMessage in workspace index', async () => {
+    const conv = await service.createConversation('Test', '/tmp/idx');
+    await service.addMessage(conv.id, 'user', 'Index check message');
+
+    const hash = workspaceHash('/tmp/idx');
+    const index = JSON.parse(fs.readFileSync(
+      path.join(tmpDir, 'data', 'chat', 'workspaces', hash, 'index.json'), 'utf8'
+    ));
+    expect(index.conversations[0].lastMessage).toBe('Index check message');
+    expect(index.conversations[0].lastActivity).toBeDefined();
   });
 });
 
@@ -249,7 +313,6 @@ describe('updateMessageContent', () => {
 
 describe('resetSession', () => {
   beforeEach(() => {
-    // Mock _generateSessionSummary to avoid CLI calls in tests
     service._generateSessionSummary = async (msgs, fallback) => 'Test summary for session';
   });
 
@@ -265,33 +328,41 @@ describe('resetSession', () => {
     expect(result.archivedSession.messageCount).toBe(2);
 
     const loaded = await service.getConversation(conv.id);
-    expect(loaded.sessions).toBeUndefined();
     expect(loaded.sessionNumber).toBe(2);
     expect(loaded.messages).toHaveLength(0);
   });
 
-  test('creates archive files on disk', async () => {
-    const conv = await service.createConversation();
+  test('creates session files on disk', async () => {
+    const conv = await service.createConversation('Test', '/tmp/reset-test');
     await service.addMessage(conv.id, 'user', 'Hello');
 
     await service.resetSession(conv.id);
 
-    const archiveDir = path.join(tmpDir, 'data', 'chat', 'archives', conv.id);
-    expect(fs.existsSync(archiveDir)).toBe(true);
+    const hash = workspaceHash('/tmp/reset-test');
+    const convDir = path.join(tmpDir, 'data', 'chat', 'workspaces', hash, conv.id);
 
-    // Check index.json
-    const index = JSON.parse(fs.readFileSync(path.join(archiveDir, 'index.json'), 'utf8'));
-    expect(index.sessions).toHaveLength(1);
-    expect(index.sessions[0].number).toBe(1);
-    expect(index.sessions[0].summary).toBe('Test summary for session');
+    // Check session-1.json (archived)
+    const session1 = JSON.parse(fs.readFileSync(path.join(convDir, 'session-1.json'), 'utf8'));
+    expect(session1.messages).toHaveLength(1);
+    expect(session1.messages[0].content).toBe('Hello');
+    expect(session1.endedAt).toBeDefined();
 
-    // Check session-1.json
-    const session = JSON.parse(fs.readFileSync(path.join(archiveDir, 'session-1.json'), 'utf8'));
-    expect(session.messages).toHaveLength(1);
-    expect(session.messages[0].content).toBe('Hello');
+    // Check session-2.json (new active)
+    const session2 = JSON.parse(fs.readFileSync(path.join(convDir, 'session-2.json'), 'utf8'));
+    expect(session2.messages).toHaveLength(0);
+
+    // Check workspace index
+    const index = JSON.parse(fs.readFileSync(
+      path.join(tmpDir, 'data', 'chat', 'workspaces', hash, 'index.json'), 'utf8'
+    ));
+    const convEntry = index.conversations.find(c => c.id === conv.id);
+    expect(convEntry.sessions).toHaveLength(2);
+    expect(convEntry.sessions[0].active).toBe(false);
+    expect(convEntry.sessions[0].summary).toBe('Test summary for session');
+    expect(convEntry.sessions[1].active).toBe(true);
   });
 
-  test('multiple resets create sequential archives', async () => {
+  test('multiple resets create sequential sessions', async () => {
     const conv = await service.createConversation();
     await service.addMessage(conv.id, 'user', 'Session 1 msg');
     await service.resetSession(conv.id);
@@ -302,16 +373,6 @@ describe('resetSession', () => {
     const loaded = await service.getConversation(conv.id);
     expect(loaded.sessionNumber).toBe(3);
     expect(loaded.messages).toHaveLength(0);
-
-    const archiveDir = path.join(tmpDir, 'data', 'chat', 'archives', conv.id);
-    const index = JSON.parse(fs.readFileSync(path.join(archiveDir, 'index.json'), 'utf8'));
-    expect(index.sessions).toHaveLength(2);
-    expect(index.sessions[0].number).toBe(1);
-    expect(index.sessions[1].number).toBe(2);
-
-    // Verify session files
-    expect(fs.existsSync(path.join(archiveDir, 'session-1.json'))).toBe(true);
-    expect(fs.existsSync(path.join(archiveDir, 'session-2.json'))).toBe(true);
   });
 
   test('returns null for non-existent conversation', async () => {
@@ -456,130 +517,229 @@ describe('sessionToMarkdown', () => {
   });
 });
 
-// ── Migration ───────────────────────────────────────────────────────────────
+// ── Workspace Context ────────────────────────────────────────────────────────
 
-describe('migrateConversation', () => {
-  test('migrates legacy conversation with sessions array', async () => {
-    // Create a legacy-format conversation with sessions array and dividers
-    const conv = await service.createConversation('Legacy Conv');
-    const convPath = path.join(tmpDir, 'data', 'chat', 'conversations', `${conv.id}.json`);
-
-    const legacyConv = {
-      ...conv,
-      sessions: [
-        { number: 1, sessionId: 'sess-1', startedAt: '2024-01-01T00:00:00Z', endedAt: '2024-01-01T01:00:00Z', messageCount: 2 },
-        { number: 2, sessionId: 'sess-2', startedAt: '2024-01-01T01:00:00Z', endedAt: null, messageCount: 1 },
-      ],
-      messages: [
-        { id: 'm1', role: 'user', content: 'Hello', backend: 'claude-code', timestamp: '2024-01-01T00:00:00Z' },
-        { id: 'm2', role: 'assistant', content: 'Hi', backend: 'claude-code', timestamp: '2024-01-01T00:30:00Z' },
-        { id: 'div1', role: 'system', content: 'Session reset', isSessionDivider: true, timestamp: '2024-01-01T01:00:00Z' },
-        { id: 'm3', role: 'user', content: 'New session', backend: 'claude-code', timestamp: '2024-01-01T01:30:00Z' },
-      ],
-    };
-    fs.writeFileSync(convPath, JSON.stringify(legacyConv, null, 2), 'utf8');
-
-    const result = await service.migrateConversation(conv.id);
-    expect(result).toBe(true);
-
-    // Verify conversation file is updated
-    const migrated = await service.getConversation(conv.id);
-    expect(migrated.sessions).toBeUndefined();
-    expect(migrated.messages).toHaveLength(1);
-    expect(migrated.messages[0].content).toBe('New session');
-
-    // Verify archive files
-    const archiveDir = path.join(tmpDir, 'data', 'chat', 'archives', conv.id);
-    expect(fs.existsSync(archiveDir)).toBe(true);
-
-    const index = JSON.parse(fs.readFileSync(path.join(archiveDir, 'index.json'), 'utf8'));
-    expect(index.sessions).toHaveLength(1);
-    expect(index.sessions[0].summary).toBe('(Migrated session)');
-
-    const session = JSON.parse(fs.readFileSync(path.join(archiveDir, 'session-1.json'), 'utf8'));
-    expect(session.messages).toHaveLength(2);
-    expect(session.messages[0].content).toBe('Hello');
+describe('getWorkspaceContext', () => {
+  test('returns injection prompt with workspace path', async () => {
+    const conv = await service.createConversation('Test', '/tmp/ctx-test');
+    const ctx = service.getWorkspaceContext(conv.id);
+    expect(ctx).toContain('Workspace discussion history');
+    const hash = workspaceHash('/tmp/ctx-test');
+    expect(ctx).toContain(hash);
+    expect(ctx).toContain('index.json');
   });
 
-  test('removes sessions array even with single session', async () => {
-    const conv = await service.createConversation('Single Session');
-    const convPath = path.join(tmpDir, 'data', 'chat', 'conversations', `${conv.id}.json`);
-
-    const legacyConv = {
-      ...conv,
-      sessions: [
-        { number: 1, sessionId: 'sess-1', startedAt: '2024-01-01T00:00:00Z', endedAt: null, messageCount: 1 },
-      ],
-      messages: [
-        { id: 'm1', role: 'user', content: 'Hello', backend: 'claude-code', timestamp: '2024-01-01T00:00:00Z' },
-      ],
-    };
-    fs.writeFileSync(convPath, JSON.stringify(legacyConv, null, 2), 'utf8');
-
-    const result = await service.migrateConversation(conv.id);
-    expect(result).toBe(true);
-
-    const migrated = await service.getConversation(conv.id);
-    expect(migrated.sessions).toBeUndefined();
-    expect(migrated.messages).toHaveLength(1);
-  });
-
-  test('skips already migrated conversations', async () => {
-    const conv = await service.createConversation('Already Migrated');
-    // New-format conversations don't have sessions array
-    const result = await service.migrateConversation(conv.id);
-    expect(result).toBe(false);
-  });
-
-  test('is idempotent', async () => {
-    const conv = await service.createConversation('Idempotent');
-    const convPath = path.join(tmpDir, 'data', 'chat', 'conversations', `${conv.id}.json`);
-
-    const legacyConv = {
-      ...conv,
-      sessions: [
-        { number: 1, sessionId: 'sess-1', startedAt: '2024-01-01T00:00:00Z', endedAt: '2024-01-01T01:00:00Z', messageCount: 1 },
-        { number: 2, sessionId: 'sess-2', startedAt: '2024-01-01T01:00:00Z', endedAt: null, messageCount: 0 },
-      ],
-      messages: [
-        { id: 'm1', role: 'user', content: 'Hello', backend: 'claude-code', timestamp: '2024-01-01T00:00:00Z' },
-        { id: 'div1', role: 'system', content: 'Session reset', isSessionDivider: true, timestamp: '2024-01-01T01:00:00Z' },
-      ],
-    };
-    fs.writeFileSync(convPath, JSON.stringify(legacyConv, null, 2), 'utf8');
-
-    await service.migrateConversation(conv.id);
-    // Second call should be a no-op (sessions array is gone)
-    const result2 = await service.migrateConversation(conv.id);
-    expect(result2).toBe(false);
+  test('returns null for non-existent conversation', () => {
+    expect(service.getWorkspaceContext('nope')).toBeNull();
   });
 });
 
-describe('migrateAllConversations', () => {
-  test('migrates all legacy conversations', async () => {
-    const conv1 = await service.createConversation('Legacy 1');
-    const conv2 = await service.createConversation('Legacy 2');
+// ── Migration ───────────────────────────────────────────────────────────────
 
-    // Make them legacy format
-    for (const conv of [conv1, conv2]) {
-      const convPath = path.join(tmpDir, 'data', 'chat', 'conversations', `${conv.id}.json`);
-      const legacyConv = {
-        ...conv,
-        sessions: [{ number: 1, sessionId: 's1', startedAt: conv.createdAt, endedAt: null, messageCount: 0 }],
-      };
-      fs.writeFileSync(convPath, JSON.stringify(legacyConv, null, 2), 'utf8');
-    }
+describe('migration from legacy format', () => {
+  test('migrates conversations to workspace format', async () => {
+    // Set up legacy directory structure
+    const convDir = path.join(tmpDir, 'data', 'chat', 'conversations');
+    fs.mkdirSync(convDir, { recursive: true });
 
-    await service.migrateAllConversations();
+    const convId = crypto.randomUUID();
+    const conv = {
+      id: convId,
+      title: 'Legacy Conv',
+      backend: 'claude-code',
+      workingDir: '/tmp/legacy-project',
+      currentSessionId: 'sess-1',
+      sessionNumber: 1,
+      updatedAt: '2024-06-01T00:00:00Z',
+      messages: [
+        { id: 'm1', role: 'user', content: 'Hello', backend: 'claude-code', timestamp: '2024-06-01T00:00:00Z' },
+        { id: 'm2', role: 'assistant', content: 'Hi', backend: 'claude-code', timestamp: '2024-06-01T00:01:00Z' },
+      ],
+    };
+    fs.writeFileSync(path.join(convDir, `${convId}.json`), JSON.stringify(conv, null, 2));
 
-    const loaded1 = await service.getConversation(conv1.id);
-    const loaded2 = await service.getConversation(conv2.id);
-    expect(loaded1.sessions).toBeUndefined();
-    expect(loaded2.sessions).toBeUndefined();
+    // Create fresh service and initialize (triggers migration)
+    const svc = new ChatService(tmpDir, { defaultWorkspace: DEFAULT_WORKSPACE });
+    await svc.initialize();
+
+    // Old dir should be renamed to backup
+    expect(fs.existsSync(convDir)).toBe(false);
+    expect(fs.existsSync(convDir + '_backup')).toBe(true);
+
+    // Should be able to load the conversation
+    const loaded = await svc.getConversation(convId);
+    expect(loaded).not.toBeNull();
+    expect(loaded.title).toBe('Legacy Conv');
+    expect(loaded.messages).toHaveLength(2);
+
+    // Workspace index should exist
+    const hash = workspaceHash('/tmp/legacy-project');
+    const indexPath = path.join(tmpDir, 'data', 'chat', 'workspaces', hash, 'index.json');
+    expect(fs.existsSync(indexPath)).toBe(true);
   });
 
-  test('does not error on empty directory', async () => {
-    await expect(service.migrateAllConversations()).resolves.not.toThrow();
+  test('migrates conversations with archived sessions', async () => {
+    const convDir = path.join(tmpDir, 'data', 'chat', 'conversations');
+    const archivesDir = path.join(tmpDir, 'data', 'chat', 'archives');
+    fs.mkdirSync(convDir, { recursive: true });
+
+    const convId = crypto.randomUUID();
+
+    // Conversation file (current session 2)
+    const conv = {
+      id: convId,
+      title: 'Archived Conv',
+      backend: 'claude-code',
+      workingDir: '/tmp/archived-project',
+      currentSessionId: 'sess-2',
+      sessionNumber: 2,
+      updatedAt: '2024-06-02T00:00:00Z',
+      messages: [
+        { id: 'm3', role: 'user', content: 'New session msg', backend: 'claude-code', timestamp: '2024-06-02T00:00:00Z' },
+      ],
+    };
+    fs.writeFileSync(path.join(convDir, `${convId}.json`), JSON.stringify(conv, null, 2));
+
+    // Archive files
+    const archiveConvDir = path.join(archivesDir, convId);
+    fs.mkdirSync(archiveConvDir, { recursive: true });
+
+    const archiveIndex = {
+      conversationId: convId,
+      conversationTitle: 'Archived Conv',
+      sessions: [{
+        number: 1,
+        file: 'session-1.json',
+        sessionId: 'sess-1',
+        startedAt: '2024-06-01T00:00:00Z',
+        endedAt: '2024-06-01T12:00:00Z',
+        messageCount: 2,
+        summary: 'Discussed the project setup',
+      }],
+    };
+    fs.writeFileSync(path.join(archiveConvDir, 'index.json'), JSON.stringify(archiveIndex, null, 2));
+
+    const session1 = {
+      sessionNumber: 1,
+      sessionId: 'sess-1',
+      startedAt: '2024-06-01T00:00:00Z',
+      endedAt: '2024-06-01T12:00:00Z',
+      messages: [
+        { id: 'm1', role: 'user', content: 'Old msg 1', backend: 'claude-code', timestamp: '2024-06-01T00:00:00Z' },
+        { id: 'm2', role: 'assistant', content: 'Old reply', backend: 'claude-code', timestamp: '2024-06-01T00:01:00Z' },
+      ],
+    };
+    fs.writeFileSync(path.join(archiveConvDir, 'session-1.json'), JSON.stringify(session1, null, 2));
+
+    // Initialize
+    const svc = new ChatService(tmpDir, { defaultWorkspace: DEFAULT_WORKSPACE });
+    await svc.initialize();
+
+    // Verify migration
+    expect(fs.existsSync(convDir)).toBe(false);
+    expect(fs.existsSync(archivesDir)).toBe(false);
+
+    const loaded = await svc.getConversation(convId);
+    expect(loaded.title).toBe('Archived Conv');
+    expect(loaded.messages).toHaveLength(1);
+    expect(loaded.sessionNumber).toBe(2);
+
+    // Verify archived session is accessible
+    const sessions = await svc.getSessionHistory(convId);
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0].summary).toBe('Discussed the project setup');
+    expect(sessions[0].isCurrent).toBe(false);
+    expect(sessions[1].isCurrent).toBe(true);
+
+    // Verify archived messages are accessible
+    const archivedMsgs = await svc.getSessionMessages(convId, 1);
+    expect(archivedMsgs).toHaveLength(2);
+    expect(archivedMsgs[0].content).toBe('Old msg 1');
+  });
+
+  test('migrates legacy sessions with dividers', async () => {
+    const convDir = path.join(tmpDir, 'data', 'chat', 'conversations');
+    fs.mkdirSync(convDir, { recursive: true });
+
+    const convId = crypto.randomUUID();
+    const conv = {
+      id: convId,
+      title: 'Divider Conv',
+      backend: 'claude-code',
+      workingDir: '/tmp/divider',
+      currentSessionId: 'sess-2',
+      sessionNumber: 2,
+      updatedAt: '2024-06-02T00:00:00Z',
+      sessions: [
+        { number: 1, sessionId: 'sess-1', startedAt: '2024-06-01T00:00:00Z', endedAt: '2024-06-01T12:00:00Z', messageCount: 2 },
+        { number: 2, sessionId: 'sess-2', startedAt: '2024-06-02T00:00:00Z', endedAt: null, messageCount: 1 },
+      ],
+      messages: [
+        { id: 'm1', role: 'user', content: 'Session 1 msg', backend: 'claude-code', timestamp: '2024-06-01T00:00:00Z' },
+        { id: 'm2', role: 'assistant', content: 'Reply', backend: 'claude-code', timestamp: '2024-06-01T00:01:00Z' },
+        { id: 'div1', role: 'system', content: 'Session reset', isSessionDivider: true, timestamp: '2024-06-01T12:00:00Z' },
+        { id: 'm3', role: 'user', content: 'Session 2 msg', backend: 'claude-code', timestamp: '2024-06-02T00:00:00Z' },
+      ],
+    };
+    fs.writeFileSync(path.join(convDir, `${convId}.json`), JSON.stringify(conv, null, 2));
+
+    const svc = new ChatService(tmpDir, { defaultWorkspace: DEFAULT_WORKSPACE });
+    await svc.initialize();
+
+    const loaded = await svc.getConversation(convId);
+    expect(loaded.messages).toHaveLength(1);
+    expect(loaded.messages[0].content).toBe('Session 2 msg');
+    expect(loaded.sessionNumber).toBe(2);
+
+    const archivedMsgs = await svc.getSessionMessages(convId, 1);
+    expect(archivedMsgs).toHaveLength(2);
+    expect(archivedMsgs[0].content).toBe('Session 1 msg');
+  });
+
+  test('groups conversations by workspace during migration', async () => {
+    const convDir = path.join(tmpDir, 'data', 'chat', 'conversations');
+    fs.mkdirSync(convDir, { recursive: true });
+
+    const conv1 = {
+      id: crypto.randomUUID(),
+      title: 'Same WS 1',
+      backend: 'claude-code',
+      workingDir: '/tmp/shared-ws',
+      currentSessionId: 's1',
+      sessionNumber: 1,
+      updatedAt: '2024-06-01T00:00:00Z',
+      messages: [],
+    };
+    const conv2 = {
+      id: crypto.randomUUID(),
+      title: 'Same WS 2',
+      backend: 'claude-code',
+      workingDir: '/tmp/shared-ws',
+      currentSessionId: 's2',
+      sessionNumber: 1,
+      updatedAt: '2024-06-02T00:00:00Z',
+      messages: [],
+    };
+    fs.writeFileSync(path.join(convDir, `${conv1.id}.json`), JSON.stringify(conv1, null, 2));
+    fs.writeFileSync(path.join(convDir, `${conv2.id}.json`), JSON.stringify(conv2, null, 2));
+
+    const svc = new ChatService(tmpDir, { defaultWorkspace: DEFAULT_WORKSPACE });
+    await svc.initialize();
+
+    const hash = workspaceHash('/tmp/shared-ws');
+    const index = JSON.parse(fs.readFileSync(
+      path.join(tmpDir, 'data', 'chat', 'workspaces', hash, 'index.json'), 'utf8'
+    ));
+    expect(index.conversations).toHaveLength(2);
+  });
+
+  test('does not error on empty conversations directory', async () => {
+    const convDir = path.join(tmpDir, 'data', 'chat', 'conversations');
+    fs.mkdirSync(convDir, { recursive: true });
+
+    const svc = new ChatService(tmpDir, { defaultWorkspace: DEFAULT_WORKSPACE });
+    await expect(svc.initialize()).resolves.not.toThrow();
+    expect(fs.existsSync(convDir)).toBe(false); // renamed to _backup
   });
 });
 


### PR DESCRIPTION
## Summary
- Replace per-conversation JSON files + archive folders with workspace-scoped storage (`data/chat/workspaces/{hash}/index.json` as single source of truth)
- Conversations sharing the same `workingDir` are grouped under one workspace folder (keyed by `SHA-256(path).substring(0,16)`)
- Active and archived session messages stored as `session-N.json` files under each conversation subfolder
- Add workspace context injection: prepends a 4-line prompt to the first CLI message per session, giving Claude Code access to all past conversations/sessions in the workspace
- Automatic migration from old format on first startup (renames legacy dirs to `_backup`)
- In-memory `convId → workspaceHash` lookup map built on startup for O(1) lookups

## Test plan
- [x] All 185 tests pass (93 chatService + 39 chat routes + 53 others)
- [x] Manual test: create conversation, send messages, verify workspace folder structure
- [x] Manual test: reset session, verify archived session file and index update
- [x] Manual test: start server with existing legacy data, verify migration to workspace format
- [x] Manual test: verify workspace context injection appears in CLI on first message of new session