### PR TITLE
fix: update header title on reset and skip fallback auto-title

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -365,7 +365,7 @@ Unauthenticated requests redirect to `/auth/login`.
 | `renameConversation(id, newTitle)` | Updates title in workspace index. Returns full conversation or `null`. |
 | `deleteConversation(id)` | Removes from index, deletes session folder + artifacts, removes from lookup map. |
 | `updateConversationBackend(convId, backend)` | Updates backend field in workspace index. |
-| `addMessage(convId, role, content, backend, thinking)` | Appends to active session + updates index metadata. Auto-titles on first user message. `thinking` omitted if falsy. |
+| `addMessage(convId, role, content, backend, thinking)` | Appends to active session + updates index metadata. Auto-titles on first user message (session 1 only; post-reset sessions rely on LLM title generation). `thinking` omitted if falsy. |
 | `updateMessageContent(convId, messageId, newContent)` | Truncates after target message, adds edited content as new message. |
 | `generateAndUpdateTitle(convId, userMessage)` | Generates a new title via the backend adapter's `generateTitle()` and persists it. Returns the new title or `null`. |
 | `resetSession(convId)` | Archives active session (summary, endedAt), creates new session, resets title to "New Chat". Returns `{ conversation, newSessionNumber, archivedSession }`. |
@@ -658,7 +658,7 @@ Vanilla JavaScript SPA — no framework, no bundler, no build step. Uses marked 
 
 ### Session Management
 
-- **Reset:** archives active session with LLM summary, creates new session, resets conversation title to "New Chat". Shows "Archiving session..." indicator. Blocked during streaming. Double-click prevented via `chatResettingConvs` set.
+- **Reset:** archives active session with LLM summary, creates new session, resets conversation title to "New Chat" in both header and sidebar. Shows "Archiving session..." indicator. Blocked during streaming. Double-click prevented via `chatResettingConvs` set.
 - **History modal:** lists sessions with summaries, view and download buttons
 - **View session:** fetches archived messages from API
 

--- a/public/app.js
+++ b/public/app.js
@@ -1988,6 +1988,7 @@ async function chatResetSession(convIdOverride) {
     if (convId === chatActiveConvId) {
       chatActiveConv = data.conversation;
       chatRenderMessages();
+      chatUpdateHeader();
     }
     chatLoadConversations();
   } catch (err) {

--- a/src/services/chatService.js
+++ b/src/services/chatService.js
@@ -313,14 +313,15 @@ class ChatService {
       msg.thinking = thinking;
     }
 
-    // Auto-title from first user message (only if still default title)
-    if (role === 'user' && convEntry.title === 'New Chat') {
-      convEntry.title = content.substring(0, 80).replace(/\n/g, ' ').trim() || 'New Chat';
-    }
-
     // Find active session
     const activeSession = convEntry.sessions.find(s => s.active);
     const sessionNumber = activeSession ? activeSession.number : 1;
+
+    // Auto-title from first user message (only if still default title).
+    // Skip for post-reset sessions (sessionNumber > 1) — LLM generates a proper title.
+    if (role === 'user' && convEntry.title === 'New Chat' && sessionNumber <= 1) {
+      convEntry.title = content.substring(0, 80).replace(/\n/g, ' ').trim() || 'New Chat';
+    }
 
     // Read session file, add message, write back
     let sessionFile = await this._readSessionFile(hash, convId, sessionNumber);

--- a/test/chatService.test.js
+++ b/test/chatService.test.js
@@ -218,6 +218,16 @@ describe('addMessage', () => {
     expect(loaded.title).toBe('First question');
   });
 
+  test('does not fallback auto-title in post-reset sessions', async () => {
+    const conv = await service.createConversation();
+    await service.addMessage(conv.id, 'user', 'First question');
+    await service.resetSession(conv.id);
+    // After reset, title is "New Chat"; first message in session 2 should NOT auto-title
+    await service.addMessage(conv.id, 'user', 'New topic after reset');
+    const loaded = await service.getConversation(conv.id);
+    expect(loaded.title).toBe('New Chat');
+  });
+
   test('re-titles after session reset when title reverts to New Chat', async () => {
     const conv = await service.createConversation();
     await service.addMessage(conv.id, 'user', 'First question');


### PR DESCRIPTION
## Summary
- Header title was not updating after session reset because `chatUpdateHeader()` was not called — now it is
- Fallback auto-title (first 80 chars of user message) was overwriting "New Chat" on post-reset sessions before the LLM could generate a proper title — now skipped for sessions > 1
- Added test verifying post-reset sessions keep "New Chat" as title

## Test plan
- [ ] Reset a session, verify both header and sidebar show "New Chat"
- [ ] Send a message after reset, verify title stays "New Chat" until the LLM generates a proper one
- [ ] Verify first session of a new conversation still auto-titles from the first user message