### PR TITLE
Fix plan mode: display plan content and persist approval dialog

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1265,13 +1265,15 @@ async function chatSendMessage() {
             }
             // Track pending interactions for restoration on switch-back
             if (event.isPlanMode && event.planAction === 'exit') {
-              st.pendingInteraction = { type: 'planApproval', planContent: st.assistantContent };
+              // Prefer plan file content (from Write tool) over streamed text summary
+              const planContent = event.planContent || st.assistantContent;
+              st.pendingInteraction = { type: 'planApproval', planContent };
             } else if (event.isQuestion) {
               st.pendingInteraction = { type: 'userQuestion', event };
             }
             if (isStillActive) {
               if (event.isPlanMode && event.planAction === 'exit') {
-                chatShowPlanApproval(st.streamingMsgEl, targetConvId, st.assistantContent);
+                chatShowPlanApproval(st.streamingMsgEl, targetConvId, st.pendingInteraction.planContent);
               } else if (event.isQuestion) {
                 chatShowUserQuestion(st.streamingMsgEl, targetConvId, event);
               } else {
@@ -1282,12 +1284,16 @@ async function chatSendMessage() {
             // Reset streaming state before re-render so the restored bubble
             // shows typing dots instead of stale content duplicating the
             // completed message that chatRenderMessages is about to display.
+            // Preserve pending interactions (plan approval, user questions)
+            // so they survive intermediate message saves — chatRenderMessages()
+            // will restore the UI from pendingInteraction.
+            const savedInteraction = st.pendingInteraction;
             st.assistantContent = '';
             st.assistantThinking = '';
             st.activeTools = [];
             st.activeAgents = [];
             st.planModeActive = false;
-            st.pendingInteraction = null;
+            st.pendingInteraction = savedInteraction;
             if (isStillActive && chatActiveConv) {
               chatActiveConv.messages.push(event.message);
               chatRenderMessages();
@@ -1298,10 +1304,15 @@ async function chatSendMessage() {
             st.pendingInteraction = null;
             if (isStillActive) chatAppendError(event.error);
           } else if (event.type === 'done') {
-            if (st.streamingMsgEl && st.streamingMsgEl.isConnected) {
-              st.streamingMsgEl.remove();
+            if (st.pendingInteraction) {
+              // Keep the streaming bubble alive for pending interactions
+              // (plan approval, user questions) so the user can still act on them
+            } else {
+              if (st.streamingMsgEl && st.streamingMsgEl.isConnected) {
+                st.streamingMsgEl.remove();
+              }
+              chatStreamingState.delete(targetConvId);
             }
-            chatStreamingState.delete(targetConvId);
           }
         } catch {}
       }
@@ -1460,7 +1471,13 @@ function chatShowPlanApproval(msgEl, convId, planContent) {
           body: JSON.stringify({ text }),
         });
         const approvalState = chatStreamingState.get(convId);
-        if (approvalState) approvalState.pendingInteraction = null;
+        if (approvalState) {
+          approvalState.pendingInteraction = null;
+          // If the stream already ended, clean up the streaming state now
+          if (!approvalState.streamingMsgEl || !approvalState.streamingMsgEl.isConnected) {
+            chatStreamingState.delete(convId);
+          }
+        }
         contentEl.innerHTML = `${planHtml ? `<div class="chat-plan-approval-content">${planHtml}</div>` : ''}<div style="font-size:12px;color:var(--muted);font-style:italic;">Plan ${action === 'approve' ? 'approved' : 'rejected'}.</div>`;
         chatHighlightCode(contentEl);
       } catch (err) {

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -379,6 +379,7 @@ function createChatRouter({ chatService, backendRegistry, updateService }) {
     let thinkingText = '';
     let resultText = null;
     let hasStreamingDeltas = false;
+    let pendingPlanContent = '';  // Plan file content from Write tool (Claude Code specific)
 
     (async () => {
       try {
@@ -408,7 +409,15 @@ function createChatRouter({ chatService, backendRegistry, updateService }) {
             thinkingText = '';
             hasStreamingDeltas = false;
           } else if (event.type === 'tool_activity') {
-            const { type: _t, ...rest } = event;
+            // Track plan file content written by Claude Code's Write tool
+            if (event.isPlanFile && event.planContent) {
+              pendingPlanContent = event.planContent;
+            }
+            const { type: _t, planContent: _pc, ...rest } = event;
+            // Attach accumulated plan content when ExitPlanMode fires
+            if (rest.isPlanMode && rest.planAction === 'exit' && pendingPlanContent) {
+              rest.planContent = pendingPlanContent;
+            }
             res.write(`data: ${JSON.stringify({ type: 'tool_activity', ...rest })}\n\n`);
           } else if (event.type === 'result') {
             resultText = event.content;

--- a/src/services/backends/claudeCode.js
+++ b/src/services/backends/claudeCode.js
@@ -58,6 +58,9 @@ function extractToolDetails(block) {
         ? `Writing \`${shortenPath(input.file_path)}\``
         : 'Writing file';
       detail.isPlanFile = !!(input.file_path && input.file_path.includes('.claude/plans/'));
+      if (detail.isPlanFile && input.content) {
+        detail.planContent = input.content;
+      }
       break;
     case 'Edit':
       detail.description = input.file_path


### PR DESCRIPTION
## Summary
- **Plan content now displayed**: The approval UI was showing the assistant's streamed text summary instead of the actual plan file content. Now the Write tool event captures plan file content from `.claude/plans/` and forwards it through the SSE stream to the ExitPlanMode event.
- **Approval dialog persists**: The Approve/Reject dialog was vanishing seconds after appearing because `turn_boundary` → `assistant_message` events cleared `pendingInteraction` and removed the streaming DOM element. Pending interactions are now preserved across intermediate message saves, and the streaming bubble stays alive when the stream ends with a pending interaction.
- **Cleanup on action**: When the user clicks Approve/Reject after the stream has already ended, the orphaned streaming state is properly cleaned up.

## Test plan
- [ ] Start a chat with Claude Code backend and ask it to plan something
- [ ] Verify the plan file content (not just a summary) appears in the approval card
- [ ] Verify the Approve/Reject buttons persist and don't disappear
- [ ] Click Approve — verify it sends the response and shows confirmation
- [ ] Switch conversations while plan approval is pending, switch back — verify it's restored
- [ ] Verify normal (non-plan) conversations still work correctly