### PR TITLE
Group sidebar conversations by workspace

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -945,7 +945,7 @@ Single-page layout:
     - `.chat-sidebar` — left panel:
       - `.chat-sidebar-header` — collapse toggle + "New Chat" button
       - `.chat-search` — search input
-      - `.chat-conv-list` — conversation list (populated by JS)
+      - `.chat-conv-list` — conversation list grouped by workspace (populated by JS); each group has a collapsible header (`.chat-conv-group-header`) with chevron toggle, workspace label, and count badge when collapsed
       - `.chat-sidebar-footer` — Settings button
       - `.chat-sidebar-footer` — Sign Out button
       - `.chat-sidebar-version` — App version label + update indicator (fetched from `/api/chat/version`)
@@ -1027,7 +1027,9 @@ _ensureConvPromise          // Promise cache for concurrent chatEnsureConversati
 - `chatRenameConversation(id)` — prompts for new name, PUTs update
 - `chatDeleteConversation(id)` — confirms, DELETEs, clears selection if active. When the active conversation is deleted: aborts in-flight uploads, clears pending file chips, resets send button state, and renders the empty state.
 - `chatLoadConversations(query)` — fetches list, renders sidebar
-- `chatGroupConversations(convs)` — groups by relative date: "Today", "Yesterday", "Previous 7 Days", "Previous 30 Days", "Older"
+- `chatGroupConversations(convs)` — groups conversations by workspace (last 2 path segments of `workingDir`), returning `{ label: { fullPath, convs[] } }`
+- `chatGetCollapsedGroups()` — reads collapsed workspace group state from localStorage
+- `chatSetGroupCollapsed(label, collapsed)` — persists collapse toggle for a workspace group to localStorage
 
 #### Messaging
 

