### PR TITLE
fix: prevent stale response from overwriting header title after session reset

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -658,7 +658,7 @@ Vanilla JavaScript SPA — no framework, no bundler, no build step. Uses marked 
 
 ### Session Management
 
-- **Reset:** archives active session with LLM summary, creates new session, resets conversation title to "New Chat" in both header and sidebar. Shows "Archiving session..." indicator. Blocked during streaming. Double-click prevented via `chatResettingConvs` set. Header title is also synced from server data whenever the conversation list reloads (via `chatLoadConversations`), ensuring the header stays consistent even if the inline update is missed.
+- **Reset:** archives active session with LLM summary, creates new session, resets conversation title to "New Chat" in both header and sidebar. Shows "Archiving session..." indicator. Blocked during streaming. Double-click prevented via `chatResettingConvs` set. Header title is also synced from server data whenever the conversation list reloads (via `chatLoadConversations`), ensuring the header stays consistent even if the inline update is missed. `chatLoadConversations` uses a generation counter to discard stale responses, preventing race conditions where an older response overwrites a title that was already updated by an SSE `title_updated` event. A final `chatLoadConversations()` call in the streaming `finally` block ensures the sidebar and header reflect the latest server state after streaming ends.
 - **History modal:** lists sessions with summaries, view and download buttons
 - **View session:** fetches archived messages from API
 

--- a/public/app.js
+++ b/public/app.js
@@ -143,6 +143,7 @@ let chatPendingWorkingDir = null;
 let chatPendingFiles = []; // Each: { file, status: 'uploading'|'done'|'error', progress, result, xhr }
 let chatDraftState = new Map(); // convId|'__new__' -> { text, pendingFiles }
 let _ensureConvPromise = null;
+let chatConvLoadGen = 0; // generation counter for chatLoadConversations to discard stale responses
 
 function chatApiUrl(path) {
   return apiUrl('chat/' + path);
@@ -592,9 +593,11 @@ function chatToggleSidebar() {
 // ── Conversation list ─────────────────────────────────────────────────────────
 
 async function chatLoadConversations(query) {
+  const gen = ++chatConvLoadGen;
   try {
     const q = query ? `?q=${encodeURIComponent(query)}` : '';
     const res = await chatFetch(`conversations${q}`);
+    if (gen !== chatConvLoadGen) return; // stale response — a newer call was made
     const data = await res.json();
     chatConversations = data.conversations || [];
     chatRenderConvList();
@@ -1564,6 +1567,9 @@ async function chatSendMessage() {
     chatCleanupStreamState(targetConvId, { force: true });
     chatUpdateSendButtonState();
     chatRenderConvList();
+    // Refresh conversation list from server to pick up title changes and message counts.
+    // The generation counter in chatLoadConversations discards any stale in-flight responses.
+    chatLoadConversations();
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds a generation counter to `chatLoadConversations()` so stale async responses are discarded when a newer call has been made, preventing race conditions where an older response overwrites a title already updated by an SSE `title_updated` event
- Adds a final `chatLoadConversations()` call in the streaming `finally` block to ensure sidebar and header reflect the latest server state after streaming ends

## Test plan
- [ ] Reset a session, send a message in the new session, verify the auto-generated title appears in both the sidebar and the header
- [ ] During a multi-turn conversation (with tool use), verify titles stay consistent between sidebar and header
- [ ] Run `npx jest` — all 277 tests pass