### PR TITLE
Add self-update mechanism with UI notification

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -78,7 +78,8 @@ agent-cockpit/
 │   │   └── chat.js                     # All chat API routes
 │   └── services/
 │       ├── chatService.js              # Conversation CRUD, messages, sessions, settings
-│       └── cliBackend.js               # Claude CLI process spawning and streaming
+│       ├── cliBackend.js               # Claude CLI process spawning and streaming
+│       └── updateService.js            # Self-update: version checking, git pull, PM2 restart
 ├── public/
 │   ├── index.html                      # HTML shell (79 lines)
 │   ├── app.js                          # All frontend JavaScript (~1560 lines)
@@ -88,7 +89,8 @@ agent-cockpit/
 │   ├── chatService.test.js             # ChatService unit tests — CRUD, messages, sessions, workspace storage, migration, markdown export, workspace context (93 tests)
 │   ├── cliBackend.test.js              # CLIBackend + extractToolDetails unit tests (33 tests)
 │   ├── graceful-shutdown.test.js       # Server shutdown tests (2 tests)
-│   └── sessionStore.test.js            # Session file-store tests (4 tests)
+│   ├── sessionStore.test.js            # Session file-store tests (4 tests)
+│   └── updateService.test.js           # UpdateService unit tests — version comparison, status, trigger guards
 └── data/                               # Runtime data (gitignored, created at startup)
     ├── chat/
     │   ├── workspaces/                 # Workspace-based storage
@@ -543,7 +545,52 @@ Writes the full body to `data/chat/settings.json`.
 ```
 GET /api/chat/version
 ```
-Returns `{ version: string }` read from `package.json`. No CSRF required (read-only).
+Returns `{ version: string, remoteVersion: string|null, updateAvailable: boolean }` read from `package.json` and the update service. No CSRF required (read-only).
+
+### 9.12 Self-Update
+
+**Check update status:**
+```
+GET /api/chat/update-status
+```
+Returns cached update status from the server-side version checker:
+```json
+{
+  "localVersion": "0.1.5",
+  "remoteVersion": "0.1.6",
+  "updateAvailable": true,
+  "lastCheckAt": "2026-03-31T10:00:00.000Z",
+  "lastError": null,
+  "updateInProgress": false
+}
+```
+No CSRF required (read-only). The server checks the remote `origin/main` branch every 15 minutes via `git fetch` + `git show origin/main:package.json`.
+
+**Trigger update:**
+```
+POST /api/chat/update-trigger  [CSRF]
+```
+Executes the full update sequence:
+1. Checks for active CLI streams — refuses if any conversations are actively streaming
+2. Checks `git status --porcelain` — refuses if uncommitted changes exist (ignoring runtime artifacts like `data/`, `.env`, `ecosystem.config.js`)
+3. `git checkout main`
+4. `git pull origin main`
+5. `npm install --production`
+6. `pm2 restart ecosystem.config.js`
+
+Returns:
+```json
+{
+  "success": true,
+  "steps": [
+    { "name": "git checkout main", "success": true, "output": "..." },
+    { "name": "git pull origin main", "success": true, "output": "..." },
+    { "name": "npm install", "success": true, "output": "..." },
+    { "name": "pm2 restart", "success": true, "output": "..." }
+  ]
+}
+```
+On failure, `success` is `false` and an `error` field describes which step failed. The concurrent update guard (`updateInProgress` flag) prevents multiple triggers from running simultaneously.
 
 ---
 
@@ -782,6 +829,55 @@ claude --print \
 - Generator yields events from a queue
 - Waits with `Promise` resolved by stdout/close events or a 100ms timeout
 
