### PR TITLE
feat: display uploaded images inline in chat with lightbox

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -528,6 +528,17 @@ DELETE /api/chat/conversations/:id/upload/:filename  [CSRF]
 - Path traversal guard: verifies resolved path stays under `artifactsDir`
 - Returns `{ ok: true }`. `404` if file not found. `400` if path invalid.
 
+**Serve uploaded file:**
+```
+GET /api/chat/conversations/:id/files/:filename
+```
+
+- Sanitizes filename identically to upload: `/` and `\` replaced by `_`
+- Path traversal guard: verifies resolved path stays under `artifactsDir`
+- Serves the file via `res.sendFile()` with proper MIME type
+- `404` if file not found. `400` if path invalid.
+- No CSRF required (GET request, used by `<img>` tags)
+
 ### 9.7 Settings
 
 **Get settings:**
@@ -1057,6 +1068,23 @@ Files upload **immediately on attach**, not when the message is sent. Each file 
 }
 ```
 
+#### Inline Image Display
+
+When rendering messages, `chatRenderUploadedFiles(html)` runs as a post-processing step after markdown parsing. It detects `[Uploaded files: ...]` patterns in the rendered HTML and replaces image file references with inline `<img>` tags.
+
+- **Supported extensions**: `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`, `.bmp`
+- **URL construction**: extracts conversation ID from the artifact path (`artifacts/{convId}/{filename}`) and builds a URL via `chatApiUrl('conversations/{convId}/files/{filename}')` pointing to the file serving endpoint
+- **Non-image files**: remain as text `[Uploaded files: filename]`
+- **Regex**: matches both `<p>[Uploaded files: ...]</p>` (standalone paragraph) and bare `[Uploaded files: ...]` (inline)
+- **Styling**: `.chat-inline-image` — `max-width: 300px`, `max-height: 300px`, `border-radius: 8px`, `cursor: pointer`
+
+**Lightbox (click-to-enlarge):**
+
+- Clicking an inline image calls `chatOpenLightbox(src)` which shows a full-screen overlay (`#chat-lightbox`)
+- Overlay: fixed position, dark backdrop (`rgba(0,0,0,0.85)`), `z-index: 9999`
+- Full-size image: `max-width: 90vw`, `max-height: 90vh`, `object-fit: contain`
+- Close: click backdrop or press Escape (via `chatLightboxEscHandler`)
+
 #### Session Management
 
 - `chatResetSession()` — adds convId to `chatResettingConvs` (disables send button and reset button), shows "Archiving session..." progress indicator with typing-dots animation in the messages area, POSTs reset endpoint, updates conversation on success, cleans up state in `finally` block. Prevents double-clicks via `chatResettingConvs` guard. On conversation switch, reset button state is synced to reflect in-progress resets.
@@ -1150,6 +1178,8 @@ Theme is applied by setting `data-theme` attribute on `<html>`:
 - **Plan mode banner** (`.chat-plan-mode-banner`): green accent indicator showing "Plan mode active"
 - **Plan approval** (`.chat-plan-approval`): card with approve/reject buttons for interactive plan approval. Plan content rendered above the card in a scrollable container (`.chat-plan-approval-content`, max-height 400px)
 - **Folder picker toolbar** (`.folder-browser-toolbar`): flex row with hidden files toggle and "+ New Folder" button. Path row (`.folder-browser-path-row`) includes parent navigation and delete icon buttons (`.folder-browser-icon-btn`). Delete button shows red hover state. Inline folder name input (`.folder-browser-new-input`). Delete confirmation dialog (`.folder-browser-confirm-delete`) replaces the folder list with a warning message and red Delete / Cancel buttons
+- **Inline images** (`.chat-inline-image`): uploaded images rendered inline in messages at max 300×300px, click to open lightbox
+- **Lightbox** (`.chat-lightbox`): full-screen overlay for viewing images at full size (90vw×90vh max), click backdrop or Escape to close
 - **User question** (`.chat-user-question`): question text with clickable option buttons and text input fallback
 - **Streaming indicator dot** (`.chat-conv-streaming-dot`): 8×8 pulsing dot next to streaming conversations in sidebar, uses `streaming-pulse` keyframe animation (1.5s ease-in-out infinite)
 
@@ -1308,6 +1338,7 @@ The `isNewSession` flag is determined by checking if the current session's `mess
 - **SSE tool_activity forwarding**: enriched fields (tool, description, id), `isAgent` flag with `subagentType`, `isPlanMode`/`planAction`, `isQuestion` with `questions` array
 - **Turn boundary intermediate messages**: saves intermediate message on turn_boundary, saves thinking with intermediate message, skips empty boundaries, skips non-streaming text, saves result text as final message when no streaming deltas
 - **DELETE /upload/:filename**: deletes uploaded file, returns 404 for non-existent, sanitizes slashes in filename matching upload behavior
