### PR TITLE
feat: per-agent activity tracking with CLI event attribution

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -119,7 +119,18 @@ All workspace hashes throughout the system use: `SHA-256(workspacePath).substrin
   content: string,              // Message text
   backend: string,              // Backend that generated the response
   timestamp: string,            // ISO 8601
-  thinking?: string             // Extended thinking (assistant only, omitted if empty)
+  thinking?: string,            // Extended thinking (assistant only, omitted if empty)
+  toolActivity?: [{             // Tool/agent activity log (assistant only, omitted if empty)
+    tool: string,               // Tool name: 'Read', 'Write', 'Bash', 'Agent', etc.
+    description: string,        // Human-readable description
+    id: string|null,            // Block ID from CLI event
+    isAgent?: boolean,          // true for Agent tool invocations
+    subagentType?: string,      // 'Explore', 'general-purpose', etc. (when isAgent)
+    duration: number|null,      // Estimated duration in milliseconds
+    startTime: number,          // Unix timestamp ms when event was received
+    outcome?: string,           // Short outcome summary (e.g. 'exit 0', '4 matches', 'not found')
+    status?: string             // 'success' | 'error' | 'warning' (derived from tool result)
+  }]
 }
 ```
 
@@ -244,8 +255,9 @@ data: {"type":"<type>", ...fields}\n\n
 |------|--------|-------------|
 | `text` | `content`, `streaming` | Text delta from assistant |
 | `thinking` | `content`, `streaming` | Extended thinking delta |
-| `tool_activity` | `tool`, `description`, `id`, + enriched fields | Tool use notification (see enriched fields below) |
-| `turn_boundary` | — | Marks boundary between assistant turns (internal — not forwarded to client) |
+| `tool_activity` | `tool`, `description`, `id`, + enriched fields | Tool use notification (see enriched fields below). Events are accumulated per-turn and persisted as `toolActivity` on the saved assistant message (excluding `isPlanMode` and `isQuestion` meta-events). |
+| `tool_outcomes` | `outcomes` | Array of tool result outcomes extracted from CLI `user` events. Each outcome: `{ toolUseId, isError, outcome, status }`. Merged into `toolActivity` accumulator for persistence and forwarded to frontend for live display. |
+| `turn_boundary` | — | Marks boundary between assistant turns (internal — not forwarded to client). Triggers persistence of accumulated `toolActivity` on the intermediate message. |
 | `turn_complete` | — | Notifies client that tools finished and a new turn is starting |
 | `result` | `content` | Final result text from CLI |
 | `assistant_message` | `message` | Saved assistant message (intermediate or final) |
@@ -377,7 +389,7 @@ Unauthenticated requests redirect to `/auth/login`.
 | `renameConversation(id, newTitle)` | Updates title in workspace index. Returns full conversation or `null`. |
 | `deleteConversation(id)` | Removes from index, deletes session folder + artifacts, removes from lookup map. |
 | `updateConversationBackend(convId, backend)` | Updates backend field in workspace index. |
-| `addMessage(convId, role, content, backend, thinking)` | Appends to active session + updates index metadata. Auto-titles on first user message (session 1 only; post-reset sessions rely on LLM title generation). `thinking` omitted if falsy. |
+| `addMessage(convId, role, content, backend, thinking, toolActivity)` | Appends to active session + updates index metadata. Auto-titles on first user message (session 1 only; post-reset sessions rely on LLM title generation). `thinking` omitted if falsy. `toolActivity` omitted if falsy or empty array. |
 | `updateMessageContent(convId, messageId, newContent)` | Truncates after target message, adds edited content as new message. |
 | `generateAndUpdateTitle(convId, userMessage)` | Generates a new title via the backend adapter's `generateTitle()` and persists it. Returns the new title or `null`. |
 | `resetSession(convId)` | Archives active session (summary, endedAt), creates new session, resets title to "New Chat". Returns `{ conversation, newSessionNumber, archivedSession }`. |
@@ -643,9 +655,16 @@ Vanilla JavaScript SPA — no framework, no bundler, no build step. Uses marked 
 - Streaming uses `fetch` with manual ReadableStream parsing (not EventSource API)
 - **Streaming state persistence:** `chatStreamingState` Map stores per-conversation state (accumulated text, thinking, tools, agents, tool/agent history, pending interactions). State survives conversation switches — on return, the streaming bubble is recreated and restored.
 - **Elapsed timer:** live timer in streaming bubble header, self-cleans on DOM disconnect
-- **Unified streaming content:** A single `chatUpdateStreamingContent()` function renders all streaming state (thinking, text, tool history, active tools, agents, plan mode) together in one stacked view. Text content and tool activity accumulate and remain visible simultaneously — new progress updates stack below previous content rather than replacing it. Tools are split by their `completed` flag: completed tools show checkmarks and elapsed durations, ALL active (non-completed) tools show spinners with live timers simultaneously. Agent cards show spinner when running, checkmark when completed.
-- **Turn boundaries:** intermediate assistant messages saved, content reset. `turn_complete` event archives active tools/agents to history so spinners stop but the accumulated history persists.
-- **Thinking events:** archive active tool/agent state to history, ensuring spinners don't persist while the model thinks after tool execution, while preserving the operation log.
+- **Unified streaming content:** A single `chatUpdateStreamingContent()` function renders all streaming state (thinking, text, tool history, active tools, agents, plan mode) together in one stacked view. Text content and tool activity accumulate and remain visible simultaneously — new progress updates stack below previous content rather than replacing it. Items are grouped by agent via `chatGroupItemsByAgent()`: standalone tools render flat, while each agent card is followed by a scrollable sub-activity panel showing its child tools. Completed items show checkmarks and elapsed durations; running agents show animated spinners with live timers that count up in real-time.
+- **Tool activity on completed messages:** When a message has a `toolActivity` array, `chatRenderToolActivityBlock()` renders a collapsible `<details>/<summary>` block (same pattern as thinking blocks) with a summary line (e.g. "15 ops · 2 agents · 5 read, 2 edited") generated by `chatBuildActivitySummary()`. Collapsed by default; expands to show the full chronological tool/agent list. Agent entries render as agent cards, tool entries as history items.
+- **Tool outcome indicators:** Each tool/agent in the activity log shows a colored outcome badge when outcome data is available. `chatRenderStatusCheck()` renders status-colored checkmarks (green ✓ for success, red ✗ for error, amber ✓ for warning). `chatRenderOutcomeBadge()` renders a small colored badge with the outcome text (e.g. "exit 0", "4 matches", "not found"). Outcomes are extracted from CLI `tool_result` blocks by `extractToolOutcome()` in the backend, correlated by `tool_use_id`, and persisted on the `toolActivity` entries.
+- **Sticky active section:** During streaming, when both completed and running tools exist, a `chat-activity-panel` container wraps them: completed items scroll in a bounded area while running items with spinners stay pinned at the bottom, always visible.
+- **Parallel group indicator:** `chatGroupParallelItems()` detects consecutive agent entries whose `startTime` values are within 500ms (`PARALLEL_THRESHOLD_MS`) and wraps them in a `chat-parallel-group` container with a "parallel" label and a left accent border. Works in both persisted activity blocks and streaming display.
+- **Agent detail expansion:** Agent cards with long descriptions or outcome data render as expandable `<details>` elements (`chatRenderAgentCard()`). Summary shows agent type, description, outcome badge, and elapsed time; expanding reveals full outcome details.
+- **Session activity overview:** `chatRenderSessionOverview()` aggregates `toolActivity` from all assistant messages in the current session and renders a collapsible dashboard at the top of the message list. Shows: total ops/agents/duration summary, status breakdown pills (success/error/warning counts), tool type bar chart sorted by frequency, and agent timeline with types and outcomes. Collapsed by default; only rendered when at least one message has `toolActivity`.
+- **Turn boundaries:** intermediate assistant messages saved, content reset. `turn_complete` event archives active tools/agents to history so spinners stop but the accumulated history persists. Agents are only archived when they have received their `tool_outcomes` (outcome/status set) — sub-tool `turn_complete` events within an agent do NOT prematurely archive the parent agent. This ensures agents show spinners and live timers throughout their full execution.
+- **Post-completion processing indicator:** When all tools/agents have completed but the model is still working (no text content yet), a "Processing..." indicator with typing dots is shown below the completed activity log. This fills the gap between agent completion and text output, so users always see ongoing work.
+- **Thinking events:** do NOT archive active tool/agent state — `turn_complete` handles archiving. This prevents premature archiving that would kill agent spinners and timers.
 - **Plan approval:** renders plan as markdown with approve/reject buttons → POSTs to `/input`
 - **User questions:** renders question text + option buttons → POSTs answer to `/input`
 - **Auto title update:** handles `title_updated` SSE event by updating the active conversation title, the header, and the sidebar list in-place (no full reload needed).
@@ -780,9 +799,9 @@ Update OAuth callback URLs to include the ngrok URL.
 
 | File | Focus |
 |------|-------|
-| `test/backends.test.js` | BaseBackendAdapter (including generateTitle), BackendRegistry, ClaudeCodeAdapter, extractToolDetails, extractUsage |
-| `test/chat.test.js` | Chat routes: /input, SSE forwarding, turn boundaries, turn_complete event forwarding, auto title update on session reset, usage event forwarding and persistence, file upload/serve, workspace instructions |
-| `test/chatService.test.js` | ChatService CRUD, messages, sessions, generateAndUpdateTitle, usage tracking (addUsage, getUsage), workspace storage, migration, markdown export |
+| `test/backends.test.js` | BaseBackendAdapter (including generateTitle), BackendRegistry, ClaudeCodeAdapter, extractToolDetails, extractToolOutcome, extractUsage |
+| `test/chat.test.js` | Chat routes: /input, SSE forwarding, turn boundaries, turn_complete event forwarding, tool activity persistence, parallel agent persistence, session overview aggregation, auto title update on session reset, usage event forwarding and persistence, file upload/serve, workspace instructions |
+| `test/chatService.test.js` | ChatService CRUD, messages (including toolActivity persistence), sessions, generateAndUpdateTitle, usage tracking (addUsage, getUsage), workspace storage, migration, markdown export |
 | `test/draftState.test.js` | Draft save/restore, key migration, cleanup, round-trip |
 | `test/graceful-shutdown.test.js` | Server shutdown on SIGINT/SIGTERM |
 | `test/sessionStore.test.js` | Session file-store persistence |