+### 10.3 UpdateService
+
+**File:** `src/services/updateService.js`
+
+**Constructor:** `new UpdateService(appRoot)`
+- Reads `localVersion` from `<appRoot>/package.json`
+- Initializes in-memory state: `_latestRemoteVersion`, `_lastCheckAt`, `_lastError`, `_updateInProgress`
+
+**Methods:**
+
+#### `start()`
+Begins periodic version checks. Runs `_checkRemoteVersion()` immediately, then every 15 minutes via `setInterval` (unref'd so it doesn't block process exit).
+
+#### `stop()`
+Clears the polling interval. Called during graceful shutdown via the router's `shutdown()` function.
+
+#### `getStatus()`
+Returns cached update status:
+```js
+{
+  localVersion: '0.1.5',
+  remoteVersion: '0.1.6',      // null if never checked
+  updateAvailable: true,         // simple numeric semver comparison
+  lastCheckAt: '2026-03-31T...', // ISO timestamp
+  lastError: null,
+  updateInProgress: false
+}
+```
+
+#### `triggerUpdate({ hasActiveStreams })`
+Executes the full update sequence with guards:
+1. **Concurrent guard** — returns error if `_updateInProgress` is true
+2. **Active streams guard** — calls `hasActiveStreams()` callback (provided by router, checks `activeStreams.size > 0`); refuses if CLI streams are active
+3. **Dirty tree guard** — runs `git status --porcelain`, filters out expected runtime artifacts (`data/`, `.env`, `ecosystem.config.js`, `.DS_Store`, `.claude/`); refuses if significant changes remain
+4. **git checkout main** (timeout: 30s)
+5. **git pull origin main** (timeout: 60s)
+6. **npm install --production** (timeout: 120s)
+7. **pm2 restart ecosystem.config.js** (timeout: 30s)
+
+Each step is recorded in a `steps[]` array. On failure, returns immediately with the failed step and error message. The `_updateInProgress` flag is reset in a `finally` block.
+
+All commands use `child_process.execFile` (no shell) with `cwd` set to `appRoot`.
+
+#### `_checkRemoteVersion()`
+Runs `git fetch origin main` then `git show origin/main:package.json`. Parses JSON to extract the remote version. On failure, sets `_lastError` and logs but does not throw.
+
+#### `_isNewer(remote, local)`
+Simple three-part numeric comparison: splits on `.`, compares each part numerically left-to-right.
+
 ---
 
 ## 11. Frontend
@@ -800,7 +896,7 @@ Single-page layout:
       - `.chat-conv-list` — conversation list (populated by JS)
       - `.chat-sidebar-footer` — Settings button
       - `.chat-sidebar-footer` — Sign Out button
-      - `.chat-sidebar-version` — App version label (fetched from `/api/chat/version`)
+      - `.chat-sidebar-version` — App version label + update indicator (fetched from `/api/chat/version`)
     - `.chat-main` — right panel:
       - `.chat-header` — sidebar toggle, title, action buttons (Download, Reset, Sessions)
       - `.chat-messages` — message area with empty state (prompt cards)
@@ -1061,6 +1157,7 @@ The chat router maintains an in-memory `Map<conversationId, { stream, abort, sen
 - **Deleted** when: stream completes, client disconnects, abort is called, conversation is deleted, or server shuts down
 - **Prevents** concurrent streams per conversation (only one active CLI process per conversation at a time)
 - **Blocks** session reset while streaming (returns `409`)
+- **Blocks** self-update while any stream is active (update would kill CLI processes via PM2 restart)
 
 ---
 
@@ -1181,6 +1278,14 @@ The `isNewSession` flag is determined by checking if the current session's `mess
 - Session retrieves correctly after write
 - Session survives store recreation (simulates server restart)
 - Session destroy removes the file
+
+**`test/updateService.test.js`**:
+- Tests `_isNewer` semver comparison (equal, newer, older, different segment counts)
+- Tests `getStatus` returns correct initial state
+- Tests `triggerUpdate` guards: blocks when update already in progress, blocks when active streams exist, blocks when working tree is dirty
+- Tests `triggerUpdate` step execution and error reporting
+- Tests `start/stop` interval management
+- Uses mocked `child_process.execFile` — no real git or pm2 calls
 
 ### Running Tests
 

