### PR TITLE
docs: reposition README around data ownership and provider portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,24 @@
 </p>
 
 <p align="center">
-  A web-based chat interface for interacting with Claude Code CLI sessions remotely from any device.
+  A unified web interface for AI coding agents. Own your data, switch between providers freely.
 </p>
 
 ---
 
+## Why Agent Cockpit?
+
+When you use vendor-hosted AI interfaces — Anthropic's Claude, Google's Gemini, OpenAI's ChatGPT — each one builds up memory and context about you: your preferences, your codebase knowledge, your working style. That memory is locked inside their platform. If a better model comes along from another provider, you can't take your conversation history, accumulated context, or customizations with you. You end up explaining yourself from scratch.
+
+Agent Cockpit solves this by decoupling **your data** from **the AI provider**. It sits on your machine, talks to CLI-based coding agents, and keeps all conversations, sessions, and context locally on disk in open JSON files. When you switch to a different CLI backend, the new agent can access everything the previous one built up. Your investment in AI-assisted workflows stays with you, not with a vendor.
+
 ## How It Works
 
-Agent Cockpit is a thin web layer that sits in front of the Claude Code CLI installed on your machine. When you send a message through the browser, the server spawns a `claude` CLI process locally, streams the response back over Server-Sent Events (SSE), and stores the conversation as a JSON file on disk. The CLI runs with full access to your local filesystem and tools, just as it would in your terminal.
+Agent Cockpit runs on the same machine as your CLI tools. When you send a message through the browser, the server spawns a CLI process locally, streams the response back over Server-Sent Events (SSE), and stores the conversation as a JSON file on disk. The CLI runs with full access to your local filesystem and tools, just as it would in your terminal.
 
 This means:
-- **The CLI and the web interface must run on the same machine.** Agent Cockpit does not connect to a remote API — it spawns local processes.
-- **Exposing the server (e.g., via ngrok) gives you remote access to your local CLIs.** You can chat with Claude Code from any browser, anywhere, while it operates on your local files and environment.
+- **The CLI and the web interface must run on the same machine.** Agent Cockpit spawns local processes, not remote API calls.
+- **Expose the server for remote access.** Use a tunnel like [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) to chat with your coding agents from any browser, anywhere, while they operate on your local files and environment.
 - **OAuth protects access.** Only the email addresses you configure in `ALLOWED_EMAIL` can log in, so your CLI sessions stay private even when exposed over the internet.
 
 ## Features
