### PR TITLE
Fix PM2 restart race condition in self-update

### DIFF
--- a/src/services/updateService.js
+++ b/src/services/updateService.js
@@ -1,4 +1,4 @@
-const { execFile } = require('child_process');
+const { execFile, spawn } = require('child_process');
 const path = require('path');
 
 /**
@@ -111,15 +111,17 @@ class UpdateService {
         return { success: false, steps, error: 'Failed to install dependencies: ' + err.message };
       }
 
-      // Step 4: PM2 restart
-      try {
-        const ecosystemPath = path.join(this._appRoot, 'ecosystem.config.js');
-        const out = await this._exec('pm2', ['restart', ecosystemPath], 30000);
-        steps.push({ name: 'pm2 restart', success: true, output: out.trim() });
-      } catch (err) {
-        steps.push({ name: 'pm2 restart', success: false, output: err.message });
-        return { success: false, steps, error: 'Failed to restart server via PM2: ' + err.message };
-      }
+      // Step 4: PM2 restart — fire and forget, because PM2 will kill this
+      // process before execFile can report success. We spawn detached so the
+      // PM2 CLI outlives our process, and return immediately.
+      const ecosystemPath = path.join(this._appRoot, 'ecosystem.config.js');
+      const pm2 = spawn('pm2', ['restart', ecosystemPath], {
+        cwd: this._appRoot,
+        detached: true,
+        stdio: 'ignore',
+      });
+      pm2.unref();
+      steps.push({ name: 'pm2 restart', success: true, output: 'Restart signal sent' });
 
       return { success: true, steps };
     } finally {

--- a/test/updateService.test.js
+++ b/test/updateService.test.js
@@ -3,8 +3,11 @@ const path = require('path');
 // ── Mock child_process.execFile ─────────────────────────────────────────────
 
 const mockExecFileFn = jest.fn();
+const mockSpawnResult = { unref: jest.fn() };
+const mockSpawnFn = jest.fn(() => mockSpawnResult);
 jest.mock('child_process', () => ({
   execFile: (...args) => mockExecFileFn(...args),
+  spawn: (...args) => mockSpawnFn(...args),
 }));
 
 const { UpdateService } = require('../src/services/updateService');
@@ -37,6 +40,8 @@ describe('UpdateService', () => {
   beforeEach(() => {
     service = new UpdateService(appRoot);
     mockExecFileFn.mockReset();
+    mockSpawnFn.mockClear();
+    mockSpawnResult.unref.mockClear();
   });
 
   afterEach(() => {
@@ -182,7 +187,6 @@ describe('UpdateService', () => {
         { stdout: 'Already on \'main\'\n' }, // git checkout
         { stdout: 'Already up to date.\n' }, // git pull
         { stdout: 'up to date\n' }, // npm install
-        { stdout: 'restarted\n' }, // pm2 restart
       ]);
 
       const result = await service.triggerUpdate({
@@ -190,6 +194,7 @@ describe('UpdateService', () => {
       });
       expect(result.success).toBe(true);
       expect(result.steps).toHaveLength(4);
+      expect(mockSpawnFn).toHaveBeenCalled();
     });
 
     test('executes all steps on success', async () => {
@@ -198,7 +203,6 @@ describe('UpdateService', () => {
         { stdout: 'Already on \'main\'\n' }, // git checkout
         { stdout: 'Updating abc..def\n' }, // git pull
         { stdout: 'added 0 packages\n' }, // npm install
-        { stdout: '[PM2] restarted\n' }, // pm2 restart
       ]);
 
       const result = await service.triggerUpdate({
@@ -211,6 +215,9 @@ describe('UpdateService', () => {
       expect(result.steps[2].name).toBe('npm install');
       expect(result.steps[3].name).toBe('pm2 restart');
       result.steps.forEach(s => expect(s.success).toBe(true));
+      // PM2 restart uses detached spawn (fire-and-forget)
+      expect(mockSpawnFn).toHaveBeenCalledWith('pm2', expect.arrayContaining(['restart']), expect.objectContaining({ detached: true }));
+      expect(mockSpawnResult.unref).toHaveBeenCalled();
     });
 
     test('stops at first failed step and reports error', async () => {
@@ -243,7 +250,6 @@ describe('UpdateService', () => {
     test('resets updateInProgress flag after success', async () => {
       mockExecFile([
         { stdout: '' },
-        { stdout: 'ok' },
         { stdout: 'ok' },
         { stdout: 'ok' },
         { stdout: 'ok' },


### PR DESCRIPTION
## Summary

- PM2 restart kills the server process before `execFile` can report success, causing the UI to show a false "pm2 restart failed" error even though the restart actually worked
- Switches the PM2 restart step from `execFile` (wait for completion) to `spawn` with `detached: true` + `unref()` (fire-and-forget)
- The HTTP response is now sent before PM2 kills the process, so the UI shows all four green checkmarks

## Test plan

- [ ] Trigger a self-update — all 4 steps should show success
- [ ] Page should auto-reload after the restart overlay
- [ ] All 215 tests pass (`npm test`)