--- a/public/app.js
+++ b/public/app.js
@@ -107,11 +107,17 @@ function chatInit() {
   chatWireEvents();
   chatLoadConversations();
 
-  // Show app version in sidebar
+  // Show app version in sidebar + check for updates
   chatFetch('version').then(res => res.json()).then(v => {
-    const el = document.getElementById('chat-version-label');
-    if (el && v.version) el.textContent = 'v' + v.version;
+    const textEl = document.getElementById('chat-version-text');
+    if (textEl && v.version) textEl.textContent = 'v' + v.version;
+    chatCheckUpdateIndicator(v);
   }).catch(() => {});
+
+  // Poll for update status every 5 minutes (reads server-cached state, no git ops)
+  setInterval(() => {
+    chatFetch('update-status').then(res => res.json()).then(chatCheckUpdateIndicator).catch(() => {});
+  }, 5 * 60 * 1000);
 
   // Sync theme from server settings
   chatFetch('settings').then(res => res.json()).then(s => {
@@ -1827,6 +1833,113 @@ function chatCloseModal() {
   if (overlay) overlay.remove();
 }
 window.chatCloseModal = chatCloseModal;
+
+// ── Self-update UI ───────────────────────────────────────────────────────────
+
+function chatCheckUpdateIndicator(status) {
+  const indicator = document.getElementById('chat-update-indicator');
+  if (!indicator) return;
+  if (status.updateAvailable && status.remoteVersion) {
+    indicator.textContent = 'v' + status.remoteVersion + ' available';
+    indicator.title = 'Update to v' + status.remoteVersion;
+    indicator.style.display = '';
+    indicator.onclick = () => chatShowUpdateModal(status);
+  } else {
+    indicator.style.display = 'none';
+    indicator.onclick = null;
+  }
+}
+
+function chatShowUpdateModal(status) {
+  const localVer = status.localVersion || status.version || '?';
+  const remoteVer = status.remoteVersion || '?';
+  const html = `
+    <div class="chat-modal-body" style="padding:16px;">
+      <div style="margin-bottom:16px;">
+        <div style="font-size:13px;color:var(--muted);margin-bottom:6px;">
+          Current version: <strong>v${esc(localVer)}</strong>
+        </div>
+        <div style="font-size:13px;color:var(--muted);margin-bottom:16px;">
+          Available version: <strong>v${esc(remoteVer)}</strong>
+        </div>
+        <div style="font-size:12px;color:var(--muted);margin-bottom:16px;">
+          This will pull the latest code from main, install dependencies, and restart the server.
+          The page will reload automatically.
+        </div>
+      </div>
+      <div id="chat-update-status" style="display:none;margin-bottom:12px;"></div>
+      <button class="chat-settings-save" id="chat-update-confirm-btn">Update Now</button>
+    </div>
+  `;
+  chatShowModal('Update Available', html);
+  document.getElementById('chat-update-confirm-btn').addEventListener('click', chatTriggerUpdate);
+}
+
+async function chatTriggerUpdate() {
+  const statusEl = document.getElementById('chat-update-status');
+  const btn = document.getElementById('chat-update-confirm-btn');
+  if (statusEl) {
+    statusEl.style.display = 'block';
+    statusEl.innerHTML = '<div style="color:var(--muted);font-size:13px;">Updating... This may take a moment.</div>';
+  }
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = 'Updating...';
+  }
+
+  try {
+    const res = await chatFetch('update-trigger', { method: 'POST' });
+    const result = await res.json();
+
+    if (result.success) {
+      if (statusEl) {
+        statusEl.innerHTML = '<div style="color:var(--done);font-size:13px;">Update successful! Restarting server...</div>';
+      }
+      setTimeout(() => chatShowRestartOverlay(), 1000);
+      setTimeout(() => window.location.reload(), 6000);
+    } else {
+      if (statusEl) {
+        const stepsHtml = (result.steps || []).map(s =>
+          '<div style="font-size:12px;color:' + (s.success ? 'var(--done)' : 'var(--danger)') + ';">'
+          + (s.success ? '&#10003; ' : '&#10007; ') + esc(s.name) + '</div>'
+        ).join('');
+        statusEl.innerHTML =
+          '<div style="color:var(--danger);font-size:13px;margin-bottom:8px;">'
+          + esc(result.error) + '</div>' + stepsHtml;
+      }
+      if (btn) {
+        btn.disabled = false;
+        btn.textContent = 'Retry Update';
+      }
+    }
+  } catch (err) {
+    // If the server restarted before sending the response, we get a network error
+    if (err.message === 'Failed to fetch' || err.name === 'TypeError') {
+      chatShowRestartOverlay();
+      setTimeout(() => window.location.reload(), 5000);
+      return;
+    }
+    if (statusEl) {
+      statusEl.innerHTML = '<div style="color:var(--danger);font-size:13px;">Update failed: ' + esc(err.message) + '</div>';
+    }
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = 'Retry Update';
+    }
+  }
+}
+
+function chatShowRestartOverlay() {
+  chatCloseModal();
+  const overlay = document.createElement('div');
+  overlay.id = 'chat-restart-overlay';
+  overlay.innerHTML =
+    '<div style="text-align:center;">'
+    + '<div style="font-size:18px;font-weight:600;margin-bottom:8px;">Restarting Server...</div>'
+    + '<div style="font-size:13px;color:var(--muted);">The page will reload automatically.</div>'
+    + '</div>';
+  document.body.appendChild(overlay);
+}
 
 // ── Keyboard shortcuts ────────────────────────────────────────────────────────
 

--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,10 @@
     <div class="chat-sidebar-footer" id="chat-signout-btn">
       ↪ Sign Out
     </div>
-    <div class="chat-sidebar-version" id="chat-version-label"></div>
+    <div class="chat-sidebar-version" id="chat-version-label">
+      <span id="chat-version-text"></span>
+      <span id="chat-update-indicator" class="chat-update-indicator" style="display:none;" title="Update available">Update available</span>
+    </div>
   </div>
   <div class="chat-main">
     <div class="chat-header">

--- a/public/styles.css
+++ b/public/styles.css
@@ -300,6 +300,37 @@
     color: var(--text-secondary);
     text-align: center;
     opacity: 0.6;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .chat-update-indicator {
+    font-size: 10px;
+    color: var(--accent-chat);
+    cursor: pointer;
+    padding: 1px 6px;
+    border-radius: 8px;
+    background: rgba(99, 102, 241, 0.1);
+    transition: background 0.15s, color 0.15s;
+    white-space: nowrap;
+  }
+
+  .chat-update-indicator:hover {
+    background: rgba(99, 102, 241, 0.2);
+  }
+
+  #chat-restart-overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--modal-overlay, rgba(0, 0, 0, 0.5));
+    z-index: 500;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text);
   }
 
   /* ── Chat Main Panel ──────────────────────────────────────── */

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const { applySecurity } = require('./src/middleware/security');
 const { createChatRouter } = require('./src/routes/chat');
 const { ChatService } = require('./src/services/chatService');
 const { CLIBackend } = require('./src/services/cliBackend');