+- **GET /files/:filename**: serves uploaded file, returns 404 for non-existent, sanitizes slashes in filename
 - **POST /abort**: returns `ok:false` when no active stream
 - **GET /version**: returns version from package.json
 

--- a/public/app.js
+++ b/public/app.js
@@ -1029,6 +1029,40 @@ function chatRenderThinkingBlock(thinking, expanded) {
   </details>`;
 }
 
+const IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|webp|svg|bmp)$/i;
+
+function chatRenderUploadedFiles(html) {
+  // Replace [Uploaded files: path1, path2] with inline images for image files.
+  // This runs on the final HTML, so the pattern may be inside <p> tags.
+  return html.replace(/<p>\s*\[Uploaded files?:\s*([^\]]+)\]\s*<\/p>|(\[Uploaded files?:\s*([^\]]+)\])/g, (match, pInner, bare, bareInner) => {
+    const pathList = pInner || bareInner;
+    if (!pathList) return match;
+    const paths = pathList.split(',').map(p => p.trim());
+    const parts = [];
+    const nonImages = [];
+    for (const fullPath of paths) {
+      const filename = fullPath.split('/').pop();
+      if (IMAGE_EXTENSIONS.test(filename)) {
+        const segments = fullPath.replace(/\\/g, '/').split('/');
+        const artifactsIdx = segments.lastIndexOf('artifacts');
+        const convId = artifactsIdx >= 0 ? segments[artifactsIdx + 1] : chatActiveConvId;
+        const url = chatApiUrl(`conversations/${encodeURIComponent(convId)}/files/${encodeURIComponent(filename)}`);
+        parts.push(`<div class="chat-inline-image-wrap"><img class="chat-inline-image" src="${url}" alt="${esc(filename)}" title="${esc(filename)}" onclick="chatOpenLightbox(this.src)"></div>`);
+      } else {
+        nonImages.push(filename);
+      }
+    }
+    let result = '';
+    if (nonImages.length) {
+      result += `<p>[Uploaded files: ${nonImages.join(', ')}]</p>`;
+    }
+    if (parts.length) {
+      result += parts.join('');
+    }
+    return result;
+  });
+}
+
 function chatRenderMarkdown(text) {
   if (!text) return '';
   if (typeof marked !== 'undefined') {
@@ -1055,9 +1089,29 @@ function chatRenderMarkdown(text) {
         ${collapsible ? '<div class="chat-code-expand" onclick="chatToggleCodeBlock(this)">Show more</div>' : ''}
       </div>`;
     };
-    return marked.parse(text, { renderer, breaks: true });
+    let html = marked.parse(text, { renderer, breaks: true });
+    return chatRenderUploadedFiles(html);
   }
