### PR TITLE
fix: add card background to restart server overlay

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2192,7 +2192,7 @@ function chatShowRestartOverlay() {
   const overlay = document.createElement('div');
   overlay.id = 'chat-restart-overlay';
   overlay.innerHTML =
-    '<div style="text-align:center;">'
+    '<div class="restart-dialog">'
     + '<div style="font-size:18px;font-weight:600;margin-bottom:8px;">Restarting Server...</div>'
     + '<div style="font-size:13px;color:var(--muted);">The page will reload automatically.</div>'
     + '</div>';

--- a/public/styles.css
+++ b/public/styles.css
@@ -333,6 +333,15 @@
     color: var(--text);
   }
 
+  #chat-restart-overlay .restart-dialog {
+    background: var(--surface, #1e1e2e);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 32px 40px;
+    text-align: center;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  }
+
   /* ── Chat Main Panel ──────────────────────────────────────── */
   .chat-main {
     flex: 1;


### PR DESCRIPTION
## Summary
- The restart server overlay had a transparent background making the text invisible
- Added a `.restart-dialog` card with solid background (`--surface`), border, rounded corners, and drop shadow
- Keeps the full-screen transparent backdrop while giving the text a proper window-style container

## Test plan
- [ ] Trigger a server update/restart and verify the overlay text is visible
- [ ] Confirm the dialog card is centered with solid background on the transparent overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)