+const { UpdateService } = require('./src/services/updateService');
 
 const app = express();
 
@@ -57,13 +58,16 @@ app.get('/api/csrf-token', (req, res) => {
 
 const chatService = new ChatService(__dirname, { defaultWorkspace: config.DEFAULT_WORKSPACE });
 const cliBackend = new CLIBackend({ workingDir: config.DEFAULT_WORKSPACE });
-const { router: chatRouter, shutdown: chatShutdown } = createChatRouter({ chatService, cliBackend });
+const updateService = new UpdateService(__dirname);
+const { router: chatRouter, shutdown: chatShutdown } = createChatRouter({ chatService, cliBackend, updateService });
 app.use('/api/chat', chatRouter);
 
 app.use(express.static(path.join(__dirname, 'public')));
 
 // Initialize workspace storage and run any pending migrations
 chatService.initialize().then(() => {
+  updateService.start();
+
   const server = app.listen(config.PORT, () => {
     console.log(`Agent Cockpit running on port ${config.PORT}`);
   });

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -5,7 +5,7 @@ const path = require('path');
 const multer = require('multer');
 const { csrfGuard } = require('../middleware/csrf');
 
-function createChatRouter({ chatService, cliBackend }) {
+function createChatRouter({ chatService, cliBackend, updateService }) {
   const router = express.Router();
   const packageJson = require('../../package.json');
 
@@ -14,7 +14,31 @@ function createChatRouter({ chatService, cliBackend }) {
 
   // ── Version ─────────────────────────────────────────────────────────────────
   router.get('/version', (req, res) => {
-    res.json({ version: packageJson.version });
+    const status = updateService ? updateService.getStatus() : {};
+    res.json({
+      version: packageJson.version,
+      remoteVersion: status.remoteVersion || null,
+      updateAvailable: status.updateAvailable || false,
+    });
+  });
+
+  // ── Update status ──────────────────────────────────────────────────────────
+  router.get('/update-status', (req, res) => {
+    if (!updateService) return res.json({ updateAvailable: false });
+    res.json(updateService.getStatus());
+  });
+
+  // ── Trigger update ─────────────────────────────────────────────────────────
+  router.post('/update-trigger', csrfGuard, async (req, res) => {
+    if (!updateService) return res.status(501).json({ error: 'Update service not available' });
+    try {
+      const result = await updateService.triggerUpdate({
+        hasActiveStreams: () => activeStreams.size > 0,
+      });
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
   });
 
   // ── Browse directories ─────────────────────────────────────────────────────
@@ -500,6 +524,7 @@ function createChatRouter({ chatService, cliBackend }) {
       entry.abort();
     }
     activeStreams.clear();
+    if (updateService) updateService.stop();
   }
 
   return { router, shutdown };

--- a/src/services/updateService.js
+++ b/src/services/updateService.js
@@ -1,0 +1,183 @@
+const { execFile } = require('child_process');
+const path = require('path');
+
+/**
+ * UpdateService — periodically checks the remote main branch for a newer
+ * version and executes self-update + PM2 restart when triggered by the user.
+ */
+class UpdateService {
+  constructor(appRoot) {
+    this._appRoot = appRoot;
+    this._localVersion = require(path.join(appRoot, 'package.json')).version;
+    this._latestRemoteVersion = null;
+    this._checkInterval = null;
+    this._lastCheckAt = null;
+    this._lastError = null;
+    this._updateInProgress = false;
+  }
+
+  /** Start periodic version checks (every 15 minutes). */
+  start() {
+    this._checkRemoteVersion();
+    this._checkInterval = setInterval(() => this._checkRemoteVersion(), 15 * 60 * 1000);
+    this._checkInterval.unref();
+  }
+
+  /** Stop periodic version checks. */
+  stop() {
+    if (this._checkInterval) {
+      clearInterval(this._checkInterval);
+      this._checkInterval = null;
+    }
+  }
+
+  /** Return cached update status. */
+  getStatus() {
+    return {
+      localVersion: this._localVersion,
+      remoteVersion: this._latestRemoteVersion,
+      updateAvailable: this._isNewer(this._latestRemoteVersion, this._localVersion),
+      lastCheckAt: this._lastCheckAt,
+      lastError: this._lastError,
+      updateInProgress: this._updateInProgress,
+    };
+  }
+
+  /**
+   * Execute the full update sequence.
+   * @param {object} opts
+   * @param {function} opts.hasActiveStreams — returns true if CLI streams are active
+   * @returns {{ success: boolean, steps: Array<{ name: string, success: boolean, output?: string }>, error?: string }}
+   */
+  async triggerUpdate({ hasActiveStreams } = {}) {
+    if (this._updateInProgress) {
+      return { success: false, steps: [], error: 'Update already in progress' };
+    }
+
+    this._updateInProgress = true;
+    const steps = [];
+
+    try {
+      // Guard: active CLI streams
+      if (hasActiveStreams && hasActiveStreams()) {
+        return { success: false, steps: [], error: 'Cannot update while conversations are actively running. Please wait for them to complete or abort them first.' };
+      }
+
+      // Guard: dirty working tree
+      const statusOut = await this._exec('git', ['status', '--porcelain']);
+      // Filter out untracked files that are expected (data/, sessions, etc.)
+      const significantChanges = statusOut.trim().split('\n').filter(line => {
+        if (!line.trim()) return false;
+        // Ignore untracked files in data/ and session dirs — they are runtime artifacts
+        if (line.startsWith('?? data/')) return false;
+        if (line.startsWith('?? .env')) return false;
+        if (line.startsWith('?? ecosystem.config.js')) return false;
+        if (line.startsWith('?? .DS_Store')) return false;
+        if (line.startsWith('?? .claude/')) return false;
+        return true;
+      });
+      if (significantChanges.length > 0) {
+        return {
+          success: false,
+          steps: [],
+          error: 'Uncommitted local changes detected. Please commit or stash changes before updating.',
+        };
+      }
+
+      // Step 1: git checkout main
+      try {
+        const out = await this._exec('git', ['checkout', 'main']);
+        steps.push({ name: 'git checkout main', success: true, output: out.trim() });
+      } catch (err) {
+        steps.push({ name: 'git checkout main', success: false, output: err.message });
+        return { success: false, steps, error: 'Failed to checkout main branch: ' + err.message };
+      }
+
+      // Step 2: git pull origin main
+      try {
+        const out = await this._exec('git', ['pull', 'origin', 'main'], 60000);
+        steps.push({ name: 'git pull origin main', success: true, output: out.trim() });
+      } catch (err) {
+        steps.push({ name: 'git pull origin main', success: false, output: err.message });
+        return { success: false, steps, error: 'Failed to pull latest changes: ' + err.message };
+      }
+
+      // Step 3: npm install
+      try {
+        const out = await this._exec('npm', ['install', '--production'], 120000);
+        steps.push({ name: 'npm install', success: true, output: out.trim() });
+      } catch (err) {
+        steps.push({ name: 'npm install', success: false, output: err.message });
+        return { success: false, steps, error: 'Failed to install dependencies: ' + err.message };
+      }
+
+      // Step 4: PM2 restart
+      try {
+        const ecosystemPath = path.join(this._appRoot, 'ecosystem.config.js');
+        const out = await this._exec('pm2', ['restart', ecosystemPath], 30000);
+        steps.push({ name: 'pm2 restart', success: true, output: out.trim() });
+      } catch (err) {
+        steps.push({ name: 'pm2 restart', success: false, output: err.message });
+        return { success: false, steps, error: 'Failed to restart server via PM2: ' + err.message };
+      }
+
+      return { success: true, steps };
+    } finally {
+      this._updateInProgress = false;
+    }
+  }
+
+  // ── Internal helpers ──────────────────────────────────────────────────────
+
+  async _checkRemoteVersion() {
+    try {
+      await this._exec('git', ['fetch', 'origin', 'main'], 30000);
+      const raw = await this._exec('git', ['show', 'origin/main:package.json'], 10000);
+      const parsed = JSON.parse(raw);
+      this._latestRemoteVersion = parsed.version || null;
+      this._lastCheckAt = new Date().toISOString();
+      this._lastError = null;
+    } catch (err) {
+      this._lastError = err.message;
+      console.error('[updateService] Version check failed:', err.message);
+    }
+  }
+
+  /**
+   * Run a command via execFile.
+   * @param {string} cmd
+   * @param {string[]} args
+   * @param {number} [timeout=30000]
+   * @returns {Promise<string>} stdout
+   */
+  _exec(cmd, args, timeout = 30000) {
+    return new Promise((resolve, reject) => {
+      execFile(cmd, args, { cwd: this._appRoot, timeout, maxBuffer: 5 * 1024 * 1024 }, (err, stdout, stderr) => {
+        if (err) {
+          reject(new Error(stderr || err.message));
+        } else {
+          resolve(stdout);
+        }
+      });
+    });
+  }
+
+  /**
+   * Simple semver comparison: returns true if `remote` is strictly newer than `local`.
+   * Handles standard three-part versions (e.g. 0.1.6 > 0.1.5).
+   */
+  _isNewer(remote, local) {
+    if (!remote || !local) return false;
+    const r = remote.split('.').map(Number);
+    const l = local.split('.').map(Number);
+    for (let i = 0; i < Math.max(r.length, l.length); i++) {
+      const rv = r[i] || 0;
+      const lv = l[i] || 0;
+      if (rv > lv) return true;
+      if (rv < lv) return false;
+    }
+    return false;
+  }
+}
+
+module.exports = { UpdateService };

--- a/test/chat.test.js
+++ b/test/chat.test.js
@@ -758,6 +758,8 @@ describe('GET /api/chat/version', () => {
     const expected = require('../package.json').version;
     const res = await makeRequest('GET', '/api/chat/version');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ version: expected });
+    expect(res.body.version).toBe(expected);
+    expect(res.body).toHaveProperty('remoteVersion');
+    expect(res.body).toHaveProperty('updateAvailable');
   });
 });

--- a/test/updateService.test.js
+++ b/test/updateService.test.js
@@ -1,0 +1,256 @@
+const path = require('path');
+
+// ── Mock child_process.execFile ─────────────────────────────────────────────
+
+const mockExecFileFn = jest.fn();
+jest.mock('child_process', () => ({
+  execFile: (...args) => mockExecFileFn(...args),
+}));
+
+const { UpdateService } = require('../src/services/updateService');
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function mockExecFile(responses) {
+  let callIndex = 0;
+  mockExecFileFn.mockImplementation((cmd, args, opts, cb) => {
+    const key = cmd + ' ' + args.join(' ');
+    const entry = responses[callIndex++] || responses[key];
+    if (!entry) {
+      cb(null, '', '');
+      return;
+    }
+    if (entry.error) {
+      cb(new Error(entry.error), '', entry.stderr || entry.error);
+    } else {
+      cb(null, entry.stdout || '', entry.stderr || '');
+    }
+  });
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('UpdateService', () => {
+  let service;
+  const appRoot = path.join(__dirname, '..');
+
+  beforeEach(() => {
+    service = new UpdateService(appRoot);
+    mockExecFileFn.mockReset();
+  });
+
+  afterEach(() => {
+    service.stop();
+  });
+
+  // ── _isNewer ────────────────────────────────────────────────────────────
+
+  describe('_isNewer', () => {
+    test('returns false when versions are equal', () => {
+      expect(service._isNewer('0.1.5', '0.1.5')).toBe(false);
+    });
+
+    test('returns true when remote is newer (patch)', () => {
+      expect(service._isNewer('0.1.6', '0.1.5')).toBe(true);
+    });
+
+    test('returns true when remote is newer (minor)', () => {
+      expect(service._isNewer('0.2.0', '0.1.9')).toBe(true);
+    });
+
+    test('returns true when remote is newer (major)', () => {
+      expect(service._isNewer('1.0.0', '0.9.9')).toBe(true);
+    });
+
+    test('returns false when remote is older', () => {
+      expect(service._isNewer('0.1.4', '0.1.5')).toBe(false);
+    });
+
+    test('returns false when remote is null', () => {
+      expect(service._isNewer(null, '0.1.5')).toBe(false);
+    });
+
+    test('returns false when local is null', () => {
+      expect(service._isNewer('0.1.5', null)).toBe(false);
+    });
+
+    test('handles different segment counts', () => {
+      expect(service._isNewer('0.1.5.1', '0.1.5')).toBe(true);
+      expect(service._isNewer('0.1.5', '0.1.5.1')).toBe(false);
+    });
+  });
+
+  // ── getStatus ──────────────────────────────────────────────────────────
+
+  describe('getStatus', () => {
+    test('returns initial state', () => {
+      const status = service.getStatus();
+      expect(status.localVersion).toBe(require('../package.json').version);
+      expect(status.remoteVersion).toBeNull();
+      expect(status.updateAvailable).toBe(false);
+      expect(status.lastCheckAt).toBeNull();
+      expect(status.lastError).toBeNull();
+      expect(status.updateInProgress).toBe(false);
+    });
+
+    test('returns updateAvailable true when remote is newer', () => {
+      service._latestRemoteVersion = '99.0.0';
+      const status = service.getStatus();
+      expect(status.updateAvailable).toBe(true);
+      expect(status.remoteVersion).toBe('99.0.0');
+    });
+  });
+
+  // ── start / stop ──────────────────────────────────────────────────────
+
+  describe('start / stop', () => {
+    test('starts and stops the polling interval', () => {
+      // Mock the version check to avoid real git calls
+      mockExecFile([
+        { stdout: '' }, // git fetch
+        { stdout: JSON.stringify({ version: '0.1.5' }) }, // git show
+      ]);
+
+      service.start();
+      expect(service._checkInterval).not.toBeNull();
+
+      service.stop();
+      expect(service._checkInterval).toBeNull();
+    });
+  });
+
+  // ── _checkRemoteVersion ────────────────────────────────────────────────
+
+  describe('_checkRemoteVersion', () => {
+    test('updates remote version on success', async () => {
+      mockExecFile([
+        { stdout: '' }, // git fetch
+        { stdout: JSON.stringify({ version: '0.2.0' }) }, // git show
+      ]);
+
+      await service._checkRemoteVersion();
+      expect(service._latestRemoteVersion).toBe('0.2.0');
+      expect(service._lastCheckAt).not.toBeNull();
+      expect(service._lastError).toBeNull();
+    });
+
+    test('sets lastError on failure', async () => {
+      mockExecFile([
+        { error: 'fatal: could not fetch' },
+      ]);
+
+      await service._checkRemoteVersion();
+      expect(service._lastError).toBe('fatal: could not fetch');
+      expect(service._latestRemoteVersion).toBeNull();
+    });
+  });
+
+  // ── triggerUpdate guards ──────────────────────────────────────────────
+
+  describe('triggerUpdate', () => {
+    test('blocks when update is already in progress', async () => {
+      service._updateInProgress = true;
+      const result = await service.triggerUpdate();
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/already in progress/);
+    });
+
+    test('blocks when active streams exist', async () => {
+      const result = await service.triggerUpdate({
+        hasActiveStreams: () => true,
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/actively running/);
+    });
+
+    test('blocks when working tree is dirty', async () => {
+      mockExecFile([
+        { stdout: ' M server.js\n' }, // git status --porcelain
+      ]);
+
+      const result = await service.triggerUpdate({
+        hasActiveStreams: () => false,
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Uncommitted local changes/);
+    });
+
+    test('ignores expected untracked files in git status', async () => {
+      // git status shows only runtime artifacts -> should proceed
+      mockExecFile([
+        { stdout: '?? data/sessions/abc.json\n?? .env\n?? ecosystem.config.js\n?? .DS_Store\n?? .claude/something\n' }, // git status
+        { stdout: 'Already on \'main\'\n' }, // git checkout
+        { stdout: 'Already up to date.\n' }, // git pull
+        { stdout: 'up to date\n' }, // npm install
+        { stdout: 'restarted\n' }, // pm2 restart
+      ]);
+
+      const result = await service.triggerUpdate({
+        hasActiveStreams: () => false,
+      });
+      expect(result.success).toBe(true);
+      expect(result.steps).toHaveLength(4);
+    });
+
+    test('executes all steps on success', async () => {
+      mockExecFile([
+        { stdout: '' }, // git status (clean)
+        { stdout: 'Already on \'main\'\n' }, // git checkout
+        { stdout: 'Updating abc..def\n' }, // git pull
+        { stdout: 'added 0 packages\n' }, // npm install
+        { stdout: '[PM2] restarted\n' }, // pm2 restart
+      ]);
+
+      const result = await service.triggerUpdate({
+        hasActiveStreams: () => false,
+      });
+      expect(result.success).toBe(true);
+      expect(result.steps).toHaveLength(4);
+      expect(result.steps[0].name).toBe('git checkout main');
+      expect(result.steps[1].name).toBe('git pull origin main');
+      expect(result.steps[2].name).toBe('npm install');
+      expect(result.steps[3].name).toBe('pm2 restart');
+      result.steps.forEach(s => expect(s.success).toBe(true));
+    });
+
+    test('stops at first failed step and reports error', async () => {
+      mockExecFile([
+        { stdout: '' }, // git status (clean)
+        { stdout: 'Switched to branch \'main\'\n' }, // git checkout
+        { error: 'fatal: could not connect to remote' }, // git pull fails
+      ]);
+
+      const result = await service.triggerUpdate({
+        hasActiveStreams: () => false,
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Failed to pull/);
+      expect(result.steps).toHaveLength(2);
+      expect(result.steps[0].success).toBe(true);
+      expect(result.steps[1].success).toBe(false);
+    });
+
+    test('resets updateInProgress flag after failure', async () => {
+      mockExecFile([
+        { stdout: '' }, // git status
+        { error: 'checkout failed' }, // git checkout fails
+      ]);
+
+      await service.triggerUpdate({ hasActiveStreams: () => false });
+      expect(service._updateInProgress).toBe(false);
+    });
+
+    test('resets updateInProgress flag after success', async () => {
+      mockExecFile([
+        { stdout: '' },
+        { stdout: 'ok' },
+        { stdout: 'ok' },
+        { stdout: 'ok' },
+        { stdout: 'ok' },
+      ]);
+
+      await service.triggerUpdate({ hasActiveStreams: () => false });
+      expect(service._updateInProgress).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `UpdateService` that polls `origin/main` every 15 minutes to detect newer versions via `git fetch` + `git show`
- Shows a muted, clickable "Update available" indicator next to the version label in the sidebar
- Clicking opens a modal with version comparison and "Update Now" button
- Update sequence: `git checkout main` → `git pull` → `npm install` → `pm2 restart ecosystem.config.js`
- Guards prevent update during active CLI streams, dirty working tree, or concurrent triggers
- Fullscreen "Restarting..." overlay with automatic page reload after PM2 restart
- Handles network errors gracefully (server may die before sending HTTP response during PM2 restart)

## Files Changed

- **New:** `src/services/updateService.js` — core update logic (version checking, update execution)
- **New:** `test/updateService.test.js` — 21 tests (semver comparison, status, guards, step execution)
- **Modified:** `server.js` — instantiate and wire UpdateService
- **Modified:** `src/routes/chat.js` — enhanced `/version`, new `/update-status` and `/update-trigger` routes, active stream guard
- **Modified:** `public/index.html` — version label now contains text + indicator spans
- **Modified:** `public/app.js` — update indicator, modal, trigger handler, restart overlay, 5-min polling
- **Modified:** `public/styles.css` — indicator pill and restart overlay styles
- **Modified:** `SPEC.md` — documented UpdateService, new API endpoints, testing
- **Modified:** `test/chat.test.js` — updated version endpoint test for new response shape

## Test plan

- [x] Verify `GET /api/chat/version` returns `remoteVersion` and `updateAvailable` fields
- [x] Confirm indicator does NOT appear when versions match
- [x] Confirm indicator appears when a newer version exists on origin/main
- [x] Click indicator → modal opens with current/available version info
- [x] Test update with active CLI stream → should be blocked with error message
- [x] Test update with dirty working tree → should be blocked
- [x] Test successful update flow → git pull, npm install, PM2 restart, page reload
- [x] Verify all 215 tests pass (`npm test`)

Closes #26