### PR TITLE
Remove archive button from conversation context menu

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -854,7 +854,6 @@ function chatShowContextMenu(e, convId) {
   menu.className = 'chat-context-menu';
   menu.innerHTML = `
     <button class="chat-context-menu-item" data-action="rename">Rename</button>
-    <button class="chat-context-menu-item" data-action="archive">Archive</button>
     <button class="chat-context-menu-item danger" data-action="delete">Delete</button>
   `;
   menu.style.left = e.clientX + 'px';
@@ -864,7 +863,6 @@ function chatShowContextMenu(e, convId) {
     item.onclick = () => {
       chatCloseContextMenu();
       if (item.dataset.action === 'rename') chatRenameConversation(convId);
-      else if (item.dataset.action === 'archive') chatResetSession(convId);
       else if (item.dataset.action === 'delete') chatDeleteConversation(convId);
     };
   });


### PR DESCRIPTION
## Summary
- Removed the "Archive" button and its click handler from the conversation context menu
- No longer relevant with the workspace-based storage architecture

Closes #20

## Test plan
- [x] All 194 existing tests pass
- [x] Open conversation context menu and verify only "Rename" and "Delete" options appear