### PR TITLE
feat: add timestamps to messages and elapsed timer for CLI processes

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -996,7 +996,9 @@ _ensureConvPromise          // Promise cache for concurrent chatEnsureConversati
   activeAgents: Array,           // Current agent cards
   planModeActive: boolean,       // Plan mode banner visible
   pendingInteraction: object|null, // { type: 'planApproval', planContent: string } or { type: 'userQuestion', event }
-  streamingMsgEl: HTMLElement|null // Reference to current streaming bubble DOM element
+  streamingMsgEl: HTMLElement|null, // Reference to current streaming bubble DOM element
+  streamStartTime: number,       // Date.now() when streaming began (for elapsed timer)
+  elapsedTimerInterval: number|null // setInterval ID for live elapsed timer updates
 }
 ```
 
@@ -1031,15 +1033,16 @@ _ensureConvPromise          // Promise cache for concurrent chatEnsureConversati
 
 - `chatSendMessage()` — Gathers completed file paths from `chatPendingFiles` (no upload at send time — files are already on the server), appends `[Uploaded files: ...]` to message content, then POSTs message. Creates conversation if none exists (text-only messages without prior file attach). Initializes `chatStreamingState` entry for the conversation, opens EventSource to `/stream`. The SSE loop writes all state to the Map entry rather than closure-local variables, enabling state persistence across conversation switches. After `chatRenderMessages()` renders the user message, the streaming bubble is only created if one wasn't already created by the render's streaming state restoration (guarded by `!state.streamingMsgEl` check to prevent duplicate bubbles).
 - `chatStopStreaming()` — POSTs abort endpoint
-- `chatAppendStreamingMessage()` — inserts empty assistant message bubble with pulsing cursor
+- `chatAppendStreamingMessage()` — inserts empty assistant message bubble with pulsing cursor and an elapsed timer element in the role header
 - `chatUpdateStreamingMessage(msgEl, content, thinking)` — renders Markdown incrementally into the streaming bubble. Optionally shows thinking block in a collapsible `<details>` element.
 - `chatUpdateStreamingActivity(msgEl, tools, agents, planMode)` — renders rich tool activity display: activity history (completed tools with checkmarks), current tool with description, agent cards with spinners and type labels, plan mode banner.
+- `chatStartElapsedTimer(convId)` — starts a 1-second interval that updates the `.chat-elapsed-timer` element in the streaming bubble with the elapsed time since `streamStartTime`. Self-cleans if the DOM element is disconnected. Called when streaming begins and on conversation switch restore.
 - `chatShowPlanApproval(msgEl, convId, planContent)` — renders the accumulated plan content as markdown above approve/reject buttons. On click, POSTs to `/conversations/:id/input` with `"yes"` or `"no"`, clears `pendingInteraction` state. Plan content is preserved after approval/rejection and survives conversation switching via `pendingInteraction.planContent`.
 - `chatShowUserQuestion(msgEl, convId, event)` — renders question text, clickable option buttons, and text input. On selection, POSTs answer to `/conversations/:id/input`, clears `pendingInteraction` state.
 - `chatUpdateSendButtonState()` — updates send button to show stop (■) when the current conversation is streaming, or send (↑) when idle. Disables send when any upload is in progress (`status === 'uploading'`), or when the conversation is resetting (`chatResettingConvs`). Enables when text or completed files exist. Called on conversation switch, stream completion, upload progress, file add/remove, and session reset start/end.
 - `chatRetryLast()` — sends the last user message again (for regeneration)
 - Streaming uses `fetch` with manual ReadableStream parsing (not EventSource API) — reads SSE lines from the response body, parses `data:` lines as JSON
-- **Streaming state restoration:** When `chatRenderMessages()` is called and `chatStreamingState` has an entry for the active conversation, it re-creates the streaming bubble and restores the UI: pending interactions (plan approval/user question), accumulated text/thinking, or active tool/agent display. Uses `streamingMsgEl.isConnected` to detect orphaned DOM nodes destroyed by `innerHTML` replacement. On `assistant_message` events, streaming state (content, thinking, tools, agents) is reset **before** calling `chatRenderMessages()` so the restored bubble shows typing dots rather than stale content duplicating the completed message.
+- **Streaming state restoration:** When `chatRenderMessages()` is called and `chatStreamingState` has an entry for the active conversation, it re-creates the streaming bubble, restores the UI (pending interactions, accumulated text/thinking, or active tool/agent display), and restarts the elapsed timer via `chatStartElapsedTimer()`. Uses `streamingMsgEl.isConnected` to detect orphaned DOM nodes destroyed by `innerHTML` replacement. On `assistant_message` events, streaming state (content, thinking, tools, agents) is reset **before** calling `chatRenderMessages()` so the restored bubble shows typing dots rather than stale content duplicating the completed message.
 
 #### File Handling
 
@@ -1109,7 +1112,9 @@ When rendering messages, `chatRenderUploadedFiles(html)` runs as a post-processi
 
 - `chatToggleSidebar()` — adds/removes `.collapsed` CSS class
 - `chatAutoResize(textarea)` — sets height to scrollHeight, max ~200px
-- `chatRenderMessages()` — renders all messages in the active conversation
+- `chatRenderMessages()` — renders all messages in the active conversation. Each message displays a timestamp (formatted by `chatFormatTimestamp`) in the role header. Assistant messages also show elapsed time since the preceding user message (e.g., "(45s)").
+- `chatFormatTimestamp(isoString)` — formats ISO 8601 timestamp for display: time-only for today ("3:42 PM"), "Yesterday 3:42 PM", or "Mar 15 3:42 PM" for older messages
+- `chatFormatElapsed(ms)` — formats milliseconds as human-readable duration ("45s" or "2m 03s")
 - `chatRenderMarkdown(text)` — uses `marked.parse()` for Markdown rendering
 - `chatHighlightCode(container)` — applies highlight.js to `<code>` blocks, adds copy buttons and expandable wrappers for long code blocks
 - `chatShowFolderPicker(initialPath)` — modal with directory browser (calls `GET /api/chat/browse`), supports navigation, hidden file toggle, new folder creation (calls `POST /api/chat/mkdir`), parent folder navigation button, and delete current folder button with confirmation (calls `POST /api/chat/rmdir`)

--- a/public/app.js
+++ b/public/app.js
@@ -11,6 +11,30 @@ function escWithCode(str) {
   return esc(str).replace(/`([^`]+)`/g, '<code>$1</code>');
 }
 