--- a/public/app.js
+++ b/public/app.js
@@ -552,24 +552,27 @@ async function chatLoadConversations(query) {
 
 function chatGroupConversations(convs) {
   const groups = {};
-  const now = new Date();
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const yesterday = new Date(today); yesterday.setDate(yesterday.getDate() - 1);
-  const week = new Date(today); week.setDate(week.getDate() - 7);
-  const month = new Date(today); month.setDate(month.getDate() - 30);
-
   for (const c of convs) {
-    const d = new Date(c.updatedAt);
-    let label;
-    if (d >= today) label = 'Today';
-    else if (d >= yesterday) label = 'Yesterday';
-    else if (d >= week) label = 'Previous 7 Days';
-    else if (d >= month) label = 'Previous 30 Days';
-    else label = d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
-    if (!groups[label]) groups[label] = [];
-    groups[label].push(c);
+    const label = c.workingDir
+      ? c.workingDir.split('/').filter(Boolean).slice(-2).join('/')
+      : 'workspace';
+    if (!groups[label]) groups[label] = { fullPath: c.workingDir || '', convs: [] };
+    groups[label].convs.push(c);
   }
   return groups;
+}
+
+function chatGetCollapsedGroups() {
+  try {
+    return JSON.parse(localStorage.getItem('chatCollapsedGroups') || '{}');
+  } catch { return {}; }
+}
+
+function chatSetGroupCollapsed(label, collapsed) {
+  const state = chatGetCollapsedGroups();
+  if (collapsed) state[label] = true;
+  else delete state[label];
+  localStorage.setItem('chatCollapsedGroups', JSON.stringify(state));
 }
 
 function chatRenderConvList() {
@@ -582,26 +585,44 @@ function chatRenderConvList() {
   }
 
   const groups = chatGroupConversations(chatConversations);
+  const collapsed = chatGetCollapsedGroups();
   let html = '';
-  for (const [label, convs] of Object.entries(groups)) {
-    html += `<div class="chat-conv-group-label">${esc(label)}</div>`;
-    for (const c of convs) {
-      const isActive = c.id === chatActiveConvId;
-      const isStreaming = chatStreamingConvs.has(c.id);
-      const folderLabel = c.workingDir ? c.workingDir.split('/').filter(Boolean).slice(-2).join('/') : 'workspace';
-      html += `
-        <div class="chat-conv-item${isActive ? ' active' : ''}" data-conv-id="${esc(c.id)}">
-          <div style="flex:1;min-width:0;">
-            <span class="chat-conv-item-title">${esc(c.title)}</span>
-            <div class="chat-conv-item-workdir" title="${esc(c.workingDir || 'Default workspace')}">📁 ${esc(folderLabel)}</div>
+  for (const [label, group] of Object.entries(groups)) {
+    const isCollapsed = !!collapsed[label];
+    const count = group.convs.length;
+    html += `
+      <div class="chat-conv-group-header" data-group="${esc(label)}" title="${esc(group.fullPath || 'Default workspace')}">
+        <svg class="chat-conv-group-chevron${isCollapsed ? ' collapsed' : ''}" width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4.5 6L8 9.5L11.5 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <span class="chat-conv-group-label">${esc(label)}</span>
+        ${isCollapsed ? `<span class="chat-conv-group-count">${count}</span>` : ''}
+      </div>`;
+    if (!isCollapsed) {
+      for (const c of group.convs) {
+        const isActive = c.id === chatActiveConvId;
+        const isStreaming = chatStreamingConvs.has(c.id);
+        html += `
+          <div class="chat-conv-item${isActive ? ' active' : ''}" data-conv-id="${esc(c.id)}">
+            <div style="flex:1;min-width:0;">
+              <span class="chat-conv-item-title">${esc(c.title)}</span>
+            </div>
+            ${isStreaming ? '<span class="chat-conv-streaming-dot"></span>' : ''}
+            <button class="chat-conv-item-menu" data-conv-menu="${esc(c.id)}" title="Options">⋯</button>
           </div>
-          ${isStreaming ? '<span class="chat-conv-streaming-dot"></span>' : ''}
-          <button class="chat-conv-item-menu" data-conv-menu="${esc(c.id)}" title="Options">⋯</button>
-        </div>
-      `;
+        `;
+      }
     }
   }
   list.innerHTML = html;
+
+  // Wire group toggle events
+  list.querySelectorAll('.chat-conv-group-header').forEach(el => {
+    el.onclick = () => {
+      const grp = el.dataset.group;
+      const isNowCollapsed = !chatGetCollapsedGroups()[grp];
+      chatSetGroupCollapsed(grp, isNowCollapsed);
+      chatRenderConvList();
+    };
+  });
 
   // Wire click events
   list.querySelectorAll('.chat-conv-item').forEach(el => {

--- a/public/styles.css
+++ b/public/styles.css
@@ -215,17 +215,52 @@
     padding: 6px;
   }
 
-  .chat-conv-group-label {
-    font-size: 10px;
-    font-weight: 600;
+  .chat-conv-group-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 8px;
+    margin: 4px 0 0;
+    cursor: pointer;
+    border-radius: 6px;
+    user-select: none;
+    background: var(--surface2);
+    transition: background 0.12s;
+  }
+  .chat-conv-group-header:first-child { margin-top: 0; }
+  .chat-conv-group-header:hover { background: var(--border); }
+
+  .chat-conv-group-chevron {
     color: var(--muted);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    padding: 10px 8px 4px;
+    flex-shrink: 0;
+    transition: transform 0.15s ease;
+  }
+  .chat-conv-group-chevron.collapsed { transform: rotate(-90deg); }
+
+  .chat-conv-group-label {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+    opacity: 0.55;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .chat-conv-group-count {
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--muted);
+    background: var(--surface2);
+    padding: 0 6px;
+    border-radius: 10px;
+    line-height: 18px;
+    flex-shrink: 0;
+    margin-left: auto;
   }
 
   .chat-conv-item {
-    padding: 10px 10px;
+    padding: 8px 10px 8px 30px;
     border-radius: 6px;
     cursor: pointer;
     display: flex;
@@ -237,19 +272,19 @@
   }
 
   .chat-conv-item:hover { background: var(--surface2); }
-  .chat-conv-item.active { background: rgba(99,102,241,0.08); }
+  .chat-conv-item.active { background: transparent; }
 
   .chat-conv-item-title {
     display: block;
     font-size: 13px;
-    font-weight: 500;
+    font-weight: 400;
     color: var(--text);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
-  .chat-conv-item.active .chat-conv-item-title { color: var(--accent-chat); font-weight: 600; }
+  .chat-conv-item.active .chat-conv-item-title { color: var(--accent-chat); font-weight: 500; }
 
   .chat-conv-item-menu {
     background: none;
@@ -1633,14 +1668,6 @@
     max-width: 300px;
   }
 
-  .chat-conv-item-workdir {
-    font-size: 10px;
-    color: var(--muted);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    margin-top: 2px;
-  }
 
   .chat-settings-group {
     margin-bottom: 20px;


### PR DESCRIPTION
## Summary
- Replace date-based conversation grouping (Today, Yesterday, etc.) with workspace-based grouping using the last 2 path segments of `workingDir`
- Each workspace group has a collapsible header with SVG chevron, label, and count badge when collapsed
- Collapse state persists in localStorage across page reloads
- Conversation items are indented under their group and no longer show a redundant workspace line

## Test plan
- [ ] Verify conversations are grouped by workspace path
- [ ] Click group headers to toggle collapse/expand
- [ ] Refresh page and confirm collapsed groups stay collapsed
- [ ] Verify dark mode renders correctly
- [ ] Confirm all 245 existing tests pass