@@ -40,10 +46,9 @@ This means:
 ## Prerequisites
 
 - Node.js 18+
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated on the same machine
-- A Google Cloud project with OAuth 2.0 credentials (required)
-- A GitHub OAuth App (optional — enables GitHub login)
-- (Optional) [ngrok](https://ngrok.com/) or a similar tunnel for remote access
+- At least one CLI backend installed and authenticated on the same machine (currently [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code))
+- At least one OAuth provider configured: Google OAuth 2.0 **or** GitHub OAuth (or both)
+- (Optional) [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) or a similar tunnel for remote access
 
 ## Quick Start
 
@@ -75,17 +80,23 @@ npm start
 |----------|----------|---------|-------------|
 | `PORT` | No | `3334` | Server listen port |
 | `SESSION_SECRET` | Yes | — | Secret for signing session cookies |
-| `GOOGLE_CLIENT_ID` | Yes | — | Google OAuth 2.0 client ID |
-| `GOOGLE_CLIENT_SECRET` | Yes | — | Google OAuth 2.0 client secret |
-| `GOOGLE_CALLBACK_URL` | Yes | — | Google OAuth callback URL |
-| `GITHUB_CLIENT_ID` | No | — | GitHub OAuth client ID (enables GitHub login) |
-| `GITHUB_CLIENT_SECRET` | No | — | GitHub OAuth client secret |
-| `GITHUB_CALLBACK_URL` | No | — | GitHub OAuth callback URL |
+| `GOOGLE_CLIENT_ID` | No* | — | Google OAuth 2.0 client ID |
+| `GOOGLE_CLIENT_SECRET` | No* | — | Google OAuth 2.0 client secret |
+| `GOOGLE_CALLBACK_URL` | No* | — | Google OAuth callback URL |
+| `GITHUB_CLIENT_ID` | No* | — | GitHub OAuth client ID |
+| `GITHUB_CLIENT_SECRET` | No* | — | GitHub OAuth client secret |
+| `GITHUB_CALLBACK_URL` | No* | — | GitHub OAuth callback URL |
 | `ALLOWED_EMAIL` | Yes | — | Comma-separated list of allowed email addresses |
 | `DEFAULT_WORKSPACE` | No | `~/.openclaw/workspace` | Default working directory for CLI processes |
 | `BASE_PATH` | No | `''` | URL base path for reverse proxy deployments |
 
-## Google OAuth Setup
+*\* At least one OAuth provider (Google or GitHub) must be fully configured. You can set up one or both.*
+
+## Authentication Setup
+
+You need at least one OAuth provider configured. You can use Google, GitHub, or both.
+
+### Google OAuth
 
 1. Go to the [Google Cloud Console](https://console.cloud.google.com/).
 2. Create a new project (or select an existing one).
@@ -97,24 +108,22 @@ npm start
 8. Copy the Client ID and Client Secret into your `.env` file.
 9. Set `ALLOWED_EMAIL` to the Google account email you want to grant access.
 
-## GitHub OAuth Setup (Optional)
+### GitHub OAuth
 
 1. Go to **GitHub Settings > Developer settings > OAuth Apps > New OAuth App**.
 2. Set the **Authorization callback URL** to `http://localhost:3334/auth/github/callback` (or your production URL).
 3. After creating the app, copy the Client ID and generate a Client Secret.
 4. Add `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and `GITHUB_CALLBACK_URL` to your `.env`.
 
-If the GitHub env vars are not set, the app works with Google-only login.
+## Remote Access with Cloudflare Tunnel
 
-## Remote Access with ngrok
-
-To access Agent Cockpit from outside your local network:
+To access Agent Cockpit from outside your local network, use [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/):
 
 ```bash
-ngrok http 3334
+cloudflared tunnel --url http://localhost:3334
 ```
 
-Use the ngrok-provided URL to reach your local Agent Cockpit from any device. Make sure to update your Google (and GitHub, if configured) OAuth **Authorized JavaScript origins** and **Authorized redirect URIs** to include the ngrok URL.
+Use the tunnel-provided URL to reach your local Agent Cockpit from any device. Make sure to update your OAuth provider's **Authorized JavaScript origins** and **Authorized redirect URIs** to include the tunnel URL.
 
 ## Project Structure
 
@@ -187,6 +196,13 @@ Agent Cockpit spawns Claude Code CLI processes on your behalf. To get the best e
 - **`permissions.allow: ["Edit(**)"]`** gives Claude Code permission to edit any file without prompting for confirmation. This is useful when running through Agent Cockpit since there is no interactive terminal to approve file edits.
 
 These settings are optional but recommended for a smoother experience when using Agent Cockpit as your primary interface to Claude Code.
+
+## Roadmap
+
+Agent Cockpit currently supports the Claude Code CLI as its first backend. The pluggable adapter system is built to support multiple CLI backends side by side. Planned integrations:
+
+- **Kiro CLI** — next in line
+- **Additional CLI backends** — as vendors release CLI-based coding agents, Agent Cockpit will add adapters so you can use them all from a single interface while keeping your data portable
 
 ## Specification
 


### PR DESCRIPTION
## Summary
- Reframe product positioning from Claude Code CLI wrapper to a unified interface for AI coding agents with local data ownership and provider portability
- Replace ngrok references with Cloudflare Tunnel
- Fix OAuth docs: both Google and GitHub are optional, at least one is required
- Add roadmap section (Kiro CLI next, more backends planned)

## Test plan
- [ ] Verify README renders correctly on GitHub (logo, tables, formatting)
- [ ] Confirm env variable table footnote about OAuth is clear