+// ─── Timestamp / elapsed formatting ─────────────────────────────────────────
+function chatFormatTimestamp(isoString) {
+  if (!isoString) return '';
+  const date = new Date(isoString);
+  if (isNaN(date.getTime())) return '';
+  const now = new Date();
+  const isToday = date.toDateString() === now.toDateString();
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const isYesterday = date.toDateString() === yesterday.toDateString();
+  const timeStr = date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  if (isToday) return timeStr;
+  if (isYesterday) return `Yesterday ${timeStr}`;
+  return date.toLocaleDateString([], { month: 'short', day: 'numeric' }) + ' ' + timeStr;
+}
+
+function chatFormatElapsed(ms) {
+  const totalSec = Math.floor(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (min === 0) return `${sec}s`;
+  return `${min}m ${sec < 10 ? '0' : ''}${sec}s`;
+}
+
 // ─── Theme ───────────────────────────────────────────────────────────────────
 function applyTheme(theme) {
   let resolved = theme;
@@ -966,7 +990,8 @@ function chatRenderMessages() {
   const currentSessionMsgs = chatActiveConv.messages;
 
   let html = '';
-  for (const msg of currentSessionMsgs) {
+  for (let mi = 0; mi < currentSessionMsgs.length; mi++) {
+    const msg = currentSessionMsgs[mi];
 
     const isUser = msg.role === 'user';
     const backendIcon = !isUser && msg.backend ? getBackendIcon(msg.backend) : null;
@@ -978,12 +1003,28 @@ function chatRenderMessages() {
     const caps = msg.backend ? getBackendCapabilities(msg.backend) : {};
     const thinkingHtml = msg.thinking && caps.thinking !== false ? chatRenderThinkingBlock(msg.thinking, false) : '';
 
+    // Elapsed time for assistant messages (time since preceding user message)
+    let elapsedLabel = '';
+    if (!isUser && msg.timestamp) {
+      for (let j = mi - 1; j >= 0; j--) {
+        if (currentSessionMsgs[j].role === 'user' && currentSessionMsgs[j].timestamp) {
+          const delta = new Date(msg.timestamp) - new Date(currentSessionMsgs[j].timestamp);
+          if (delta > 0 && delta < 3600000) {
+            elapsedLabel = `<span class="chat-msg-elapsed">${chatFormatElapsed(delta)}</span>`;
+          }
+          break;
+        }
+      }
+    }
+
+    const timeLabel = msg.timestamp ? `<span class="chat-msg-time">${chatFormatTimestamp(msg.timestamp)}${elapsedLabel}</span>` : '';
+
     html += `
       <div class="chat-msg ${esc(msg.role)}" data-msg-id="${esc(msg.id)}">
         <div class="chat-msg-wrapper">
           <div class="chat-msg-avatar${avatarClass}">${avatar}</div>
           <div class="chat-msg-body">
-            <div class="chat-msg-role">${roleLabel} ${backendLabel}</div>
+            <div class="chat-msg-role">${roleLabel} ${backendLabel}${timeLabel}</div>
             <div class="chat-msg-content">${thinkingHtml}${rendered}</div>
             <div class="chat-msg-actions">
               <button class="chat-msg-action" data-action="copy-msg" title="Copy">Copy</button>
@@ -1003,6 +1044,7 @@ function chatRenderMessages() {
   if (streamState) {
     const msgEl = chatAppendStreamingMessage();
     streamState.streamingMsgEl = msgEl;
+    chatStartElapsedTimer(chatActiveConvId);
 
     if (streamState.pendingInteraction) {
       if (streamState.pendingInteraction.type === 'planApproval') {
@@ -1220,6 +1262,8 @@ async function chatSendMessage() {
     planModeActive: false,
     pendingInteraction: null,
     streamingMsgEl: null,
+    streamStartTime: Date.now(),
+    elapsedTimerInterval: null,
   });
   chatRenderConvList();
   chatUpdateSendButtonState();
@@ -1252,6 +1296,7 @@ async function chatSendMessage() {
 
     if (chatActiveConvId === targetConvId && !state.streamingMsgEl) {
       state.streamingMsgEl = chatAppendStreamingMessage();
+      chatStartElapsedTimer(targetConvId);
     }
 
     const sseResponse = await fetch(chatApiUrl(`conversations/${targetConvId}/stream`), {
@@ -1358,6 +1403,7 @@ async function chatSendMessage() {
             st.pendingInteraction = null;
             if (isStillActive) chatAppendError(event.error);
           } else if (event.type === 'done') {
+            if (st.elapsedTimerInterval) clearInterval(st.elapsedTimerInterval);
             if (st.pendingInteraction) {
               // Keep the streaming bubble alive for pending interactions
               // (plan approval, user questions) so the user can still act on them
@@ -1378,8 +1424,11 @@ async function chatSendMessage() {
   } finally {
     chatStreamingConvs.delete(targetConvId);
     const finalState = chatStreamingState.get(targetConvId);
-    if (finalState && finalState.streamingMsgEl && finalState.streamingMsgEl.isConnected) {
-      finalState.streamingMsgEl.remove();
+    if (finalState) {
+      if (finalState.elapsedTimerInterval) clearInterval(finalState.elapsedTimerInterval);
+      if (finalState.streamingMsgEl && finalState.streamingMsgEl.isConnected) {
+        finalState.streamingMsgEl.remove();
+      }
     }
     chatStreamingState.delete(targetConvId);
     chatUpdateSendButtonState();
@@ -1399,7 +1448,7 @@ function chatAppendStreamingMessage() {
     <div class="chat-msg-wrapper">
       <div class="chat-msg-avatar${icon ? ' chat-msg-avatar-svg' : ''}">${icon || DEFAULT_BACKEND_ICON}</div>
       <div class="chat-msg-body">
-        <div class="chat-msg-role">Assistant</div>
+        <div class="chat-msg-role">Assistant<span class="chat-elapsed-timer"></span></div>
         <div class="chat-msg-content">
           <div class="chat-typing">
             <div class="chat-typing-dot"></div>
@@ -1497,6 +1546,23 @@ function chatUpdateStreamingActivity(msgEl, tools, agents, planMode) {
   chatScrollToBottom();
 }
 
+function chatStartElapsedTimer(convId) {
+  const state = chatStreamingState.get(convId);
+  if (!state || state.elapsedTimerInterval) return;
+  // Show initial value immediately
+  const timerEl = state.streamingMsgEl?.querySelector('.chat-elapsed-timer');
+  if (timerEl) timerEl.textContent = chatFormatElapsed(Date.now() - state.streamStartTime);
+  state.elapsedTimerInterval = setInterval(() => {
+    const st = chatStreamingState.get(convId);
+    if (!st || !st.streamingMsgEl || !st.streamingMsgEl.isConnected) {
+      clearInterval(state.elapsedTimerInterval);
+      return;
+    }
+    const el = st.streamingMsgEl.querySelector('.chat-elapsed-timer');
+    if (el) el.textContent = chatFormatElapsed(Date.now() - st.streamStartTime);
+  }, 1000);
+}
+
 function chatShowPlanApproval(msgEl, convId, planContent) {
   if (!msgEl) return;
   const contentEl = msgEl.querySelector('.chat-msg-content');
@@ -1526,6 +1592,7 @@ function chatShowPlanApproval(msgEl, convId, planContent) {
         });
         const approvalState = chatStreamingState.get(convId);
         if (approvalState) {
+          if (approvalState.elapsedTimerInterval) clearInterval(approvalState.elapsedTimerInterval);
           approvalState.pendingInteraction = null;
           // If the stream already ended, clean up the streaming state now
           if (!approvalState.streamingMsgEl || !approvalState.streamingMsgEl.isConnected) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -527,6 +527,35 @@
     opacity: 0.7;
   }
 
+  .chat-msg-time {
+    margin-left: auto;
+    font-size: 10px;
+    font-weight: 400;
+    color: var(--muted);
+    opacity: 0.6;
+    white-space: nowrap;
+  }
+
+  .chat-msg-elapsed {
+    margin-left: 6px;
+    font-size: 10px;
+    font-weight: 400;
+    color: var(--muted);
+    opacity: 0.5;
+  }
+  .chat-msg-elapsed::before { content: '('; }
+  .chat-msg-elapsed::after { content: ')'; }
+
+  .chat-elapsed-timer {
+    margin-left: auto;
+    font-size: 10px;
+    font-weight: 400;
+    color: var(--muted);
+    opacity: 0.7;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
   .chat-msg-content {
     font-size: 14px;
     line-height: 1.65;


### PR DESCRIPTION
## Summary
- Display a formatted timestamp on every chat message (compact time for today, date+time for older messages)
- Show a live elapsed timer in the streaming bubble that ticks every second during CLI processing
- Show total elapsed duration on completed assistant messages (time since the user's message)

Closes #38

## Test plan
- [ ] Send a message and verify timestamps appear on both user and assistant messages
- [ ] During CLI processing, confirm the elapsed timer ticks up every second in the streaming bubble
- [ ] After completion, verify the assistant message shows timestamp + elapsed duration (e.g., "(45s)")
- [ ] Switch conversations mid-stream and back — timer should persist
- [ ] Verify appearance in both light and dark themes
- [ ] Check older messages show date + time format