-  return esc(text).replace(/\n/g, '<br>');
+  let html = esc(text).replace(/\n/g, '<br>');
+  return chatRenderUploadedFiles(html);
+}
+
+function chatOpenLightbox(src) {
+  const overlay = document.getElementById('chat-lightbox');
+  const img = document.getElementById('chat-lightbox-img');
+  img.src = src;
+  overlay.classList.add('active');
+  document.addEventListener('keydown', chatLightboxEscHandler);
+}
+
+function chatCloseLightbox() {
+  const overlay = document.getElementById('chat-lightbox');
+  overlay.classList.remove('active');
+  document.removeEventListener('keydown', chatLightboxEscHandler);
+}
+
+function chatLightboxEscHandler(e) {
+  if (e.key === 'Escape') chatCloseLightbox();
 }
 
 function chatHighlightCode(container) {

--- a/public/index.html
+++ b/public/index.html
@@ -76,6 +76,11 @@
   </div>
 </div>
 
+<!-- Lightbox overlay for full-size images -->
+<div class="chat-lightbox" id="chat-lightbox" onclick="chatCloseLightbox()">
+  <img class="chat-lightbox-img" id="chat-lightbox-img" src="" alt="" onclick="event.stopPropagation()">
+</div>
+
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/12.0.2/marked.min.js"></script>
 <script src="app.js"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -565,6 +565,43 @@
   .chat-msg-content th { padding: 6px 10px; background: var(--surface2); border: 1px solid var(--border); font-weight: 600; text-align: left; }
   .chat-msg-content td { padding: 6px 10px; border: 1px solid var(--border); }
 
+  /* Inline images */
+  .chat-inline-image-wrap {
+    display: inline-block;
+    margin: 6px 4px 6px 0;
+  }
+  .chat-inline-image {
+    max-width: 300px;
+    max-height: 300px;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    cursor: pointer;
+    transition: opacity 0.15s;
+    display: block;
+  }
+  .chat-inline-image:hover { opacity: 0.85; }
+
+  /* Lightbox overlay */
+  .chat-lightbox {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    background: rgba(0, 0, 0, 0.85);
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+  }
+  .chat-lightbox.active { display: flex; }
+  .chat-lightbox-img {
+    max-width: 90vw;
+    max-height: 90vh;
+    border-radius: 8px;
+    object-fit: contain;
+    cursor: default;
+    box-shadow: 0 4px 40px rgba(0, 0, 0, 0.5);
+  }
+
   /* Code blocks */
   .chat-code-block {
     margin: 10px 0;

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -511,6 +511,21 @@ function createChatRouter({ chatService, backendRegistry, updateService }) {
     res.json({ files });
   });
 
+  // Serve uploaded files (images, etc.)
+  router.get('/conversations/:id/files/:filename', async (req, res) => {
+    const safe = req.params.filename.replace(/[\/\\]/g, '_');
+    const filePath = path.join(chatService.artifactsDir, req.params.id, safe);
+    if (!path.resolve(filePath).startsWith(path.resolve(chatService.artifactsDir))) {
+      return res.status(400).json({ error: 'Invalid path' });
+    }
+    try {
+      await fs.promises.access(filePath);
+      res.sendFile(path.resolve(filePath));
+    } catch {
+      res.status(404).json({ error: 'File not found' });
+    }
+  });
+
   router.delete('/conversations/:id/upload/:filename', csrfGuard, async (req, res) => {
     const safe = req.params.filename.replace(/[\/\\]/g, '_');
     const filePath = path.join(chatService.artifactsDir, req.params.id, safe);

--- a/test/chat.test.js
+++ b/test/chat.test.js
@@ -602,6 +602,36 @@ describe('DELETE /conversations/:id/upload/:filename', () => {
   });
 });
 
+// ── GET /conversations/:id/files/:filename ──────────────────────────────────
+
+describe('GET /conversations/:id/files/:filename', () => {
+  test('serves an uploaded file', async () => {
+    const conv = await chatService.createConversation('Test');
+    const artifactDir = path.join(tmpDir, 'data', 'chat', 'artifacts', conv.id);
+    fs.mkdirSync(artifactDir, { recursive: true });
+    fs.writeFileSync(path.join(artifactDir, 'photo.png'), 'fakeimage');
+
+    const res = await makeRequest('GET', `/api/chat/conversations/${conv.id}/files/photo.png`);
+    expect(res.status).toBe(200);
+  });
+
+  test('returns 404 for non-existent file', async () => {
+    const conv = await chatService.createConversation('Test');
+    const res = await makeRequest('GET', `/api/chat/conversations/${conv.id}/files/nope.png`);
+    expect(res.status).toBe(404);
+  });
+
+  test('sanitizes slashes in filename', async () => {
+    const conv = await chatService.createConversation('Test');
+    const artifactDir = path.join(tmpDir, 'data', 'chat', 'artifacts', conv.id);
+    fs.mkdirSync(artifactDir, { recursive: true });
+    fs.writeFileSync(path.join(artifactDir, 'a_b.png'), 'data');
+
+    const res = await makeRequest('GET', `/api/chat/conversations/${conv.id}/files/a%2Fb.png`);
+    expect(res.status).toBe(200);
+  });
+});
+
 // ── POST /conversations/:id/abort ───────────────────────────────────────────
 
 describe('POST /conversations/:id/abort', () => {


### PR DESCRIPTION
## Summary
- Uploaded images now render inline in chat messages (max 300x300px) instead of showing as plain file paths
- Clicking an image opens a full-screen lightbox overlay (close via backdrop click or Escape)
- Adds `GET /conversations/:id/files/:filename` endpoint to serve uploaded files from the artifacts directory
- Non-image files continue to display as text references

## Test plan
- [x] Upload an image in a chat message and confirm it renders inline
- [x] Click the image and confirm it opens full-screen in the lightbox
- [x] Press Escape or click the backdrop to close the lightbox
- [x] Upload a non-image file and confirm it still shows as text
- [x] Reload the page and confirm images render in conversation history
- [x] All 243 tests pass including 3 new tests for the file serving route