### PR TITLE
fix: preserve tool and agent activity history across stream transitions

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -627,10 +627,11 @@ Vanilla JavaScript SPA — no framework, no bundler, no build step. Uses marked 
 
 - `chatSendMessage()` gathers completed file paths from pending uploads, appends `[Uploaded files: ...]` to content, POSTs message, opens SSE stream
 - Streaming uses `fetch` with manual ReadableStream parsing (not EventSource API)
-- **Streaming state persistence:** `chatStreamingState` Map stores per-conversation state (accumulated text, thinking, tools, agents, pending interactions). State survives conversation switches — on return, the streaming bubble is recreated and restored.
+- **Streaming state persistence:** `chatStreamingState` Map stores per-conversation state (accumulated text, thinking, tools, agents, tool/agent history, pending interactions). State survives conversation switches — on return, the streaming bubble is recreated and restored.
 - **Elapsed timer:** live timer in streaming bubble header, self-cleans on DOM disconnect
-- **Turn boundaries:** intermediate assistant messages saved, content reset. `turn_complete` event clears active tool/agent spinners so the UI reflects that tools have finished.
-- **Thinking events:** clear stale tool/agent activity state, ensuring spinners don't persist while the model thinks after tool execution.
+- **Activity history:** Completed tools and agents are archived to `toolHistory`/`agentHistory` arrays that persist across thinking/text/turn transitions. The full operation history is displayed as a stacking list with checkmarks and elapsed durations, while the current active tool shows a spinner with a live timer. Agent cards show spinner when running, checkmark when completed.
+- **Turn boundaries:** intermediate assistant messages saved, content reset. `turn_complete` event archives active tools/agents to history so spinners stop but the accumulated history persists.
+- **Thinking events:** archive active tool/agent state to history, ensuring spinners don't persist while the model thinks after tool execution, while preserving the operation log.
 - **Plan approval:** renders plan as markdown with approve/reject buttons → POSTs to `/input`
 - **User questions:** renders question text + option buttons → POSTs answer to `/input`
 - **Auto title update:** handles `title_updated` SSE event by updating the active conversation title, the header, and the sidebar list in-place (no full reload needed).

--- a/public/app.js
+++ b/public/app.js
@@ -1143,8 +1143,8 @@ function chatRenderMessages() {
       }
     } else if (streamState.assistantContent || streamState.assistantThinking) {
       chatUpdateStreamingMessage(msgEl, streamState.assistantContent, streamState.assistantThinking);
-    } else if ((streamState.activeTools && streamState.activeTools.length) || (streamState.activeAgents && streamState.activeAgents.length) || streamState.planModeActive) {
-      chatUpdateStreamingActivity(msgEl, streamState.activeTools || [], streamState.activeAgents || [], streamState.planModeActive);
+    } else if (chatCombinedTools(streamState).length || chatCombinedAgents(streamState).length || streamState.planModeActive) {
+      chatUpdateStreamingActivity(msgEl, chatCombinedTools(streamState), chatCombinedAgents(streamState), streamState.planModeActive);
       chatStartActivityTimer(chatActiveConvId);
     }
     // else: default typing dots shown by chatAppendStreamingMessage
