### PR TITLE
Refactor CLI backend into pluggable adapter pattern

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1538,10 +1538,32 @@ function chatShowUserQuestion(msgEl, convId, event) {
   chatScrollToBottom();
 }
 
+function chatFormatErrorMessage(errorMsg) {
+  // Parse "API Error: 500 {...json...}" into a friendly message
+  const apiMatch = errorMsg.match(/^API Error:\s*(\d{3})\s*(.*)/s);
+  if (apiMatch) {
+    const code = apiMatch[1];
+    const rest = apiMatch[2].trim();
+    let detail = '';
+    try {
+      const parsed = JSON.parse(rest);
+      detail = (parsed.error && parsed.error.message) || parsed.message || '';
+    } catch {
+      detail = rest;
+    }
+    if (code === '500') return 'The API returned an internal server error. This is usually a temporary issue — try again.';
+    if (code === '429') return 'Rate limit exceeded. Please wait a moment before retrying.';
+    if (code === '529') return 'The API is temporarily overloaded. Please try again shortly.';
+    return `API error ${code}${detail ? ': ' + detail : ''}`;
+  }
+  return errorMsg;
+}
+
 function chatAppendError(errorMsg) {
   const container = document.getElementById('chat-messages');
   if (!container) return;
 
+  const friendly = chatFormatErrorMessage(errorMsg);
   const errEl = document.createElement('div');
   errEl.className = 'chat-msg assistant';
   errEl.innerHTML = `
@@ -1549,7 +1571,7 @@ function chatAppendError(errorMsg) {
       <div class="chat-msg-avatar" style="background:#fee2e2;color:#dc2626;">!</div>
       <div class="chat-msg-body">
         <div class="chat-msg-role" style="color:#dc2626;">Error</div>
-        <div class="chat-msg-content" style="color:#dc2626;">${esc(errorMsg)}</div>
+        <div class="chat-msg-content" style="color:#dc2626;">${esc(friendly)}</div>
         <div class="chat-msg-actions" style="opacity:1;">
           <button class="chat-msg-action" onclick="chatRetryLast()">Retry</button>
         </div>

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -417,10 +417,17 @@ function createChatRouter({ chatService, backendRegistry, updateService }) {
             res.write(`data: ${JSON.stringify({ type: 'error', error: event.error })}\n\n`);
           } else if (event.type === 'done') {
             // Save remaining text or result as the final message
+            // Check if the accumulated text is actually an API error
+            const apiErrPattern = /^API Error:\s*\d{3}\s/;
             if (hasStreamingDeltas && fullResponse.trim()) {
-              console.log(`[chat] Stream done for conv=${convId}, saving final segment len=${fullResponse.trim().length}`);
-              const assistantMsg = await chatService.addMessage(convId, 'assistant', fullResponse.trim(), backend, thinkingText.trim() || null);
-              res.write(`data: ${JSON.stringify({ type: 'assistant_message', message: assistantMsg })}\n\n`);
+              if (apiErrPattern.test(fullResponse.trim())) {
+                console.log(`[chat] Stream done for conv=${convId}, detected API error in text — not saving as message`);
+                res.write(`data: ${JSON.stringify({ type: 'error', error: fullResponse.trim() })}\n\n`);
+              } else {
+                console.log(`[chat] Stream done for conv=${convId}, saving final segment len=${fullResponse.trim().length}`);
+                const assistantMsg = await chatService.addMessage(convId, 'assistant', fullResponse.trim(), backend, thinkingText.trim() || null);
+                res.write(`data: ${JSON.stringify({ type: 'assistant_message', message: assistantMsg })}\n\n`);
+              }
             } else if (resultText && resultText.trim()) {
               console.log(`[chat] Stream done for conv=${convId}, saving result len=${resultText.trim().length}`);
               const assistantMsg = await chatService.addMessage(convId, 'assistant', resultText.trim(), backend, thinkingText.trim() || null);

--- a/src/services/backends/claudeCode.js
+++ b/src/services/backends/claudeCode.js
@@ -9,6 +9,32 @@ const CLAUDE_CODE_ICON = '<svg width="28" height="28" viewBox="0 0 512 512" fill
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
+const MAX_SYSTEM_PROMPT_LENGTH = 50000;
+
+/**
+ * Strip control characters (keep newlines, tabs, carriage returns) and
+ * enforce a max length so the CLI argument stays safe and bounded.
+ */
+function sanitizeSystemPrompt(prompt) {
+  if (!prompt || typeof prompt !== 'string') return '';
+  // Remove control chars except \n \r \t
+  let cleaned = prompt.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
+  if (cleaned.length > MAX_SYSTEM_PROMPT_LENGTH) {
+    cleaned = cleaned.substring(0, MAX_SYSTEM_PROMPT_LENGTH);
+  }
+  return cleaned;
+}
+
+const API_ERROR_PATTERN = /^API Error:\s*\d{3}\s/;
+
+/**
+ * Detect whether text content is an API error message from the Claude CLI
+ * (e.g. "API Error: 500 {"type":"error",...}").
+ */
+function isApiError(text) {
+  return API_ERROR_PATTERN.test(text.trim());
+}
+
 function shortenPath(filePath) {
   if (!filePath) return '';
   const parts = filePath.split('/');
@@ -184,8 +210,9 @@ class ClaudeCodeAdapter extends BaseBackendAdapter {
 
     if (isNewSession) {
       args.push('--session-id', sessionId);
-      if (systemPrompt) {
-        args.push('--append-system-prompt', systemPrompt);
+      const cleanPrompt = sanitizeSystemPrompt(systemPrompt);
+      if (cleanPrompt) {
+        args.push('--append-system-prompt', cleanPrompt);
       }
     } else {
       args.push('--resume', sessionId);
@@ -242,7 +269,12 @@ class ClaudeCodeAdapter extends BaseBackendAdapter {
               textQueue.push({ type: 'turn_boundary' });
             } else if (event.type === 'result') {
               if (event.result) {
-                textQueue.push({ type: 'result', content: event.result });
+                const resultStr = typeof event.result === 'string' ? event.result : JSON.stringify(event.result);
+                if (isApiError(resultStr)) {
+                  textQueue.push({ type: 'error', error: resultStr.trim() });
+                } else {
+                  textQueue.push({ type: 'result', content: event.result });
+                }
               }
             }
           } catch {
@@ -329,4 +361,4 @@ class ClaudeCodeAdapter extends BaseBackendAdapter {
   }
 }
 
-module.exports = { ClaudeCodeAdapter, extractToolDetails, shortenPath };
+module.exports = { ClaudeCodeAdapter, extractToolDetails, shortenPath, sanitizeSystemPrompt, isApiError };

--- a/test/backends.test.js
+++ b/test/backends.test.js
@@ -3,7 +3,7 @@ const { BackendRegistry } = require('../src/services/backends/registry');
 const { ClaudeCodeAdapter } = require('../src/services/backends/claudeCode');
 
 // extractToolDetails / shortenPath are not public on the class, so access via exports
-const { extractToolDetails, shortenPath } = require('../src/services/backends/claudeCode');
+const { extractToolDetails, shortenPath, sanitizeSystemPrompt, isApiError } = require('../src/services/backends/claudeCode');
 
 const fs = require('fs');
 const vm = require('vm');
@@ -321,6 +321,65 @@ describe('shortenPath via Read tool', () => {
   });
 });
 
+// ── sanitizeSystemPrompt ──────────────────────────────────────────────────
+
+describe('sanitizeSystemPrompt', () => {
+  test('returns empty string for null/undefined', () => {
+    expect(sanitizeSystemPrompt(null)).toBe('');
+    expect(sanitizeSystemPrompt(undefined)).toBe('');
+    expect(sanitizeSystemPrompt('')).toBe('');
+  });
+
+  test('returns non-string types as empty', () => {
+    expect(sanitizeSystemPrompt(42)).toBe('');
+    expect(sanitizeSystemPrompt({})).toBe('');
+  });
+
+  test('passes through normal text unchanged', () => {
+    expect(sanitizeSystemPrompt('You are a helpful assistant.')).toBe('You are a helpful assistant.');
+  });
+
+  test('preserves newlines, tabs, and carriage returns', () => {
+    expect(sanitizeSystemPrompt('line1\nline2\ttab\r')).toBe('line1\nline2\ttab\r');
+  });
+
+  test('strips control characters', () => {
+    expect(sanitizeSystemPrompt('hello\x00world\x07!')).toBe('helloworld!');
+    expect(sanitizeSystemPrompt('\x01\x02\x03safe\x1F')).toBe('safe');
+  });
+
+  test('truncates at max length', () => {
+    const long = 'a'.repeat(60000);
+    const result = sanitizeSystemPrompt(long);
+    expect(result.length).toBe(50000);
+  });
+});
+
+// ── isApiError ─────────────────────────────────────────────────────────────
+
+describe('isApiError', () => {
+  test('detects API Error: 500 pattern', () => {
+    expect(isApiError('API Error: 500 {"type":"error"}')).toBe(true);
+  });
+
+  test('detects API Error: 429 pattern', () => {
+    expect(isApiError('API Error: 429 rate limited')).toBe(true);
+  });
+
+  test('detects with leading whitespace', () => {
+    expect(isApiError('  API Error: 500 server error')).toBe(true);
+  });
+
+  test('rejects normal text', () => {
+    expect(isApiError('Hello world')).toBe(false);
+    expect(isApiError('The API returned an error')).toBe(false);
+  });
+
+  test('rejects partial match', () => {
+    expect(isApiError('API Error without code')).toBe(false);
+  });
+});
+
 // ── ClaudeCodeAdapter sendMessage ──────────────────────────────────────────
 
 describe('ClaudeCodeAdapter sendMessage', () => {
@@ -381,6 +440,82 @@ describe('ClaudeCodeAdapter sendMessage', () => {
     const idx = capturedArgs.indexOf('--append-system-prompt');
     expect(idx).toBeGreaterThan(-1);
     expect(capturedArgs[idx + 1]).toBe('You are a helpful assistant');
+  });
+
+  test('sanitizes system prompt with control characters', async () => {
+    let capturedArgs;
+    let streamRef;
+    jest.isolateModules(() => {
+      jest.mock('child_process', () => ({
+        spawn: (_cmd, args) => {
+          capturedArgs = args;
+          const { EventEmitter } = require('events');
+          const proc = new EventEmitter();
+          proc.stdout = new EventEmitter();
+          proc.stderr = new EventEmitter();
+          proc.stdin = { write: () => {}, destroyed: false };
+          proc.kill = () => {};
+          setTimeout(() => proc.emit('close', 0, null), 10);
+          return proc;
+        },
+        execFile: () => {},
+      }));
+      const { ClaudeCodeAdapter: IsolatedAdapter } = require('../src/services/backends/claudeCode');
+      const adapter = new IsolatedAdapter({ workingDir: '/tmp' });
+      const { stream } = adapter.sendMessage('hello', {
+        sessionId: 'test-sanitize',
+        isNewSession: true,
+        workingDir: '/tmp',
+        systemPrompt: 'Be helpful\x00\x07 and safe',
+      });
+      streamRef = stream;
+    });
+
+    for await (const event of streamRef) {
+      if (event.type === 'done') break;
+    }
+
+    expect(capturedArgs).toBeDefined();
+    const idx = capturedArgs.indexOf('--append-system-prompt');
+    expect(idx).toBeGreaterThan(-1);
+    expect(capturedArgs[idx + 1]).toBe('Be helpful and safe');
+  });
+
+  test('omits --append-system-prompt when systemPrompt is only control chars', async () => {
+    let capturedArgs;
+    let streamRef;
+    jest.isolateModules(() => {
+      jest.mock('child_process', () => ({
+        spawn: (_cmd, args) => {
+          capturedArgs = args;
+          const { EventEmitter } = require('events');
+          const proc = new EventEmitter();
+          proc.stdout = new EventEmitter();
+          proc.stderr = new EventEmitter();
+          proc.stdin = { write: () => {}, destroyed: false };
+          proc.kill = () => {};
+          setTimeout(() => proc.emit('close', 0, null), 10);
+          return proc;
+        },
+        execFile: () => {},
+      }));
+      const { ClaudeCodeAdapter: IsolatedAdapter } = require('../src/services/backends/claudeCode');
+      const adapter = new IsolatedAdapter({ workingDir: '/tmp' });
+      const { stream } = adapter.sendMessage('hello', {
+        sessionId: 'test-ctrl-only',
+        isNewSession: true,
+        workingDir: '/tmp',
+        systemPrompt: '\x00\x01\x02',
+      });
+      streamRef = stream;
+    });
+
+    for await (const event of streamRef) {
+      if (event.type === 'done') break;
+    }
+
+    expect(capturedArgs).toBeDefined();
+    expect(capturedArgs).not.toContain('--append-system-prompt');
   });
 
   test('omits --append-system-prompt when systemPrompt is empty', async () => {


### PR DESCRIPTION
## Summary
- Refactors the monolithic `CLIBackend` into a pluggable adapter pattern with `BaseBackendAdapter`, `ClaudeCodeAdapter`, and `BackendRegistry`
- Frontend dynamically loads available backends and gates UI features based on adapter capabilities
- Adds system prompt sanitization (strips control characters, enforces max length) before passing to CLI
- Detects API error patterns (500, 429, 529) in stream output and routes them as proper error events with friendly messages and a Retry button, instead of saving raw error JSON as assistant messages

## Test plan
- [x] All 240 tests pass (13 new tests for sanitization and error detection)
- [ ] Verify new session with custom system prompt containing special characters
- [ ] Trigger an API error (e.g. rate limit) and confirm friendly error UI with Retry button appears
- [ ] Confirm backend selector works and capabilities are correctly reported