### PR TITLE
fix: sync header title on conversation list reload

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -658,7 +658,7 @@ Vanilla JavaScript SPA — no framework, no bundler, no build step. Uses marked 
 
 ### Session Management
 
-- **Reset:** archives active session with LLM summary, creates new session, resets conversation title to "New Chat" in both header and sidebar. Shows "Archiving session..." indicator. Blocked during streaming. Double-click prevented via `chatResettingConvs` set.
+- **Reset:** archives active session with LLM summary, creates new session, resets conversation title to "New Chat" in both header and sidebar. Shows "Archiving session..." indicator. Blocked during streaming. Double-click prevented via `chatResettingConvs` set. Header title is also synced from server data whenever the conversation list reloads (via `chatLoadConversations`), ensuring the header stays consistent even if the inline update is missed.
 - **History modal:** lists sessions with summaries, view and download buttons
 - **View session:** fetches archived messages from API
 

--- a/public/app.js
+++ b/public/app.js
@@ -559,6 +559,14 @@ async function chatLoadConversations(query) {
     const data = await res.json();
     chatConversations = data.conversations || [];
     chatRenderConvList();
+    // Sync active conversation title with authoritative server data
+    if (chatActiveConv && chatActiveConvId) {
+      const match = chatConversations.find(c => c.id === chatActiveConvId);
+      if (match && match.title !== chatActiveConv.title) {
+        chatActiveConv.title = match.title;
+        chatUpdateHeader();
+      }
+    }
   } catch (err) {
     console.error('Failed to load conversations:', err);
   }


### PR DESCRIPTION
## Summary
- After a session reset, the sidebar updated to "New Chat" but the header bar could retain the old title due to a race condition in the async reset flow.
- `chatLoadConversations()` now syncs the active conversation's header title with the authoritative server data whenever the conversation list is refreshed.

## Test plan
- [ ] Reset a session on a conversation and verify both sidebar and header show "New Chat"
- [ ] Verify auto-title generation still updates the header after the first message in a new session
- [ ] Confirm 277 existing tests pass