### PR TITLE
Fix version-bump workflow not pushing tags

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -28,4 +28,5 @@ jobs:
           git add package.json package-lock.json
           git commit -m "chore: bump version to $VERSION"
           git tag -f "v$VERSION"
-          git push origin main --follow-tags --force
+          git push origin main
+          git push origin "v$VERSION" --force


### PR DESCRIPTION
## Summary
- Push the tag explicitly with `git push origin "v$VERSION" --force` instead of relying on `--follow-tags`
- `--follow-tags` silently skips lightweight tags, which is why no tag was created on the previous merge

## Test plan
- [x] Merge and verify the `v0.1.3` (or next) tag appears in the repo