--- a/public/app.js
+++ b/public/app.js
@@ -1148,6 +1148,11 @@ function chatRenderMessages() {
   const currentSessionMsgs = chatActiveConv.messages;
 
   let html = '';
+
+  // Session activity overview — aggregate all toolActivity across messages
+  const overviewHtml = chatRenderSessionOverview(currentSessionMsgs);
+  if (overviewHtml) html += overviewHtml;
+
   for (let mi = 0; mi < currentSessionMsgs.length; mi++) {
     const msg = currentSessionMsgs[mi];
 
@@ -1160,6 +1165,7 @@ function chatRenderMessages() {
     const rendered = chatRenderMarkdown(msg.content);
     const caps = msg.backend ? getBackendCapabilities(msg.backend) : {};
     const thinkingHtml = msg.thinking && caps.thinking !== false ? chatRenderThinkingBlock(msg.thinking, false) : '';
+    const toolActivityHtml = !isUser && msg.toolActivity ? chatRenderToolActivityBlock(msg.toolActivity) : '';
 
     // Elapsed time for assistant messages (time since preceding user message)
     let elapsedLabel = '';
@@ -1183,7 +1189,7 @@ function chatRenderMessages() {
           <div class="chat-msg-avatar${avatarClass}">${avatar}</div>
           <div class="chat-msg-body">
             <div class="chat-msg-role">${roleLabel} ${backendLabel}${timeLabel}</div>
-            <div class="chat-msg-content">${thinkingHtml}${rendered}</div>
+            <div class="chat-msg-content">${thinkingHtml}${toolActivityHtml}${rendered}</div>
             <div class="chat-msg-actions">
               <button class="chat-msg-action" data-action="copy-msg" title="Copy">Copy</button>
             </div>
@@ -1227,6 +1233,228 @@ function chatRenderThinkingBlock(thinking, expanded) {
   return `<details class="chat-thinking-block"${openAttr}>
     <summary class="chat-thinking-toggle">Thinking</summary>
     <div class="chat-thinking-content">${chatRenderMarkdown(thinking)}</div>
+  </details>`;
+}
+
+/** Render an outcome badge for a completed tool, e.g. "exit 0", "4 matches", "not found" */
+function chatRenderOutcomeBadge(item) {
+  if (!item.outcome && !item.status) return '';
+  const statusClass = item.status === 'error' ? 'chat-outcome-error'
+    : item.status === 'warning' ? 'chat-outcome-warning'
+    : 'chat-outcome-success';
+  const text = item.outcome ? esc(item.outcome) : '';
+  return text ? `<span class="chat-outcome-badge ${statusClass}">${text}</span>` : '';
+}
+
+/** Render a status indicator (checkmark color varies by outcome status) */
+function chatRenderStatusCheck(item) {
+  if (item.status === 'error') return '<span class="chat-activity-check chat-status-error">\u2717</span>';
+  if (item.status === 'warning') return '<span class="chat-activity-check chat-status-warning">\u2713</span>';
+  return '<span class="chat-activity-check">\u2713</span>';
+}
+
+/** Build a short summary string from a toolActivity array, e.g. "15 ops · 2 agents · 5 read, 2 edited" */
+function chatBuildActivitySummary(toolActivity) {
+  if (!toolActivity || toolActivity.length === 0) return 'No activity';
+  const agents = toolActivity.filter(t => t.isAgent);
+  const tools = toolActivity.filter(t => !t.isAgent);
+  const parts = [];
+  parts.push(`${toolActivity.length} op${toolActivity.length !== 1 ? 's' : ''}`);
+  if (agents.length > 0) {
+    parts.push(`${agents.length} agent${agents.length !== 1 ? 's' : ''}`);
+  }
+  const counts = {};
+  for (const t of tools) { counts[t.tool] = (counts[t.tool] || 0) + 1; }
+  const labels = { Read: 'read', Write: 'written', Edit: 'edited', Bash: 'command', Grep: 'search', Glob: 'glob', WebSearch: 'web search', WebFetch: 'web fetch', TodoWrite: 'task update' };
+  const breakdown = Object.entries(counts).map(([tool, n]) => `${n} ${labels[tool] || tool.toLowerCase()}`);
+  if (breakdown.length > 0) parts.push(breakdown.join(', '));
+  return parts.join(' \u00b7 ');
+}
+
+/** Render a collapsible <details> block for tool activity on completed messages. */
+/** Render a completed agent card (expandable with details on click) */
+function chatRenderAgentCard(t, checkHtml, outcomeBadge, elapsed) {
+  const agentType = esc(t.subagentType || 'agent');
+  const agentDesc = t.description ? escWithCode(t.description) : '';
+  const fullDesc = t.description && t.description.length > 40 ? escWithCode(t.description) : '';
+  const outcomeDetail = t.outcome ? `<span class="chat-agent-detail-outcome">Result: ${esc(t.outcome)}</span>` : '';
+  const hasDetails = fullDesc || outcomeDetail;
+  if (hasDetails) {
+    return `<details class="chat-agent-card chat-agent-card-done chat-agent-expandable">
+      <summary class="chat-agent-card-summary">
+        ${checkHtml}
+        <div class="chat-agent-card-header">
+          <span class="chat-agent-type">${agentType}</span>
+          ${agentDesc ? `<span class="chat-agent-card-desc">${agentDesc}</span>` : ''}
+        </div>
+        ${outcomeBadge}${elapsed ? `<span class="chat-activity-elapsed">${elapsed}</span>` : ''}
+      </summary>
+      <div class="chat-agent-card-details">
+        ${outcomeDetail}
+      </div>
+    </details>`;
+  }
+  return `<div class="chat-agent-card chat-agent-card-done">
+    ${checkHtml}
+    <div class="chat-agent-card-header">
+      <span class="chat-agent-type">${agentType}</span>
+      ${agentDesc ? `<span class="chat-agent-card-desc">${agentDesc}</span>` : ''}
+    </div>
+    ${outcomeBadge}${elapsed ? `<span class="chat-activity-elapsed">${elapsed}</span>` : ''}
+  </div>`;
+}
+
+/** Detect parallel groups among items: consecutive agents with startTimes within threshold */
+const PARALLEL_THRESHOLD_MS = 500;
+function chatGroupParallelItems(items) {
+  const groups = [];
+  let i = 0;
+  while (i < items.length) {
+    // Check if this is the start of a parallel agent group
+    if (items[i].isAgent || items[i]._kind === 'agent') {
+      const groupStart = i;
+      let j = i + 1;
+      while (j < items.length
+        && (items[j].isAgent || items[j]._kind === 'agent')
+        && items[j].startTime && items[groupStart].startTime
+        && Math.abs(items[j].startTime - items[groupStart].startTime) < PARALLEL_THRESHOLD_MS) {
+        j++;
+      }
+      if (j - groupStart > 1) {
+        // Parallel group of agents
+        groups.push({ type: 'parallel', items: items.slice(groupStart, j) });
+        i = j;
+        continue;
+      }
+    }
+    groups.push({ type: 'single', item: items[i] });
+    i++;
+  }
+  return groups;
+}
+
+/** Render a single tool activity item (completed, for persisted display) */
+function chatRenderCompletedItem(t) {
+  const checkHtml = chatRenderStatusCheck(t);
+  const outcomeBadge = chatRenderOutcomeBadge(t);
+  if (t.isAgent || t._kind === 'agent') {
+    const elapsed = t.duration ? chatFormatElapsedShort(t.duration) : '';
+    return chatRenderAgentCard(t, checkHtml, outcomeBadge, elapsed);
+  }
+  const desc = t.description ? escWithCode(t.description) : esc(t.tool || 'Tool');
+  const elapsed = t.duration ? chatFormatElapsedShort(t.duration) : '';
+  return `<div class="chat-activity-history-item">${checkHtml} <span class="chat-activity-history-desc">${desc}</span>${outcomeBadge}${elapsed ? `<span class="chat-activity-elapsed">${elapsed}</span>` : ''}</div>`;
+}
+
+function chatRenderToolActivityBlock(toolActivity) {
+  if (!toolActivity || toolActivity.length === 0) return '';
+  const summary = chatBuildActivitySummary(toolActivity);
+  const groups = chatGroupParallelItems(toolActivity);
+  let itemsHtml = '';
+  for (const group of groups) {
+    if (group.type === 'parallel') {
+      itemsHtml += '<div class="chat-parallel-group">';
+      itemsHtml += '<div class="chat-parallel-label">parallel</div>';
+      for (const t of group.items) {
+        itemsHtml += chatRenderCompletedItem(t);
+      }
+      itemsHtml += '</div>';
+    } else {
+      itemsHtml += chatRenderCompletedItem(group.item);
+    }
+  }
+  return `<details class="chat-activity-block">
+    <summary class="chat-activity-toggle">Activity: ${summary}</summary>
+    <div class="chat-activity-block-content">${itemsHtml}</div>
+  </details>`;
+}
+
+/** Render a session-level activity overview dashboard, aggregating toolActivity from all assistant messages. */
+function chatRenderSessionOverview(messages) {
+  if (!messages || messages.length === 0) return '';
+  const allActivity = [];
+  for (const msg of messages) {
+    if (msg.role === 'assistant' && msg.toolActivity && msg.toolActivity.length > 0) {
+      for (const t of msg.toolActivity) allActivity.push(t);
+    }
+  }
+  if (allActivity.length === 0) return '';
+
+  // Counts
+  const totalOps = allActivity.length;
+  const agents = allActivity.filter(t => t.isAgent);
+  const tools = allActivity.filter(t => !t.isAgent);
+  const totalDuration = allActivity.reduce((sum, t) => sum + (t.duration || 0), 0);
+
+  // Tool type breakdown
+  const toolCounts = {};
+  for (const t of tools) {
+    const name = t.tool || 'Unknown';
+    toolCounts[name] = (toolCounts[name] || 0) + 1;
+  }
+  const sortedTools = Object.entries(toolCounts).sort((a, b) => b[1] - a[1]);
+  const maxCount = sortedTools.length > 0 ? sortedTools[0][1] : 1;
+
+  // Status breakdown
+  let successCount = 0, errorCount = 0, warningCount = 0;
+  for (const t of allActivity) {
+    if (t.status === 'success') successCount++;
+    else if (t.status === 'error') errorCount++;
+    else if (t.status === 'warning') warningCount++;
+  }
+
+  // Build summary line
+  const summaryParts = [`${totalOps} ops`];
+  if (agents.length > 0) summaryParts.push(`${agents.length} agent${agents.length !== 1 ? 's' : ''}`);
+  if (totalDuration > 0) summaryParts.push(chatFormatElapsedShort(totalDuration) + ' total');
+
+  // Build bar chart rows
+  let barsHtml = '';
+  for (const [tool, count] of sortedTools) {
+    const pct = Math.max(4, Math.round((count / maxCount) * 100));
+    barsHtml += `<div class="chat-overview-bar-row">
+      <span class="chat-overview-bar-label">${esc(tool)}</span>
+      <div class="chat-overview-bar-track"><div class="chat-overview-bar-fill" style="width:${pct}%"></div></div>
+      <span class="chat-overview-bar-count">${count}</span>
+    </div>`;
+  }
+
+  // Status pills
+  let statusHtml = '';
+  if (successCount || errorCount || warningCount) {
+    statusHtml = '<div class="chat-overview-status-row">';
+    if (successCount) statusHtml += `<span class="chat-outcome-badge chat-outcome-success">${successCount} success</span>`;
+    if (errorCount) statusHtml += `<span class="chat-outcome-badge chat-outcome-error">${errorCount} error</span>`;
+    if (warningCount) statusHtml += `<span class="chat-outcome-badge chat-outcome-warning">${warningCount} warning</span>`;
+    statusHtml += '</div>';
+  }
+
+  // Agent list
+  let agentsHtml = '';
+  if (agents.length > 0) {
+    agentsHtml = '<div class="chat-overview-agents">';
+    for (const a of agents) {
+      const agentType = esc(a.subagentType || 'agent');
+      const elapsed = a.duration ? chatFormatElapsedShort(a.duration) : '';
+      const desc = a.description ? escWithCode(a.description) : '';
+      const outcomeBadge = chatRenderOutcomeBadge(a);
+      agentsHtml += `<div class="chat-overview-agent-row">
+        <span class="chat-agent-type">${agentType}</span>
+        ${desc ? `<span class="chat-overview-agent-desc">${desc}</span>` : ''}
+        ${outcomeBadge}
+        ${elapsed ? `<span class="chat-activity-elapsed">${elapsed}</span>` : ''}
+      </div>`;
+    }
+    agentsHtml += '</div>';
+  }
+
+  return `<details class="chat-session-overview">
+    <summary class="chat-session-overview-toggle">Session Overview: ${summaryParts.join(' \u00b7 ')}</summary>
+    <div class="chat-session-overview-content">
+      ${statusHtml}
+      ${barsHtml ? `<div class="chat-overview-bars">${barsHtml}</div>` : ''}
+      ${agentsHtml ? `<div class="chat-overview-section"><div class="chat-overview-section-title">Agents</div>${agentsHtml}</div>` : ''}
+    </div>
   </details>`;
 }
 
@@ -1513,9 +1741,20 @@ async function chatSendMessage() {
 
           if (event.type === 'thinking') {
             st.assistantThinking += event.content;
-            // Archive active tools/agents to history so spinners stop but history persists
-            if (st.activeTools.length || st.activeAgents.length) {
-              chatArchiveActiveState(st);
+            // Note: do NOT archive active tools here — turn_complete handles that.
+            // Archiving on thinking prematurely kills agent spinners and timers.
+            if (isStillActive) {
+              chatUpdateStreamingContent(st.streamingMsgEl, st);
+            }
+          } else if (event.type === 'tool_outcomes') {
+            // Merge tool outcomes into active tools by matching toolUseId → id
+            for (const outcome of (event.outcomes || [])) {
+              const match = st.activeTools.find(t => t.id === outcome.toolUseId)
+                || st.activeAgents.find(a => a.id === outcome.toolUseId);
+              if (match) {
+                match.outcome = outcome.outcome;
+                match.status = outcome.status;
+              }
             }
             if (isStillActive) {
               chatUpdateStreamingContent(st.streamingMsgEl, st);
@@ -1532,20 +1771,19 @@ async function chatSendMessage() {
               // Pending interaction (plan approval, user question) — don't overwrite
               // dialog with streaming text. Just accumulate assistantContent silently.
             } else {
-              if (st.activeTools.length || st.activeAgents.length) chatArchiveActiveState(st);
               if (isStillActive) {
                 chatUpdateStreamingContent(st.streamingMsgEl, st);
               }
             }
           } else if (event.type === 'tool_activity') {
             if (event.isAgent) {
-              st.activeAgents.push({ subagentType: event.subagentType || 'agent', description: event.description || '', startTime: event.startTime || Date.now() });
+              st.activeAgents.push({ subagentType: event.subagentType || 'agent', description: event.description || '', startTime: event.startTime || Date.now(), id: event.id, isAgent: true, parentAgentId: event.parentAgentId || null });
             } else if (event.isPlanMode) {
               if (event.planAction === 'enter') st.planModeActive = true;
               else if (event.planAction === 'exit') st.planModeActive = false;
             }
             if (!event.isAgent && !event.isPlanMode) {
-              st.activeTools.push({ tool: event.tool, description: event.description || '', startTime: event.startTime || Date.now() });
+              st.activeTools.push({ tool: event.tool, description: event.description || '', startTime: event.startTime || Date.now(), id: event.id, parentAgentId: event.parentAgentId || null });
             }
             // Track pending interactions for restoration on switch-back
             if (event.isPlanMode && event.planAction === 'exit') {
@@ -1577,6 +1815,8 @@ async function chatSendMessage() {
             st.assistantContent = '';
             st.assistantThinking = '';
             chatArchiveActiveState(st);
+            // Keep toolHistory and agentHistory — they're needed for rendering
+            // sub-tasks under agent cards. They'll be cleared when streaming ends.
             st.planModeActive = false;
             st.pendingInteraction = savedInteraction;
             if (isStillActive && chatActiveConv) {
@@ -1660,6 +1900,74 @@ function chatAppendStreamingMessage() {
   return msgEl;
 }
 
+/** Group sorted items by agent: each agent gets its own group with sub-tools assigned via parentAgentId.
+ *  Agents ALWAYS get their own top-level card — even sub-agents with parentAgentId.
+ *  Only non-agent tools are nested into their parent agent's sub-activities panel. */
+function chatGroupItemsByAgent(items) {
+  const groups = [];
+  const agentGroupMap = new Map(); // agentId → group object
+  let currentStandalone = null;
+
+  for (const item of items) {
+    if (item._kind === 'agent' || item.isAgent) {
+      // Every agent gets its own card — never nest agents inside other agents
+      currentStandalone = null;
+      const group = { type: 'agent', agent: item, items: [] };
+      groups.push(group);
+      if (item.id) agentGroupMap.set(item.id, group);
+    } else if (item.parentAgentId && agentGroupMap.has(item.parentAgentId)) {
+      // Sub-tool with explicit parent — assign to parent agent's sub-activities
+      currentStandalone = null;
+      agentGroupMap.get(item.parentAgentId).items.push(item);
+    } else {
+      // No parentAgentId — fall back to last agent group (chronological)
+      let lastAgentGroup = null;
+      for (let i = groups.length - 1; i >= 0; i--) {
+        if (groups[i].type === 'agent') { lastAgentGroup = groups[i]; break; }
+      }
+      if (lastAgentGroup) {
+        currentStandalone = null;
+        lastAgentGroup.items.push(item);
+      } else {
+        if (!currentStandalone) {
+          currentStandalone = { type: 'standalone', items: [] };
+          groups.push(currentStandalone);
+        }
+        currentStandalone.items.push(item);
+      }
+    }
+  }
+  return groups;
+}
+
+/** Render a single streaming item (tool or agent) — either running (spinner) or completed (check). */
+function chatRenderStreamingItem(item) {
+  if (item.completed) {
+    return chatRenderCompletedItem(item);
+  }
+  // Running item
+  if (item._kind === 'agent' || item.isAgent) {
+    const agentType = esc(item.subagentType || 'agent');
+    const agentDesc = item.description ? escWithCode(item.description) : '';
+    const initialElapsed = item.startTime ? chatFormatElapsed(Date.now() - item.startTime) : '';
+    return `<div class="chat-agent-card">
+      <div class="chat-agent-spinner" style="animation-delay:-${Date.now() % 800}ms"></div>
+      <div class="chat-agent-card-header">
+        <span class="chat-agent-type">${agentType}</span>
+        ${agentDesc ? `<span class="chat-agent-card-desc">${agentDesc}</span>` : ''}
+      </div>
+      ${initialElapsed ? `<span class="chat-agent-timer-live">${initialElapsed}</span>` : ''}
+    </div>`;
+  }
+  const desc = item.description ? escWithCode(item.description) : esc(item.tool || 'Working');
+  const initialElapsed = item.startTime ? chatFormatElapsed(Date.now() - item.startTime) : '';
+  return `<div class="chat-activity-indicator">
+    <div class="chat-typing"><div class="chat-typing-dot"></div><div class="chat-typing-dot"></div><div class="chat-typing-dot"></div></div>
+    <span class="chat-activity-label">${desc}</span>
+    ${initialElapsed ? `<span class="chat-activity-timer-live">${initialElapsed}</span>` : ''}
+  </div>`;
+}
+
 /** Unified streaming render — stacks text, thinking, tool history, and active tool in one view. */
 function chatUpdateStreamingContent(msgEl, st) {
   if (!msgEl) return;
@@ -1680,70 +1988,75 @@ function chatUpdateStreamingContent(msgEl, st) {
     html += '<div class="chat-thinking-status">Thinking...</div>';
   }
 
-  // 3. Tool activity (combined history + active, split by completed flag)
-  const tools = chatCombinedTools(st);
-  const agents = chatCombinedAgents(st);
+  // 3. Tool activity — per-agent layout: each agent card followed by its sub-activities
+  const allItems = [
+    ...chatCombinedTools(st).map(t => ({ ...t, _kind: 'tool' })),
+    ...chatCombinedAgents(st).map(a => ({ ...a, _kind: 'agent' })),
+  ].sort((a, b) => (a.startTime || 0) - (b.startTime || 0));
 
-  const completedTools = tools.filter(t => t.completed);
-  const runningTools = tools.filter(t => !t.completed);
-
-  // Completed tools (with checkmarks)
-  if (completedTools.length > 0) {
-    html += '<div class="chat-activity-history">';
-    for (let i = 0; i < completedTools.length; i++) {
-      const t = completedTools[i];
-      const desc = t.description ? escWithCode(t.description) : esc(t.tool || 'Tool');
-      let durationMs = t.duration;
-      if (!durationMs && t.startTime) {
-        const nextStart = (completedTools[i + 1] || runningTools[0])?.startTime || Date.now();
-        durationMs = nextStart - t.startTime;
-      }
-      const elapsed = durationMs ? chatFormatElapsedShort(durationMs) : '';
-      html += `<div class="chat-activity-history-item"><span class="chat-activity-check">✓</span> <span class="chat-activity-history-desc">${desc}</span>${elapsed ? `<span class="chat-activity-elapsed">${elapsed}</span>` : ''}</div>`;
+  // Fill in durations for completed items that don't have one yet
+  for (let i = 0; i < allItems.length; i++) {
+    if (allItems[i].completed && !allItems[i].duration && allItems[i].startTime) {
+      const nextStart = allItems[i + 1]?.startTime || Date.now();
+      allItems[i] = { ...allItems[i], duration: nextStart - allItems[i].startTime };
     }
-    html += '</div>';
   }
 
-  // Active tools (with spinners — all of them, not just the last)
-  for (const tool of runningTools) {
-    const desc = tool.description ? escWithCode(tool.description) : esc(tool.tool || 'Working');
-    const initialElapsed = tool.startTime ? chatFormatElapsed(Date.now() - tool.startTime) : '';
-    html += `<div class="chat-activity-indicator">
-      <div class="chat-typing"><div class="chat-typing-dot"></div><div class="chat-typing-dot"></div><div class="chat-typing-dot"></div></div>
-      <span class="chat-activity-label">${desc}</span>
-      ${initialElapsed ? `<span class="chat-activity-timer-live">${initialElapsed}</span>` : ''}
+  // Group items: standalone tools (before any agent), then agent + following tools
+  const itemGroups = chatGroupItemsByAgent(allItems);
+
+  // Helper: render a single agent card (spinner or checkmark)
+  function renderAgentCard(agent) {
+    const isRunning = !agent.completed;
+    const agentType = esc(agent.subagentType || 'agent');
+    const agentDesc = agent.description ? escWithCode(agent.description) : '';
+    const elapsed = isRunning
+      ? (agent.startTime ? chatFormatElapsed(Date.now() - agent.startTime) : '')
+      : (agent.duration ? chatFormatElapsedShort(agent.duration) : '');
+    const timerClass = isRunning ? 'chat-agent-timer-live' : 'chat-activity-elapsed';
+    return `<div class="chat-agent-card${isRunning ? '' : ' chat-agent-card-done'}">
+      ${isRunning
+        ? `<div class="chat-agent-spinner" style="animation-delay:-${Date.now() % 800}ms"></div>`
+        : chatRenderStatusCheck(agent)}
+      <div class="chat-agent-card-header">
+        <span class="chat-agent-type">${agentType}</span>
+        ${agentDesc ? `<span class="chat-agent-card-desc">${agentDesc}</span>` : ''}
+      </div>
+      ${chatRenderOutcomeBadge(agent)}
+      ${elapsed ? `<span class="${timerClass}">${elapsed}</span>` : ''}
     </div>`;
   }
 
-  // Agent cards (completed + active)
-  if (agents.length > 0) {
-    html += '<div class="chat-agent-cards">';
-    for (const agent of agents) {
-      const agentType = esc(agent.subagentType || 'agent');
-      const agentDesc = agent.description ? escWithCode(agent.description) : '';
-      if (agent.completed) {
-        const elapsed = agent.duration ? chatFormatElapsedShort(agent.duration) : '';
-        html += `<div class="chat-agent-card chat-agent-card-done">
-          <span class="chat-activity-check">✓</span>
-          <div class="chat-agent-card-header">
-            <span class="chat-agent-type">${agentType}</span>
-            ${agentDesc ? `<span class="chat-agent-card-desc">${agentDesc}</span>` : ''}
-          </div>
-          ${elapsed ? `<span class="chat-activity-elapsed">${elapsed}</span>` : ''}
-        </div>`;
-      } else {
-        const initialElapsed = agent.startTime ? chatFormatElapsed(Date.now() - agent.startTime) : '';
-        html += `<div class="chat-agent-card">
-          <div class="chat-agent-spinner"></div>
-          <div class="chat-agent-card-header">
-            <span class="chat-agent-type">${agentType}</span>
-            ${agentDesc ? `<span class="chat-agent-card-desc">${agentDesc}</span>` : ''}
-          </div>
-          ${initialElapsed ? `<span class="chat-agent-timer-live">${initialElapsed}</span>` : ''}
-        </div>`;
+  for (const group of itemGroups) {
+    if (group.type === 'standalone') {
+      for (const item of group.items) {
+        html += chatRenderStreamingItem(item);
+      }
+    } else if (group.type === 'agent') {
+      html += renderAgentCard(group.agent);
+      if (group.items.length > 0) {
+        html += '<div class="chat-agent-subactivities">';
+        for (const item of group.items) {
+          html += chatRenderStreamingItem(item);
+        }
+        html += '</div>';
+      }
+    } else if (group.type === 'parallel-agents') {
+      // Legacy path — should not occur with parentAgentId grouping
+      for (const agent of group.agents) {
+        html += renderAgentCard(agent);
       }
     }
-    html += '</div>';
+  }
+
+  // Post-completion processing indicator: tools/agents finished but model still working
+  const hasCompletedItems = st.toolHistory.length > 0 || st.agentHistory.length > 0;
+  const hasRunningItems = st.activeTools.length > 0 || st.activeAgents.length > 0;
+  if (hasCompletedItems && !hasRunningItems && !st.assistantContent) {
+    html += `<div class="chat-activity-indicator">
+      <div class="chat-typing"><div class="chat-typing-dot"></div><div class="chat-typing-dot"></div><div class="chat-typing-dot"></div></div>
+      <span class="chat-activity-label">Processing...</span>
+    </div>`;
   }
 
   // Plan mode banner
@@ -1763,21 +2076,35 @@ function chatUpdateStreamingContent(msgEl, st) {
 
   contentEl.innerHTML = html;
   if (st.assistantContent || st.assistantThinking) chatHighlightCode(contentEl);
+  // Auto-scroll each agent sub-activity panel to show latest item
+  contentEl.querySelectorAll('.chat-agent-subactivities').forEach(el => {
+    el.scrollTop = el.scrollHeight;
+  });
   chatScrollToBottom();
 }
 
-/** Archive active tools/agents to history before clearing, preserving elapsed durations. */
+/** Archive active tools/agents to history before clearing, preserving elapsed durations.
+ *  Agents are only archived once they have received their tool_outcomes (outcome/status set).
+ *  This prevents sub-tool turn_complete events from prematurely archiving a still-running agent. */
 function chatArchiveActiveState(st) {
   const now = Date.now();
   for (const tool of st.activeTools) {
     st.toolHistory.push({ ...tool, completed: true, duration: tool.startTime ? now - tool.startTime : null });
   }
   st.activeTools = [];
+  const stillRunning = [];
   for (const agent of st.activeAgents) {
-    st.agentHistory.push({ ...agent, completed: true, duration: agent.startTime ? now - agent.startTime : null });
+    if (agent.outcome !== undefined || agent.status !== undefined) {
+      st.agentHistory.push({ ...agent, completed: true, duration: agent.startTime ? now - agent.startTime : null });
+    } else {
+      stillRunning.push(agent);
+    }
   }
-  st.activeAgents = [];
-  if (st.activityTimerInterval) { clearInterval(st.activityTimerInterval); st.activityTimerInterval = null; }
+  st.activeAgents = stillRunning;
+  // Only clear timer if no active items remain
+  if (st.activeAgents.length === 0 && st.activeTools.length === 0) {
+    if (st.activityTimerInterval) { clearInterval(st.activityTimerInterval); st.activityTimerInterval = null; }
+  }
 }
 
 /** Build combined tools array (history + active) for rendering. */
@@ -1817,20 +2144,10 @@ function chatStartActivityTimer(convId) {
       state.activityTimerInterval = null;
       return;
     }
-    // Update all active tool timers
-    const toolTimerEls = st.streamingMsgEl.querySelectorAll('.chat-activity-timer-live');
-    toolTimerEls.forEach((el, idx) => {
-      if (idx < st.activeTools.length && st.activeTools[idx].startTime) {
-        el.textContent = chatFormatElapsed(Date.now() - st.activeTools[idx].startTime);
-      }
-    });
-    // Update agent card timers
-    const agentTimerEls = st.streamingMsgEl.querySelectorAll('.chat-agent-timer-live');
-    agentTimerEls.forEach((el, idx) => {
-      if (idx < st.activeAgents.length && st.activeAgents[idx].startTime) {
-        el.textContent = chatFormatElapsed(Date.now() - st.activeAgents[idx].startTime);
-      }
-    });
+    // Re-render to update all timer values (avoids DOM index mismatch issues)
+    if (st.activeTools.length > 0 || st.activeAgents.length > 0) {
+      chatUpdateStreamingContent(st.streamingMsgEl, st);
+    }
   }, 1000);
 }
 
@@ -2168,13 +2485,14 @@ async function chatViewSession(sessionNumber) {
       const rendered = chatRenderMarkdown(msg.content);
       const caps = msg.backend ? getBackendCapabilities(msg.backend) : {};
       const thinkingHtml = msg.thinking && caps.thinking !== false ? chatRenderThinkingBlock(msg.thinking, false) : '';
+      const toolActivityHtml = !isUser && msg.toolActivity ? chatRenderToolActivityBlock(msg.toolActivity) : '';
       msgsHtml += `
         <div class="chat-msg ${esc(msg.role)}">
           <div class="chat-msg-wrapper">
             <div class="chat-msg-avatar${avatarClass}">${avatar}</div>
             <div class="chat-msg-body">
               <div class="chat-msg-role">${roleLabel} ${backendLabel}</div>
-              <div class="chat-msg-content">${thinkingHtml}${rendered}</div>
+              <div class="chat-msg-content">${thinkingHtml}${toolActivityHtml}${rendered}</div>
             </div>
           </div>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
 <title>Agent Cockpit</title>
 <link rel="icon" type="image/svg+xml" href="favicon.svg">
 <link id="hljs-theme" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="styles.css?v=4">
 </head>
 <body class="chat-active">
 
@@ -84,6 +84,6 @@
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/12.0.2/marked.min.js"></script>
-<script src="app.js"></script>
+<script src="app.js?v=4"></script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -18,6 +18,8 @@
     --accent-backlog: #d946ef;
     --accent-coaching: #e11d48;
     --done:      #16a34a;
+    --error:     #ef4444;
+    --warning:   #f59e0b;
     --todo:      #d97706;
     --inprog:    #2563eb;
     --waiting:   #d97706;
@@ -64,6 +66,8 @@
     --accent-backlog: #e879f9;
     --accent-coaching: #fb7185;
     --done:      #4ade80;
+    --error:     #f87171;
+    --warning:   #fbbf24;
     --todo:      #fbbf24;
     --inprog:    #60a5fa;
     --waiting:   #fbbf24;
@@ -848,6 +852,100 @@
     font-style: italic;
   }
 
+  /* Tool activity block on completed messages (collapsible) */
+  .chat-activity-block {
+    margin: 0 0 12px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface2);
+    overflow: hidden;
+  }
+  .chat-activity-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--muted);
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+  }
+  .chat-activity-toggle::-webkit-details-marker { display: none; }
+  .chat-activity-toggle::before {
+    content: '\25B6';
+    font-size: 9px;
+    transition: transform 0.15s;
+  }
+  .chat-activity-block[open] > .chat-activity-toggle::before {
+    transform: rotate(90deg);
+  }
+  .chat-activity-block-content {
+    padding: 4px 12px 10px;
+    border-top: 1px solid var(--border);
+    max-height: 300px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .chat-activity-block-content .chat-agent-card {
+    margin: 2px 0;
+  }
+
+  /* Tool outcome badges */
+  .chat-outcome-badge {
+    font-size: 10px;
+    padding: 1px 5px;
+    border-radius: 4px;
+    font-weight: 500;
+    white-space: nowrap;
+    flex-shrink: 0;
+    margin-left: 4px;
+  }
+  .chat-outcome-success {
+    color: var(--done);
+    background: color-mix(in srgb, var(--done) 12%, transparent);
+  }
+  .chat-outcome-error {
+    color: var(--error, #ef4444);
+    background: color-mix(in srgb, var(--error, #ef4444) 12%, transparent);
+  }
+  .chat-outcome-warning {
+    color: var(--warning, #f59e0b);
+    background: color-mix(in srgb, var(--warning, #f59e0b) 12%, transparent);
+  }
+  .chat-status-error {
+    color: var(--error, #ef4444) !important;
+  }
+  .chat-status-warning {
+    color: var(--warning, #f59e0b) !important;
+  }
+
+  /* Per-agent scrollable sub-activity panel */
+  .chat-agent-subactivities {
+    max-height: 120px;
+    overflow-y: auto;
+    border: 1px solid var(--border);
+    border-top: none;
+    border-radius: 0 0 8px 8px;
+    padding: 4px 8px 4px 30px;
+    margin-top: -1px;
+    margin-bottom: 6px;
+    background: var(--surface);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .chat-agent-subactivities .chat-activity-indicator {
+    padding: 2px 0;
+    font-size: 12px;
+  }
+  .chat-agent-subactivities .chat-activity-history-item {
+    font-size: 11px;
+  }
+
   /* Tool activity indicator */
   .chat-activity-indicator {
     display: flex;
@@ -930,6 +1028,14 @@
     border-radius: 8px;
     background: var(--surface2);
   }
+  /* Flat bottom when sub-activity panel follows */
+  .chat-agent-card + .chat-agent-subactivities {
+    /* already handled by margin-top: -1px on subactivities */
+  }
+  .chat-agent-card:has(+ .chat-agent-subactivities) {
+    border-radius: 8px 8px 0 0;
+    margin-bottom: 0;
+  }
   .chat-agent-card-header {
     display: flex;
     align-items: center;
@@ -980,6 +1086,158 @@
   }
   .chat-agent-card-done .chat-activity-check {
     flex-shrink: 0;
+  }
+
+  /* Parallel group indicator */
+  .chat-parallel-group {
+    border-left: 2px solid var(--accent-agents);
+    padding-left: 8px;
+    margin: 2px 0;
+  }
+  .chat-parallel-group-active {
+    border-left-style: dashed;
+  }
+  .chat-parallel-label {
+    font-size: 9px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--accent-agents);
+    margin-bottom: 2px;
+  }
+
+  /* Expandable agent cards */
+  .chat-agent-expandable {
+    cursor: pointer;
+  }
+  .chat-agent-expandable > .chat-agent-card-summary {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    list-style: none;
+    cursor: pointer;
+  }
+  .chat-agent-expandable > .chat-agent-card-summary::-webkit-details-marker { display: none; }
+  .chat-agent-card-details {
+    padding: 6px 12px 8px 30px;
+    font-size: 12px;
+    color: var(--muted);
+    border-top: 1px solid var(--border);
+  }
+  .chat-agent-detail-outcome {
+    display: block;
+    margin-top: 2px;
+  }
+
+  /* Session activity overview dashboard */
+  .chat-session-overview {
+    margin: 0 0 16px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface2);
+    overflow: hidden;
+  }
+  .chat-session-overview-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--muted);
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+  }
+  .chat-session-overview-toggle::-webkit-details-marker { display: none; }
+  .chat-session-overview-toggle::before {
+    content: '\25B6';
+    font-size: 9px;
+    transition: transform 0.15s;
+  }
+  .chat-session-overview[open] > .chat-session-overview-toggle::before {
+    transform: rotate(90deg);
+  }
+  .chat-session-overview-content {
+    padding: 8px 12px 12px;
+    border-top: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .chat-overview-status-row {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .chat-overview-bars {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .chat-overview-bar-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 11px;
+  }
+  .chat-overview-bar-label {
+    width: 60px;
+    text-align: right;
+    color: var(--muted);
+    font-weight: 500;
+    flex-shrink: 0;
+  }
+  .chat-overview-bar-track {
+    flex: 1;
+    height: 6px;
+    background: var(--border);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+  .chat-overview-bar-fill {
+    height: 100%;
+    background: var(--accent-chat);
+    border-radius: 3px;
+    transition: width 0.2s;
+  }
+  .chat-overview-bar-count {
+    width: 24px;
+    text-align: right;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+  }
+  .chat-overview-section {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .chat-overview-section-title {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--muted);
+  }
+  .chat-overview-agents {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .chat-overview-agent-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--muted);
+  }
+  .chat-overview-agent-desc {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   /* Plan mode banner */

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -399,6 +399,23 @@ function createChatRouter({ chatService, backendRegistry, updateService }) {
     let pendingPlanContent = '';  // Plan file content from Write tool (Claude Code specific)
     let titleUpdateTriggered = false;
     let titleUpdatePromise = null;
+    let toolActivityAccumulator = [];  // Accumulate tool_activity events for persistence
+
+    // Compute durations from inter-event timing for persisted tool activity
+    function computeToolDurations(activities) {
+      if (!activities.length) return [];
+      const now = Date.now();
+      return activities.map((t, i) => {
+        const nextStart = activities[i + 1]?.startTime || now;
+        const duration = t.startTime ? nextStart - t.startTime : null;
+        const entry = { tool: t.tool, description: t.description, id: t.id, duration, startTime: t.startTime };
+        if (t.isAgent) { entry.isAgent = true; entry.subagentType = t.subagentType; }
+        if (t.parentAgentId) { entry.parentAgentId = t.parentAgentId; }
+        if (t.outcome) { entry.outcome = t.outcome; }
+        if (t.status) { entry.status = t.status; }
+        return entry;
+      });
+    }
 
     // Helper: trigger async title update after first assistant message in a new session
     function maybeUpdateTitle() {
@@ -433,11 +450,23 @@ function createChatRouter({ chatService, backendRegistry, updateService }) {
             if (event.streaming) {
               res.write(`data: ${JSON.stringify({ type: 'thinking', content: event.content })}\n\n`);
             }
+          } else if (event.type === 'tool_outcomes') {
+            // Merge tool outcomes into the accumulator by matching tool_use_id
+            for (const outcome of (event.outcomes || [])) {
+              const match = toolActivityAccumulator.find(t => t.id === outcome.toolUseId);
+              if (match) {
+                match.outcome = outcome.outcome;
+                match.status = outcome.status;
+              }
+            }
+            // Forward to frontend for live display
+            res.write(`data: ${JSON.stringify({ type: 'tool_outcomes', outcomes: event.outcomes })}\n\n`);
           } else if (event.type === 'turn_boundary') {
             // Tool use happened — save accumulated text as an intermediate message
+            const turnToolActivity = computeToolDurations(toolActivityAccumulator);
             if (hasStreamingDeltas && fullResponse.trim()) {
-              console.log(`[chat] Saving intermediate message for conv=${convId}, len=${fullResponse.trim().length}`);
-              const intermediateMsg = await chatService.addMessage(convId, 'assistant', fullResponse.trim(), backend, thinkingText.trim() || null);
+              console.log(`[chat] Saving intermediate message for conv=${convId}, len=${fullResponse.trim().length}, tools=${turnToolActivity.length}`);
+              const intermediateMsg = await chatService.addMessage(convId, 'assistant', fullResponse.trim(), backend, thinkingText.trim() || null, turnToolActivity.length > 0 ? turnToolActivity : undefined);
               res.write(`data: ${JSON.stringify({ type: 'assistant_message', message: intermediateMsg })}\n\n`);
               maybeUpdateTitle();
             }
@@ -446,6 +475,7 @@ function createChatRouter({ chatService, backendRegistry, updateService }) {
             fullResponse = '';
             thinkingText = '';
             hasStreamingDeltas = false;
+            toolActivityAccumulator = [];
           } else if (event.type === 'tool_activity') {
             // Track plan file content written by Claude Code's Write tool
             if (event.isPlanFile && event.planContent) {
@@ -456,7 +486,24 @@ function createChatRouter({ chatService, backendRegistry, updateService }) {
             if (rest.isPlanMode && rest.planAction === 'exit' && pendingPlanContent) {
               rest.planContent = pendingPlanContent;
             }
+            // parentAgentId is set by claudeCode.js via task_progress events —
+            // no heuristic state machine needed here.
+            if (rest.isAgent && rest.id) {
+              console.log(`[chat] AGENT ${rest.id} parentAgentId=${rest.parentAgentId || 'none'}`);
+            }
             res.write(`data: ${JSON.stringify({ type: 'tool_activity', ...rest })}\n\n`);
+            // Accumulate tool activity for persistence (skip plan mode and question meta-events)
+            if (!event.isPlanMode && !event.isQuestion) {
+              toolActivityAccumulator.push({
+                tool: rest.tool,
+                description: rest.description || '',
+                id: rest.id || null,
+                isAgent: rest.isAgent || undefined,
+                subagentType: rest.subagentType || undefined,
+                parentAgentId: rest.parentAgentId || undefined,
+                startTime: Date.now(),
+              });
+            }
           } else if (event.type === 'result') {
             resultText = event.content;
           } else if (event.type === 'usage') {
@@ -472,24 +519,27 @@ function createChatRouter({ chatService, backendRegistry, updateService }) {
             // Save remaining text or result as the final message
             // Check if the accumulated text is actually an API error
             const apiErrPattern = /^API Error:\s*\d{3}\s/;
+            const finalToolActivity = computeToolDurations(toolActivityAccumulator);
+            const finalToolActivityArg = finalToolActivity.length > 0 ? finalToolActivity : undefined;
             if (hasStreamingDeltas && fullResponse.trim()) {
               if (apiErrPattern.test(fullResponse.trim())) {
                 console.log(`[chat] Stream done for conv=${convId}, detected API error in text — not saving as message`);
                 res.write(`data: ${JSON.stringify({ type: 'error', error: fullResponse.trim() })}\n\n`);
               } else {
-                console.log(`[chat] Stream done for conv=${convId}, saving final segment len=${fullResponse.trim().length}`);
-                const assistantMsg = await chatService.addMessage(convId, 'assistant', fullResponse.trim(), backend, thinkingText.trim() || null);
+                console.log(`[chat] Stream done for conv=${convId}, saving final segment len=${fullResponse.trim().length}, tools=${finalToolActivity.length}`);
+                const assistantMsg = await chatService.addMessage(convId, 'assistant', fullResponse.trim(), backend, thinkingText.trim() || null, finalToolActivityArg);
                 res.write(`data: ${JSON.stringify({ type: 'assistant_message', message: assistantMsg })}\n\n`);
                 maybeUpdateTitle();
               }
             } else if (resultText && resultText.trim()) {
-              console.log(`[chat] Stream done for conv=${convId}, saving result len=${resultText.trim().length}`);
-              const assistantMsg = await chatService.addMessage(convId, 'assistant', resultText.trim(), backend, thinkingText.trim() || null);
+              console.log(`[chat] Stream done for conv=${convId}, saving result len=${resultText.trim().length}, tools=${finalToolActivity.length}`);
+              const assistantMsg = await chatService.addMessage(convId, 'assistant', resultText.trim(), backend, thinkingText.trim() || null, finalToolActivityArg);
               res.write(`data: ${JSON.stringify({ type: 'assistant_message', message: assistantMsg })}\n\n`);
               maybeUpdateTitle();
             } else {
               console.log(`[chat] Stream done for conv=${convId}, no content to save`);
             }
+            toolActivityAccumulator = [];
             // Wait for pending title update before closing the stream
             if (titleUpdatePromise) await titleUpdatePromise;
             res.write(`data: ${JSON.stringify({ type: 'done' })}\n\n`);

--- a/src/services/backends/claudeCode.js
+++ b/src/services/backends/claudeCode.js
@@ -42,6 +42,96 @@ function shortenPath(filePath) {
   return '.../' + parts.slice(-2).join('/');
 }
 
+/**
+ * Extract a short outcome summary from a tool_result content string.
+ * Returns { outcome: string, status: 'success'|'error'|'warning'|null } or null.
+ */
+function extractToolOutcome(toolName, content) {
+  if (content == null) return null;
+  const text = typeof content === 'string' ? content : JSON.stringify(content);
+  if (!text) return null;
+
+  // Bash: detect exit codes
+  if (toolName === 'Bash') {
+    // Claude Code tool results often include exit code info
+    const exitMatch = text.match(/exit (?:code|status)[:\s]*(\d+)/i) || text.match(/exited with (\d+)/i);
+    if (exitMatch) {
+      const code = parseInt(exitMatch[1], 10);
+      return { outcome: `exit ${code}`, status: code === 0 ? 'success' : 'error' };
+    }
+    // Check for common error patterns
+    if (/error|ENOENT|command not found|permission denied/i.test(text.slice(0, 500))) {
+      return { outcome: 'error', status: 'error' };
+    }
+    return { outcome: 'done', status: 'success' };
+  }
+
+  // Grep: count matches
+  if (toolName === 'Grep') {
+    const lines = text.split('\n').filter(l => l.trim());
+    if (text.includes('No matches found') || lines.length === 0) {
+      return { outcome: '0 matches', status: 'warning' };
+    }
+    // Count non-empty lines as approximate matches
+    return { outcome: `${lines.length} match${lines.length !== 1 ? 'es' : ''}`, status: 'success' };
+  }
+
+  // Glob: count files
+  if (toolName === 'Glob') {
+    const lines = text.split('\n').filter(l => l.trim());
+    if (lines.length === 0 || text.includes('No files found') || text.includes('No matches')) {
+      return { outcome: '0 files', status: 'warning' };
+    }
+    return { outcome: `${lines.length} file${lines.length !== 1 ? 's' : ''}`, status: 'success' };
+  }
+
+  // Read: success or not found
+  if (toolName === 'Read') {
+    if (/not found|does not exist|ENOENT|no such file/i.test(text.slice(0, 200))) {
+      return { outcome: 'not found', status: 'error' };
+    }
+    return { outcome: 'read', status: 'success' };
+  }
+
+  // Write: success
+  if (toolName === 'Write') {
+    if (/error|failed/i.test(text.slice(0, 200))) {
+      return { outcome: 'failed', status: 'error' };
+    }
+    return { outcome: 'written', status: 'success' };
+  }
+
+  // Edit: success or no match
+  if (toolName === 'Edit') {
+    if (/not found|no match|not unique/i.test(text.slice(0, 300))) {
+      return { outcome: 'no match', status: 'error' };
+    }
+    return { outcome: 'edited', status: 'success' };
+  }
+
+  // Agent: success or error
+  if (toolName === 'Agent') {
+    if (/error|failed|exception/i.test(text.slice(0, 300))) {
+      return { outcome: 'error', status: 'error' };
+    }
+    return { outcome: 'done', status: 'success' };
+  }
+
+  // WebSearch/WebFetch
+  if (toolName === 'WebSearch') {
+    const lines = text.split('\n').filter(l => l.trim());
+    return { outcome: `${Math.max(lines.length, 1)} result${lines.length !== 1 ? 's' : ''}`, status: 'success' };
+  }
+  if (toolName === 'WebFetch') {
+    if (/error|failed|404|500|timeout/i.test(text.slice(0, 200))) {
+      return { outcome: 'failed', status: 'error' };
+    }
+    return { outcome: 'fetched', status: 'success' };
+  }
+
+  return null;
+}
+
 function extractToolDetails(block) {
   const name = block.name;
   const input = block.input || {};
@@ -282,6 +372,8 @@ class ClaudeCodeAdapter extends BaseBackendAdapter {
       let resolveWait = null;
       let done = false;
       let stderrOutput = '';
+      const toolNameById = {};  // Track tool names by id for outcome extraction
+      let lastProgressAgentId = null;  // tool_use_id from the most recent task_progress — identifies current agent context
 
       proc.stdout.on('data', (chunk) => {
         const raw = chunk.toString();
@@ -294,7 +386,41 @@ class ClaudeCodeAdapter extends BaseBackendAdapter {
           if (!line.trim()) continue;
           try {
             const event = JSON.parse(line);
-            console.log(`[claudeCode] parsed event type=${event.type}`, event.type === 'content_block_delta' ? `delta.type=${event.delta?.type}` : '');
+            // Debug: log all event types with key fields
+            if (event.type === 'system') {
+              const keys = Object.keys(event).filter(k => k !== 'type').join(',');
+              const sub = event.subtype || event.event || event.tool || '';
+              console.log(`[claudeCode] parsed event type=system subtype=${sub} keys=[${keys}]`);
+            } else if (event.type === 'assistant') {
+              const blocks = (event.message?.content || []).map(b => b.type + (b.name ? ':' + b.name : '')).join(',');
+              console.log(`[claudeCode] parsed event type=assistant blocks=[${blocks}]`);
+            } else {
+              console.log(`[claudeCode] parsed event type=${event.type}`, event.type === 'content_block_delta' ? `delta.type=${event.delta?.type}` : '');
+            }
+            // Handle system events for agent lifecycle (task_started, task_progress, task_notification)
+            if (event.type === 'system' && event.subtype) {
+              if (event.subtype === 'task_progress' && event.tool_use_id) {
+                // Track which agent context we're in — subsequent inner tools belong to this agent
+                lastProgressAgentId = event.tool_use_id;
+              } else if (event.subtype === 'task_notification' && event.tool_use_id) {
+                // Agent task completed — emit tool_outcomes so frontend can mark it done
+                const status = event.status === 'completed' ? 'success' : (event.status || 'success');
+                textQueue.push({
+                  type: 'tool_outcomes',
+                  outcomes: [{
+                    toolUseId: event.tool_use_id,
+                    isError: status === 'error',
+                    outcome: event.summary || event.status || 'done',
+                    status,
+                  }],
+                });
+                // Clear context if this was the active agent
+                if (lastProgressAgentId === event.tool_use_id) {
+                  lastProgressAgentId = null;
+                }
+              }
+            }
+
             if (event.type === 'assistant' && event.message) {
               for (const block of (event.message.content || [])) {
                 if (block.type === 'text' && block.text) {
@@ -302,7 +428,13 @@ class ClaudeCodeAdapter extends BaseBackendAdapter {
                 } else if (block.type === 'thinking' && block.thinking) {
                   textQueue.push({ type: 'thinking', content: block.thinking });
                 } else if (block.type === 'tool_use' && block.name) {
-                  textQueue.push({ type: 'tool_activity', ...extractToolDetails(block) });
+                  if (block.id) toolNameById[block.id] = block.name;
+                  const detail = extractToolDetails(block);
+                  // Attribute inner tools to the agent identified by the most recent task_progress
+                  if (!detail.isAgent && lastProgressAgentId) {
+                    detail.parentAgentId = lastProgressAgentId;
+                  }
+                  textQueue.push({ type: 'tool_activity', ...detail });
                 }
               }
             } else if (event.type === 'content_block_delta') {
@@ -312,6 +444,32 @@ class ClaudeCodeAdapter extends BaseBackendAdapter {
                 textQueue.push({ type: 'thinking', content: event.delta.thinking, streaming: true });
               }
             } else if (event.type === 'user') {
+              // Extract tool outcomes from tool_result blocks before emitting turn_boundary
+              if (event.message && Array.isArray(event.message.content)) {
+                const outcomes = [];
+                for (const block of event.message.content) {
+                  if (block.type === 'tool_result' && block.tool_use_id) {
+                    // content can be string or array of content blocks
+                    let resultContent = '';
+                    if (typeof block.content === 'string') {
+                      resultContent = block.content;
+                    } else if (Array.isArray(block.content)) {
+                      resultContent = block.content.filter(c => c.type === 'text').map(c => c.text).join('\n');
+                    }
+                    const toolName = toolNameById[block.tool_use_id];
+                    const extracted = extractToolOutcome(toolName, resultContent);
+                    outcomes.push({
+                      toolUseId: block.tool_use_id,
+                      isError: block.is_error || false,
+                      outcome: extracted ? extracted.outcome : (block.is_error ? 'error' : null),
+                      status: extracted ? extracted.status : (block.is_error ? 'error' : null),
+                    });
+                  }
+                }
+                if (outcomes.length > 0) {
+                  textQueue.push({ type: 'tool_outcomes', outcomes });
+                }
+              }
               textQueue.push({ type: 'turn_boundary' });
             } else if (event.type === 'result') {
               if (event.result) {
@@ -418,4 +576,4 @@ class ClaudeCodeAdapter extends BaseBackendAdapter {
   }
 }
 
-module.exports = { ClaudeCodeAdapter, extractToolDetails, extractUsage, shortenPath, sanitizeSystemPrompt, isApiError };
+module.exports = { ClaudeCodeAdapter, extractToolDetails, extractToolOutcome, extractUsage, shortenPath, sanitizeSystemPrompt, isApiError };

--- a/src/services/chatService.js
+++ b/src/services/chatService.js
@@ -298,7 +298,7 @@ class ChatService {
 
   // ── Messages ───────────────────────────────────────────────────────────────
 
-  async addMessage(convId, role, content, backend, thinking) {
+  async addMessage(convId, role, content, backend, thinking, toolActivity) {
     const result = await this._getConvFromIndex(convId);
     if (!result) return null;
     const { hash, index, convEntry } = result;
@@ -313,6 +313,10 @@ class ChatService {
 
     if (thinking) {
       msg.thinking = thinking;
+    }
+
+    if (toolActivity && toolActivity.length > 0) {
+      msg.toolActivity = toolActivity;
     }
 
     // Find active session

--- a/test/backends.test.js
+++ b/test/backends.test.js
@@ -3,7 +3,7 @@ const { BackendRegistry } = require('../src/services/backends/registry');
 const { ClaudeCodeAdapter } = require('../src/services/backends/claudeCode');
 
 // extractToolDetails / shortenPath are not public on the class, so access via exports
-const { extractToolDetails, extractUsage, shortenPath, sanitizeSystemPrompt, isApiError } = require('../src/services/backends/claudeCode');
+const { extractToolDetails, extractToolOutcome, extractUsage, shortenPath, sanitizeSystemPrompt, isApiError } = require('../src/services/backends/claudeCode');
 
 const fs = require('fs');
 const vm = require('vm');
@@ -396,6 +396,92 @@ describe('isApiError', () => {
 
   test('rejects partial match', () => {
     expect(isApiError('API Error without code')).toBe(false);
+  });
+});
+
+// ── extractToolOutcome ────────────────────────────────────────────────────
+
+describe('extractToolOutcome', () => {
+  test('returns null for null content', () => {
+    expect(extractToolOutcome('Bash', null)).toBeNull();
+  });
+
+  test('returns null for empty string', () => {
+    expect(extractToolOutcome('Bash', '')).toBeNull();
+  });
+
+  test('Bash: detects exit code 0 as success', () => {
+    const result = extractToolOutcome('Bash', 'Output\nexit code: 0');
+    expect(result).toEqual({ outcome: 'exit 0', status: 'success' });
+  });
+
+  test('Bash: detects non-zero exit code as error', () => {
+    const result = extractToolOutcome('Bash', 'Error\nexit code: 1');
+    expect(result).toEqual({ outcome: 'exit 1', status: 'error' });
+  });
+
+  test('Bash: detects error patterns', () => {
+    const result = extractToolOutcome('Bash', 'command not found: foobar');
+    expect(result).toEqual({ outcome: 'error', status: 'error' });
+  });
+
+  test('Bash: returns done for normal output', () => {
+    const result = extractToolOutcome('Bash', 'some output here');
+    expect(result).toEqual({ outcome: 'done', status: 'success' });
+  });
+
+  test('Grep: counts matches', () => {
+    const result = extractToolOutcome('Grep', 'file1.js:10:match\nfile2.js:20:match\nfile3.js:30:match');
+    expect(result).toEqual({ outcome: '3 matches', status: 'success' });
+  });
+
+  test('Grep: returns 0 matches for no results', () => {
+    const result = extractToolOutcome('Grep', 'No matches found');
+    expect(result).toEqual({ outcome: '0 matches', status: 'warning' });
+  });
+
+  test('Glob: counts files', () => {
+    const result = extractToolOutcome('Glob', 'src/a.js\nsrc/b.js');
+    expect(result).toEqual({ outcome: '2 files', status: 'success' });
+  });
+
+  test('Glob: returns 0 files when empty', () => {
+    const result = extractToolOutcome('Glob', 'No files found');
+    expect(result).toEqual({ outcome: '0 files', status: 'warning' });
+  });
+
+  test('Read: returns read on success', () => {
+    const result = extractToolOutcome('Read', 'file contents here...');
+    expect(result).toEqual({ outcome: 'read', status: 'success' });
+  });
+
+  test('Read: detects not found', () => {
+    const result = extractToolOutcome('Read', 'Error: file not found at /path/to/file');
+    expect(result).toEqual({ outcome: 'not found', status: 'error' });
+  });
+
+  test('Edit: returns edited on success', () => {
+    const result = extractToolOutcome('Edit', 'The file was updated successfully');
+    expect(result).toEqual({ outcome: 'edited', status: 'success' });
+  });
+
+  test('Edit: detects no match', () => {
+    const result = extractToolOutcome('Edit', 'old_string not found in the file');
+    expect(result).toEqual({ outcome: 'no match', status: 'error' });
+  });
+
+  test('Write: returns written on success', () => {
+    const result = extractToolOutcome('Write', 'File created');
+    expect(result).toEqual({ outcome: 'written', status: 'success' });
+  });
+
+  test('Agent: returns done on success', () => {
+    const result = extractToolOutcome('Agent', 'Task completed');
+    expect(result).toEqual({ outcome: 'done', status: 'success' });
+  });
+
+  test('returns null for unknown tool', () => {
+    expect(extractToolOutcome('SomeUnknownTool', 'output')).toBeNull();
   });
 });
 

--- a/test/chat.test.js
+++ b/test/chat.test.js
@@ -327,6 +327,249 @@ describe('SSE tool_activity forwarding', () => {
   });
 });
 
+// ── Tool activity persistence ────────────────────────────────────────────────
+
+describe('Tool activity persistence', () => {
+  test('persists toolActivity on intermediate message at turn_boundary', async () => {
+    const conv = await chatService.createConversation('Test');
+
+    mockBackend.setMockEvents([
+      { type: 'tool_activity', tool: 'Read', description: 'Reading `app.js`', id: 'tool_1' },
+      { type: 'tool_activity', tool: 'Grep', description: 'Searching for `foo`', id: 'tool_2' },
+      { type: 'text', content: 'First response', streaming: true },
+      { type: 'turn_boundary' },
+      { type: 'text', content: 'Second response', streaming: true },
+      { type: 'done' },
+    ]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'test',
+      backend: 'claude-code',
+    });
+
+    await readSSE(`/api/chat/conversations/${conv.id}/stream`);
+
+    const loaded = await chatService.getConversation(conv.id);
+    const assistantMsgs = loaded.messages.filter(m => m.role === 'assistant');
+    // First assistant message (intermediate) should have toolActivity
+    expect(assistantMsgs[0].toolActivity).toBeDefined();
+    expect(assistantMsgs[0].toolActivity).toHaveLength(2);
+    expect(assistantMsgs[0].toolActivity[0].tool).toBe('Read');
+    expect(assistantMsgs[0].toolActivity[1].tool).toBe('Grep');
+  });
+
+  test('persists toolActivity on final message at done', async () => {
+    const conv = await chatService.createConversation('Test');
+
+    mockBackend.setMockEvents([
+      { type: 'tool_activity', tool: 'Bash', description: 'Running tests', id: 'tool_1' },
+      { type: 'text', content: 'Tests passed', streaming: true },
+      { type: 'done' },
+    ]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'test',
+      backend: 'claude-code',
+    });
+
+    await readSSE(`/api/chat/conversations/${conv.id}/stream`);
+
+    const loaded = await chatService.getConversation(conv.id);
+    const assistantMsgs = loaded.messages.filter(m => m.role === 'assistant');
+    expect(assistantMsgs[0].toolActivity).toBeDefined();
+    expect(assistantMsgs[0].toolActivity).toHaveLength(1);
+    expect(assistantMsgs[0].toolActivity[0].tool).toBe('Bash');
+    expect(assistantMsgs[0].toolActivity[0].duration).toBeGreaterThanOrEqual(0);
+    expect(assistantMsgs[0].toolActivity[0].startTime).toBeDefined();
+  });
+
+  test('does not persist isPlanMode or isQuestion events as toolActivity', async () => {
+    const conv = await chatService.createConversation('Test');
+
+    mockBackend.setMockEvents([
+      { type: 'tool_activity', tool: 'EnterPlanMode', isPlanMode: true, planAction: 'enter', description: 'Entering plan mode' },
+      { type: 'tool_activity', tool: 'ExitPlanMode', isPlanMode: true, planAction: 'exit', description: 'Plan ready' },
+      { type: 'tool_activity', tool: 'AskUserQuestion', isQuestion: true, questions: [], description: 'Asking' },
+      { type: 'tool_activity', tool: 'Read', description: 'Reading `file.js`', id: 'tool_1' },
+      { type: 'text', content: 'Done', streaming: true },
+      { type: 'done' },
+    ]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'test',
+      backend: 'claude-code',
+    });
+
+    await readSSE(`/api/chat/conversations/${conv.id}/stream`);
+
+    const loaded = await chatService.getConversation(conv.id);
+    const assistantMsgs = loaded.messages.filter(m => m.role === 'assistant');
+    expect(assistantMsgs[0].toolActivity).toBeDefined();
+    // Only the Read tool should be persisted, not plan mode or question events
+    expect(assistantMsgs[0].toolActivity).toHaveLength(1);
+    expect(assistantMsgs[0].toolActivity[0].tool).toBe('Read');
+  });
+
+  test('toolActivity absent when no tool events occur', async () => {
+    const conv = await chatService.createConversation('Test');
+
+    mockBackend.setMockEvents([
+      { type: 'text', content: 'Just text', streaming: true },
+      { type: 'done' },
+    ]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'test',
+      backend: 'claude-code',
+    });
+
+    await readSSE(`/api/chat/conversations/${conv.id}/stream`);
+
+    const loaded = await chatService.getConversation(conv.id);
+    const assistantMsgs = loaded.messages.filter(m => m.role === 'assistant');
+    expect(assistantMsgs[0].toolActivity).toBeUndefined();
+  });
+
+  test('persists agent tool activity with isAgent and subagentType', async () => {
+    const conv = await chatService.createConversation('Test');
+
+    mockBackend.setMockEvents([
+      { type: 'tool_activity', tool: 'Agent', description: 'Explore codebase', isAgent: true, subagentType: 'Explore', id: 'agent_1' },
+      { type: 'text', content: 'Found results', streaming: true },
+      { type: 'done' },
+    ]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'test',
+      backend: 'claude-code',
+    });
+
+    await readSSE(`/api/chat/conversations/${conv.id}/stream`);
+
+    const loaded = await chatService.getConversation(conv.id);
+    const assistantMsgs = loaded.messages.filter(m => m.role === 'assistant');
+    expect(assistantMsgs[0].toolActivity).toBeDefined();
+    expect(assistantMsgs[0].toolActivity[0].isAgent).toBe(true);
+    expect(assistantMsgs[0].toolActivity[0].subagentType).toBe('Explore');
+  });
+
+  test('forwards tool_outcomes SSE event to client', async () => {
+    const conv = await chatService.createConversation('Test');
+
+    mockBackend.setMockEvents([
+      { type: 'tool_activity', tool: 'Grep', description: 'Searching', id: 'tool_1' },
+      { type: 'tool_outcomes', outcomes: [{ toolUseId: 'tool_1', outcome: '5 matches', status: 'success' }] },
+      { type: 'turn_boundary' },
+      { type: 'text', content: 'Found it', streaming: true },
+      { type: 'done' },
+    ]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'test',
+      backend: 'claude-code',
+    });
+
+    const events = await readSSE(`/api/chat/conversations/${conv.id}/stream`);
+
+    const outcomeEvent = events.find(e => e.type === 'tool_outcomes');
+    expect(outcomeEvent).toBeDefined();
+    expect(outcomeEvent.outcomes[0].outcome).toBe('5 matches');
+    expect(outcomeEvent.outcomes[0].status).toBe('success');
+  });
+
+  test('persists outcome and status on toolActivity entries', async () => {
+    const conv = await chatService.createConversation('Test');
+
+    mockBackend.setMockEvents([
+      { type: 'tool_activity', tool: 'Bash', description: 'Running tests', id: 'tool_1' },
+      { type: 'tool_outcomes', outcomes: [{ toolUseId: 'tool_1', outcome: 'exit 0', status: 'success' }] },
+      { type: 'text', content: 'Tests pass', streaming: true },
+      { type: 'turn_boundary' },
+      { type: 'text', content: 'Done', streaming: true },
+      { type: 'done' },
+    ]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'test',
+      backend: 'claude-code',
+    });
+
+    await readSSE(`/api/chat/conversations/${conv.id}/stream`);
+
+    const loaded = await chatService.getConversation(conv.id);
+    const assistantMsgs = loaded.messages.filter(m => m.role === 'assistant');
+    // First message (intermediate, saved at turn_boundary) should have outcome
+    expect(assistantMsgs[0].toolActivity).toBeDefined();
+    expect(assistantMsgs[0].toolActivity[0].outcome).toBe('exit 0');
+    expect(assistantMsgs[0].toolActivity[0].status).toBe('success');
+  });
+});
+
+// ── Parallel grouping and session overview ────────────────────────────────────
+
+describe('Tool activity Phase 3 features', () => {
+  test('persists multiple agents with close startTimes for parallel grouping', async () => {
+    const conv = await chatService.createConversation('Test');
+    const now = Date.now();
+
+    mockBackend.setMockEvents([
+      { type: 'tool_activity', tool: 'Agent', description: 'Search code', id: 'a1', isAgent: true, subagentType: 'Explore' },
+      { type: 'tool_activity', tool: 'Agent', description: 'Check tests', id: 'a2', isAgent: true, subagentType: 'Explore' },
+      { type: 'text', content: 'Result', streaming: true },
+      { type: 'done' },
+    ]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'test', backend: 'claude-code',
+    });
+    await readSSE(`/api/chat/conversations/${conv.id}/stream`);
+
+    const loaded = await chatService.getConversation(conv.id);
+    const assistantMsgs = loaded.messages.filter(m => m.role === 'assistant');
+    expect(assistantMsgs[0].toolActivity).toBeDefined();
+    expect(assistantMsgs[0].toolActivity).toHaveLength(2);
+    expect(assistantMsgs[0].toolActivity[0].isAgent).toBe(true);
+    expect(assistantMsgs[0].toolActivity[1].isAgent).toBe(true);
+    // Both should have startTime for frontend parallel grouping
+    expect(assistantMsgs[0].toolActivity[0].startTime).toBeDefined();
+    expect(assistantMsgs[0].toolActivity[1].startTime).toBeDefined();
+  });
+
+  test('persists mix of tool and agent activity for session overview aggregation', async () => {
+    const conv = await chatService.createConversation('Test');
+
+    // First turn: tool activity
+    mockBackend.setMockEvents([
+      { type: 'tool_activity', tool: 'Read', description: 'Read file.js', id: 't1' },
+      { type: 'tool_activity', tool: 'Grep', description: 'Search pattern', id: 't2' },
+      { type: 'text', content: 'Found it', streaming: true },
+      { type: 'turn_boundary' },
+      // Second turn: agent activity
+      { type: 'tool_activity', tool: 'Agent', description: 'Explore codebase', id: 'a1', isAgent: true, subagentType: 'Explore' },
+      { type: 'text', content: 'Done exploring', streaming: true },
+      { type: 'done' },
+    ]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'test', backend: 'claude-code',
+    });
+    await readSSE(`/api/chat/conversations/${conv.id}/stream`);
+
+    const loaded = await chatService.getConversation(conv.id);
+    const assistantMsgs = loaded.messages.filter(m => m.role === 'assistant');
+    // Should have 2 assistant messages (turn_boundary + done)
+    expect(assistantMsgs.length).toBe(2);
+    // First message has Read + Grep
+    expect(assistantMsgs[0].toolActivity).toHaveLength(2);
+    expect(assistantMsgs[0].toolActivity[0].tool).toBe('Read');
+    expect(assistantMsgs[0].toolActivity[1].tool).toBe('Grep');
+    // Second message has Agent
+    expect(assistantMsgs[1].toolActivity).toHaveLength(1);
+    expect(assistantMsgs[1].toolActivity[0].isAgent).toBe(true);
+    expect(assistantMsgs[1].toolActivity[0].subagentType).toBe('Explore');
+  });
+});
+
 // ── Turn boundary intermediate message saving ───────────────────────────────
 
 describe('Turn boundary intermediate messages', () => {

--- a/test/chatService.test.js
+++ b/test/chatService.test.js
@@ -283,6 +283,45 @@ describe('addMessage', () => {
     expect(msg.thinking).toBeUndefined();
   });
 
+  test('stores toolActivity when provided', async () => {
+    const conv = await service.createConversation();
+    const activity = [
+      { tool: 'Read', description: 'Reading `app.js`', id: 'tool_1', duration: 300, startTime: Date.now() - 300 },
+      { tool: 'Agent', description: 'Explore code', id: 'tool_2', isAgent: true, subagentType: 'Explore', duration: 5000, startTime: Date.now() - 5000 },
+    ];
+    const msg = await service.addMessage(conv.id, 'assistant', 'Response', 'claude-code', null, activity);
+    expect(msg.toolActivity).toEqual(activity);
+
+    const loaded = await service.getConversation(conv.id);
+    expect(loaded.messages[0].toolActivity).toEqual(activity);
+  });
+
+  test('omits toolActivity when not provided', async () => {
+    const conv = await service.createConversation();
+    const msg = await service.addMessage(conv.id, 'assistant', 'No tools');
+    expect(msg.toolActivity).toBeUndefined();
+
+    const loaded = await service.getConversation(conv.id);
+    expect(loaded.messages[0].toolActivity).toBeUndefined();
+  });
+
+  test('omits toolActivity when empty array', async () => {
+    const conv = await service.createConversation();
+    const msg = await service.addMessage(conv.id, 'assistant', 'Empty tools', 'claude-code', null, []);
+    expect(msg.toolActivity).toBeUndefined();
+  });
+
+  test('persists toolActivity to disk', async () => {
+    const conv = await service.createConversation();
+    const activity = [{ tool: 'Bash', description: 'Running tests', id: 'tool_1', duration: 1000, startTime: Date.now() }];
+    await service.addMessage(conv.id, 'assistant', 'Answer', 'claude-code', null, activity);
+
+    const service2 = new ChatService(tmpDir, { defaultWorkspace: DEFAULT_WORKSPACE });
+    await service2.initialize();
+    const loaded = await service2.getConversation(conv.id);
+    expect(loaded.messages[0].toolActivity).toEqual(activity);
+  });
+
   test('updates lastActivity and lastMessage in workspace index', async () => {
     const conv = await service.createConversation('Test', '/tmp/idx');
     await service.addMessage(conv.id, 'user', 'Index check message');


### PR DESCRIPTION
## Summary
- **Proper agent attribution**: Use Claude Code CLI `system` events (`task_progress`, `task_notification`) to correctly attribute inner tools to their parent agent, replacing the broken heuristic state machine
- **Per-agent UI cards**: Each agent gets its own card with spinner + live timer while running, checkmark + duration when complete, and a scrollable sub-activity panel showing only that agent's tasks
- **Tool outcome extraction**: Parse tool results to show contextual outcomes (exit codes for Bash, match counts for Grep/Glob, read/written/edited status for file tools)
- **Persisted activity**: Tool activity with outcomes and durations saved to message history for replay

## Test plan
- [x] 327 existing tests pass
- [x] New tests for tool outcome extraction, system event handling, parentAgentId attribution, and tool activity persistence
- [x] Manual testing: parallel agents display correctly with sub-tasks routed to correct parent
- [x] SPEC.md updated with new event types and message schema changes