@@ -1367,6 +1367,8 @@ async function chatSendMessage() {
     assistantThinking: '',
     activeTools: [],
     activeAgents: [],
+    toolHistory: [],
+    agentHistory: [],
     planModeActive: false,
     pendingInteraction: null,
     streamingMsgEl: null,
@@ -1442,22 +1444,18 @@ async function chatSendMessage() {
 
           if (event.type === 'thinking') {
             st.assistantThinking += event.content;
-            // Clear stale tool activity so spinners don't persist while model thinks
+            // Archive active tools/agents to history so spinners stop but history persists
             if (st.activeTools.length || st.activeAgents.length) {
-              st.activeTools = [];
-              st.activeAgents = [];
-              if (st.activityTimerInterval) { clearInterval(st.activityTimerInterval); st.activityTimerInterval = null; }
+              chatArchiveActiveState(st);
             }
             if (isStillActive) {
               chatUpdateStreamingMessage(st.streamingMsgEl, st.assistantContent, st.assistantThinking);
             }
           } else if (event.type === 'turn_complete') {
-            // Tools finished executing — clear tool activity so spinners stop
-            st.activeTools = [];
-            st.activeAgents = [];
-            if (st.activityTimerInterval) { clearInterval(st.activityTimerInterval); st.activityTimerInterval = null; }
+            // Tools finished executing — archive to history so spinners stop but history persists
+            chatArchiveActiveState(st);
             if (isStillActive && !st.pendingInteraction) {
-              chatUpdateStreamingActivity(st.streamingMsgEl, st.activeTools, st.activeAgents, st.planModeActive);
+              chatUpdateStreamingActivity(st.streamingMsgEl, chatCombinedTools(st), chatCombinedAgents(st), st.planModeActive);
             }
           } else if (event.type === 'text') {
             st.assistantContent += event.content;
@@ -1465,9 +1463,7 @@ async function chatSendMessage() {
               // Pending interaction (plan approval, user question) — don't overwrite
               // dialog with streaming text. Just accumulate assistantContent silently.
             } else {
-              st.activeTools = [];
-              st.activeAgents = [];
-              if (st.activityTimerInterval) { clearInterval(st.activityTimerInterval); st.activityTimerInterval = null; }
+              if (st.activeTools.length || st.activeAgents.length) chatArchiveActiveState(st);
               if (isStillActive) {
                 chatUpdateStreamingMessage(st.streamingMsgEl, st.assistantContent, st.assistantThinking);
               }
@@ -1497,7 +1493,7 @@ async function chatSendMessage() {
                 chatShowUserQuestion(st.streamingMsgEl, targetConvId, event);
               } else if (!st.pendingInteraction) {
                 // Only render tool activity if no pending interaction (plan approval, user question)
-                chatUpdateStreamingActivity(st.streamingMsgEl, st.activeTools, st.activeAgents, st.planModeActive);
+                chatUpdateStreamingActivity(st.streamingMsgEl, chatCombinedTools(st), chatCombinedAgents(st), st.planModeActive);
                 chatStartActivityTimer(targetConvId);
               }
             }
@@ -1511,11 +1507,9 @@ async function chatSendMessage() {
             const savedInteraction = st.pendingInteraction;
             st.assistantContent = '';
             st.assistantThinking = '';
-            st.activeTools = [];
-            st.activeAgents = [];
+            chatArchiveActiveState(st);
             st.planModeActive = false;
             st.pendingInteraction = savedInteraction;
-            if (st.activityTimerInterval) { clearInterval(st.activityTimerInterval); st.activityTimerInterval = null; }
             if (isStillActive && chatActiveConv) {
               chatActiveConv.messages.push(event.message);
               chatRenderMessages();
@@ -1536,10 +1530,8 @@ async function chatSendMessage() {
             }
           } else if (event.type === 'error') {
             st.pendingInteraction = null;
-            st.activeTools = [];
-            st.activeAgents = [];
+            chatArchiveActiveState(st);
             st.planModeActive = false;
-            if (st.activityTimerInterval) { clearInterval(st.activityTimerInterval); st.activityTimerInterval = null; }
             if (isStillActive) chatAppendError(event.error);
           } else if (event.type === 'done') {
             chatCleanupStreamState(targetConvId);
@@ -1609,6 +1601,30 @@ function chatUpdateStreamingMessage(msgEl, content, thinking) {
   chatScrollToBottom();
 }
 
+/** Archive active tools/agents to history before clearing, preserving elapsed durations. */
+function chatArchiveActiveState(st) {
+  const now = Date.now();
+  for (const tool of st.activeTools) {
+    st.toolHistory.push({ ...tool, completed: true, duration: tool.startTime ? now - tool.startTime : null });
+  }
+  st.activeTools = [];
+  for (const agent of st.activeAgents) {
+    st.agentHistory.push({ ...agent, completed: true, duration: agent.startTime ? now - agent.startTime : null });
+  }
+  st.activeAgents = [];
+  if (st.activityTimerInterval) { clearInterval(st.activityTimerInterval); st.activityTimerInterval = null; }
+}
+
+/** Build combined tools array (history + active) for rendering. */
+function chatCombinedTools(st) {
+  return [...st.toolHistory, ...st.activeTools];
+}
+
+/** Build combined agents array (history + active) for rendering. */
+function chatCombinedAgents(st) {
+  return [...st.agentHistory, ...st.activeAgents];
+}
+
 function chatUpdateStreamingActivity(msgEl, tools, agents, planMode) {
   if (!msgEl) return;
   const contentEl = msgEl.querySelector('.chat-msg-content');
@@ -1616,15 +1632,20 @@ function chatUpdateStreamingActivity(msgEl, tools, agents, planMode) {
 
   let html = '';
 
+  // Determine which tools are completed history vs active
+  const lastTool = tools.length > 0 ? tools[tools.length - 1] : null;
+  const lastToolIsActive = lastTool && !lastTool.completed;
+  const historyTools = lastToolIsActive ? tools.slice(0, -1) : tools;
+
   // Activity history (completed tools with checkmarks)
-  if (tools.length > 1) {
+  if (historyTools.length > 0) {
     html += '<div class="chat-activity-history">';
-    for (let i = 0; i < tools.length - 1; i++) {
-      const t = tools[i];
+    for (let i = 0; i < historyTools.length; i++) {
+      const t = historyTools[i];
       const desc = t.description ? escWithCode(t.description) : esc(t.tool || 'Tool');
       let durationMs = t.duration;
       if (!durationMs && t.startTime) {
-        const nextStart = tools[i + 1].startTime || Date.now();
+        const nextStart = (historyTools[i + 1] || lastTool)?.startTime || Date.now();
         durationMs = nextStart - t.startTime;
       }
       const elapsed = durationMs ? chatFormatElapsedShort(durationMs) : '';
@@ -1633,11 +1654,10 @@ function chatUpdateStreamingActivity(msgEl, tools, agents, planMode) {
     html += '</div>';
   }
 
-  // Current active tool
-  if (tools.length > 0) {
-    const current = tools[tools.length - 1];
-    const desc = current.description ? escWithCode(current.description) : esc(current.tool || 'Working');
-    const initialElapsed = current.startTime ? chatFormatElapsed(Date.now() - current.startTime) : '';
+  // Current active tool (with spinner)
+  if (lastToolIsActive) {
+    const desc = lastTool.description ? escWithCode(lastTool.description) : esc(lastTool.tool || 'Working');
+    const initialElapsed = lastTool.startTime ? chatFormatElapsed(Date.now() - lastTool.startTime) : '';
     html += `<div class="chat-activity-indicator">
       <div class="chat-typing"><div class="chat-typing-dot"></div><div class="chat-typing-dot"></div><div class="chat-typing-dot"></div></div>
       <span class="chat-activity-label">${desc}</span>
@@ -1645,21 +1665,33 @@ function chatUpdateStreamingActivity(msgEl, tools, agents, planMode) {
     </div>`;
   }
 
-  // Agent cards
+  // Agent cards (completed + active)
   if (agents.length > 0) {
     html += '<div class="chat-agent-cards">';
     for (const agent of agents) {
       const agentType = esc(agent.subagentType || 'agent');
       const agentDesc = agent.description ? escWithCode(agent.description) : '';
-      const initialElapsed = agent.startTime ? chatFormatElapsed(Date.now() - agent.startTime) : '';
-      html += `<div class="chat-agent-card">
-        <div class="chat-agent-spinner"></div>
-        <div class="chat-agent-card-header">
-          <span class="chat-agent-type">${agentType}</span>
-          ${agentDesc ? `<span class="chat-agent-card-desc">${agentDesc}</span>` : ''}
-        </div>
-        ${initialElapsed ? `<span class="chat-agent-timer-live">${initialElapsed}</span>` : ''}
-      </div>`;
+      if (agent.completed) {
+        const elapsed = agent.duration ? chatFormatElapsedShort(agent.duration) : '';
+        html += `<div class="chat-agent-card chat-agent-card-done">
+          <span class="chat-activity-check">✓</span>
+          <div class="chat-agent-card-header">
+            <span class="chat-agent-type">${agentType}</span>
+            ${agentDesc ? `<span class="chat-agent-card-desc">${agentDesc}</span>` : ''}
+          </div>
+          ${elapsed ? `<span class="chat-activity-elapsed">${elapsed}</span>` : ''}
+        </div>`;
+      } else {
+        const initialElapsed = agent.startTime ? chatFormatElapsed(Date.now() - agent.startTime) : '';
+        html += `<div class="chat-agent-card">
+          <div class="chat-agent-spinner"></div>
+          <div class="chat-agent-card-header">
+            <span class="chat-agent-type">${agentType}</span>
+            ${agentDesc ? `<span class="chat-agent-card-desc">${agentDesc}</span>` : ''}
+          </div>
+          ${initialElapsed ? `<span class="chat-agent-timer-live">${initialElapsed}</span>` : ''}
+        </div>`;
+      }
     }
     html += '</div>';
   }

--- a/public/styles.css
+++ b/public/styles.css
@@ -957,6 +957,12 @@
     white-space: nowrap;
     flex-shrink: 0;
   }
+  .chat-agent-card-done {
+    opacity: 0.65;
+  }
+  .chat-agent-card-done .chat-activity-check {
+    flex-shrink: 0;
+  }
 
   /* Plan mode banner */
   .chat-plan-mode-banner {


### PR DESCRIPTION
## Summary
- Tool/agent status updates were wiped on thinking/text/turn_complete events, so only the latest operation was visible instead of the full operation log
- Completed tools and agents are now archived to persistent `toolHistory`/`agentHistory` arrays before clearing active state
- The activity display accumulates as a stacking list: completed items show checkmarks with elapsed durations, the current active tool shows a spinner with a live timer, and agent cards distinguish running (spinner) from completed (checkmark) state

## Test plan
- [ ] Start a CLI conversation and verify tool operations stack up in the chat (checkmarks + durations for completed, spinner for current)
- [ ] Verify agents show as running cards with live timers, then switch to completed cards with checkmarks when done
- [ ] Verify switching conversations and switching back preserves the activity history
- [ ] Verify the history resets properly when a new message stream starts