### PR TITLE
fix: resolve UI getting stuck on tool call spinner after CLI completes

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -236,7 +236,8 @@ data: {"type":"<type>", ...fields}\n\n
 | `text` | `content`, `streaming` | Text delta from assistant |
 | `thinking` | `content`, `streaming` | Extended thinking delta |
 | `tool_activity` | `tool`, `description`, `id`, + enriched fields | Tool use notification (see enriched fields below) |
-| `turn_boundary` | — | Marks boundary between assistant turns |
+| `turn_boundary` | — | Marks boundary between assistant turns (internal — not forwarded to client) |
+| `turn_complete` | — | Notifies client that tools finished and a new turn is starting |
 | `result` | `content` | Final result text from CLI |
 | `assistant_message` | `message` | Saved assistant message (intermediate or final) |
 | `error` | `error` | Error message string |
@@ -254,7 +255,7 @@ data: {"type":"<type>", ...fields}\n\n
 | `questions` | AskUserQuestion | Array of question objects with options |
 | `isPlanFile` | Write tool | `true` when writing to `.claude/plans/` |
 
-**Turn boundary behavior:** On `turn_boundary`, accumulated streaming content (text + thinking) is saved as an intermediate assistant message. On stream completion, final content is saved and `assistant_message` + `done` events are sent.
+**Turn boundary behavior:** On `turn_boundary`, accumulated streaming content (text + thinking) is saved as an intermediate assistant message, and a `turn_complete` event is always sent to the client (even when there is no text to save). This allows the frontend to clear stale tool activity spinners when tools finish executing. On stream completion, final content is saved and `assistant_message` + `done` events are sent.
 
 **Abort streaming:**
 ```
@@ -621,9 +622,11 @@ Vanilla JavaScript SPA — no framework, no bundler, no build step. Uses marked 
 - Streaming uses `fetch` with manual ReadableStream parsing (not EventSource API)
 - **Streaming state persistence:** `chatStreamingState` Map stores per-conversation state (accumulated text, thinking, tools, agents, pending interactions). State survives conversation switches — on return, the streaming bubble is recreated and restored.
 - **Elapsed timer:** live timer in streaming bubble header, self-cleans on DOM disconnect
-- **Turn boundaries:** intermediate assistant messages saved, content reset
+- **Turn boundaries:** intermediate assistant messages saved, content reset. `turn_complete` event clears active tool/agent spinners so the UI reflects that tools have finished.
+- **Thinking events:** clear stale tool/agent activity state, ensuring spinners don't persist while the model thinks after tool execution.
 - **Plan approval:** renders plan as markdown with approve/reject buttons → POSTs to `/input`
 - **User questions:** renders question text + option buttons → POSTs answer to `/input`
+- **Stream cleanup:** `chatCleanupStreamState()` accepts `{ force }` option. The `finally` block uses `force: true` to ensure cleanup even when a pending interaction was never resolved. Interaction response handlers also use forced cleanup when the stream has already ended.
 - **Send button state:** shows stop (■) when streaming, send (↑) when idle. Disabled during uploads or session resets.
 
 ### File Handling
@@ -754,7 +757,7 @@ Update OAuth callback URLs to include the ngrok URL.
 | File | Focus |
 |------|-------|
 | `test/backends.test.js` | BaseBackendAdapter, BackendRegistry, ClaudeCodeAdapter, extractToolDetails |
-| `test/chat.test.js` | Chat routes: /input, SSE forwarding, turn boundaries, file upload/serve, workspace instructions |
+| `test/chat.test.js` | Chat routes: /input, SSE forwarding, turn boundaries, turn_complete event forwarding, file upload/serve, workspace instructions |
 | `test/chatService.test.js` | ChatService CRUD, messages, sessions, workspace storage, migration, markdown export |
 | `test/draftState.test.js` | Draft save/restore, key migration, cleanup, round-trip |
 | `test/graceful-shutdown.test.js` | Server shutdown on SIGINT/SIGTERM |

--- a/public/app.js
+++ b/public/app.js
@@ -1299,12 +1299,12 @@ function chatScrollToBottom() {
 
 // ── Sending messages ──────────────────────────────────────────────────────────
 
-function chatCleanupStreamState(convId) {
+function chatCleanupStreamState(convId, { force = false } = {}) {
   const st = chatStreamingState.get(convId);
   if (!st) return;
   if (st.elapsedTimerInterval) clearInterval(st.elapsedTimerInterval);
   if (st.activityTimerInterval) clearInterval(st.activityTimerInterval);
-  if (st.pendingInteraction) {
+  if (st.pendingInteraction && !force) {
     // Keep the streaming bubble alive for pending interactions
     // (plan approval, user questions) so the user can still act on them
     return;
@@ -1442,8 +1442,22 @@ async function chatSendMessage() {
 
           if (event.type === 'thinking') {
             st.assistantThinking += event.content;
+            // Clear stale tool activity so spinners don't persist while model thinks
+            if (st.activeTools.length || st.activeAgents.length) {
+              st.activeTools = [];
+              st.activeAgents = [];
+              if (st.activityTimerInterval) { clearInterval(st.activityTimerInterval); st.activityTimerInterval = null; }
+            }
             if (isStillActive) {
               chatUpdateStreamingMessage(st.streamingMsgEl, st.assistantContent, st.assistantThinking);
+            }
+          } else if (event.type === 'turn_complete') {
+            // Tools finished executing — clear tool activity so spinners stop
+            st.activeTools = [];
+            st.activeAgents = [];
+            if (st.activityTimerInterval) { clearInterval(st.activityTimerInterval); st.activityTimerInterval = null; }
+            if (isStillActive && !st.pendingInteraction) {
+              chatUpdateStreamingActivity(st.streamingMsgEl, st.activeTools, st.activeAgents, st.planModeActive);
             }
           } else if (event.type === 'text') {
             st.assistantContent += event.content;
@@ -1529,7 +1543,8 @@ async function chatSendMessage() {
     }
   } finally {
     chatStreamingConvs.delete(targetConvId);
-    chatCleanupStreamState(targetConvId);
+    // Force cleanup — stream has ended, no more events will arrive
+    chatCleanupStreamState(targetConvId, { force: true });
     chatUpdateSendButtonState();
     chatRenderConvList();
   }
@@ -1727,11 +1742,10 @@ function chatShowPlanApproval(msgEl, convId, planContent) {
         });
         const approvalState = chatStreamingState.get(convId);
         if (approvalState) {
-          if (approvalState.elapsedTimerInterval) clearInterval(approvalState.elapsedTimerInterval);
           approvalState.pendingInteraction = null;
           // If the stream has ended (no longer in chatStreamingConvs), fully clean up
           if (!chatStreamingConvs.has(convId)) {
-            chatStreamingState.delete(convId);
+            chatCleanupStreamState(convId, { force: true });
           }
         }
         contentEl.innerHTML = `${planHtml ? `<div class="chat-plan-approval-content">${planHtml}</div>` : ''}<div style="font-size:12px;color:var(--muted);font-style:italic;">Plan ${action === 'approve' ? 'approved' : 'rejected'}.</div>`;
@@ -1803,8 +1817,9 @@ function chatShowUserQuestion(msgEl, convId, event) {
       const questionState = chatStreamingState.get(convId);
       if (questionState) {
         questionState.pendingInteraction = null;
+        // If the stream has ended (no longer in chatStreamingConvs), fully clean up
         if (!chatStreamingConvs.has(convId)) {
-          chatStreamingState.delete(convId);
+          chatCleanupStreamState(convId, { force: true });
         }
       }
       contentEl.innerHTML = `<div style="font-size:12px;color:var(--muted);font-style:italic;">Answered: ${esc(text)}</div>`;

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -420,6 +420,8 @@ function createChatRouter({ chatService, backendRegistry, updateService }) {
               const intermediateMsg = await chatService.addMessage(convId, 'assistant', fullResponse.trim(), backend, thinkingText.trim() || null);
               res.write(`data: ${JSON.stringify({ type: 'assistant_message', message: intermediateMsg })}\n\n`);
             }
+            // Always notify frontend that tools completed, even when no text to save
+            res.write(`data: ${JSON.stringify({ type: 'turn_complete' })}\n\n`);
             fullResponse = '';
             thinkingText = '';
             hasStreamingDeltas = false;

--- a/test/chat.test.js
+++ b/test/chat.test.js
@@ -451,6 +451,83 @@ describe('Turn boundary intermediate messages', () => {
   });
 });
 
+// ── Turn complete event forwarding ───────────────────────────────────────────
+
+describe('Turn complete event forwarding', () => {
+  test('sends turn_complete event on turn_boundary even without text', async () => {
+    const conv = await chatService.createConversation('Test');
+
+    mockBackend.setMockEvents([
+      { type: 'turn_boundary' }, // boundary with no preceding text
+      { type: 'text', content: 'Final', streaming: true },
+      { type: 'done' },
+    ]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'test',
+      backend: 'claude-code',
+    });
+
+    const events = await readSSE(`/api/chat/conversations/${conv.id}/stream`);
+
+    // Should have turn_complete event even though no text was saved
+    const turnCompletes = events.filter(e => e.type === 'turn_complete');
+    expect(turnCompletes).toHaveLength(1);
+  });
+
+  test('sends turn_complete alongside assistant_message when text exists', async () => {
+    const conv = await chatService.createConversation('Test');
+
+    mockBackend.setMockEvents([
+      { type: 'text', content: 'First response', streaming: true },
+      { type: 'turn_boundary' },
+      { type: 'text', content: 'Second response', streaming: true },
+      { type: 'done' },
+    ]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'test',
+      backend: 'claude-code',
+    });
+
+    const events = await readSSE(`/api/chat/conversations/${conv.id}/stream`);
+
+    // Should have both assistant_message and turn_complete
+    const assistantMessages = events.filter(e => e.type === 'assistant_message');
+    const turnCompletes = events.filter(e => e.type === 'turn_complete');
+    expect(assistantMessages).toHaveLength(2);
+    expect(turnCompletes).toHaveLength(1);
+
+    // turn_complete should come after the intermediate assistant_message
+    const assistantIdx = events.findIndex(e => e.type === 'assistant_message');
+    const turnCompleteIdx = events.findIndex(e => e.type === 'turn_complete');
+    expect(turnCompleteIdx).toBeGreaterThan(assistantIdx);
+  });
+
+  test('sends turn_complete for each turn_boundary', async () => {
+    const conv = await chatService.createConversation('Test');
+
+    mockBackend.setMockEvents([
+      { type: 'text', content: 'First', streaming: true },
+      { type: 'turn_boundary' },
+      { type: 'text', content: 'Second', streaming: true },
+      { type: 'turn_boundary' },
+      { type: 'text', content: 'Third', streaming: true },
+      { type: 'done' },
+    ]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'test',
+      backend: 'claude-code',
+    });
+
+    const events = await readSSE(`/api/chat/conversations/${conv.id}/stream`);
+
+    const turnCompletes = events.filter(e => e.type === 'turn_complete');
+    expect(turnCompletes).toHaveLength(2);
+  });
+});
+
 // ── Workspace context injection ──────────────────────────────────────────────
 
 describe('Workspace context injection', () => {


### PR DESCRIPTION
## Summary
- **Turn boundaries now forward `turn_complete` event** to the frontend even when there's no text to save, so tool spinners are cleared when tools finish executing
- **Thinking events clear stale tool/agent state**, preventing spinners from persisting while the model thinks after tool execution
- **`chatCleanupStreamState()` accepts a `force` option** used by the `finally` block and interaction response handlers to guarantee cleanup even when `pendingInteraction` was never resolved

## Test plan
- [x] All 276 tests pass (273 existing + 3 new)
- [x] New tests verify `turn_complete` is sent on every turn boundary (with/without text, multiple boundaries)
- [ ] Manual: trigger multi-step tool operation (e.g. push PR) and verify spinners clear promptly
- [ ] Manual: verify plan approval / user question flows still work correctly

Closes #54