### PR TITLE
Allow coverage/ and plans/ as untracked during self-update

### DIFF
--- a/src/services/updateService.js
+++ b/src/services/updateService.js
@@ -74,6 +74,8 @@ class UpdateService {
         if (line.startsWith('?? ecosystem.config.js')) return false;
         if (line.startsWith('?? .DS_Store')) return false;
         if (line.startsWith('?? .claude/')) return false;
+        if (line.startsWith('?? coverage/')) return false;
+        if (line.startsWith('?? plans/')) return false;
         return true;
       });
       if (significantChanges.length > 0) {


### PR DESCRIPTION
## Summary
- Adds `coverage/` and `plans/` to the self-update dirty-check ignore list so they don't block the update process
- These are local artifacts (test output and planning docs) that should not prevent updates

## Test plan
- [x] All 21 updateService tests pass
- [x] Trigger self-update with `coverage/` and `plans/` present — should no longer show "Uncommitted local changes" error