### PR TITLE
feat: add message queue for chat input during active responses

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -673,7 +673,8 @@ Vanilla JavaScript SPA — no framework, no bundler, no build step. Uses marked 
 - **Auto title update:** handles `title_updated` SSE event by updating the active conversation title, the header, and the sidebar list in-place (no full reload needed).
 - **Usage display:** a small indicator in the conversation header shows cumulative token count and USD cost. Updated in real-time when `usage` SSE events arrive during streaming. Displays on hover a tooltip with input/output/cache token breakdown and cost. Hidden when no usage data exists (e.g. new conversation).
 - **Stream cleanup:** `chatCleanupStreamState()` accepts `{ force }` option. The `finally` block uses `force: true` to ensure cleanup even when a pending interaction was never resolved. Interaction response handlers also use forced cleanup when the stream has already ended.
-- **Send button state:** shows stop (■) when streaming, send (↑) when idle. Disabled during uploads or session resets.
+- **Send button state:** shows stop (■) when streaming with no text input, send (↑) when idle or when streaming with text input (to queue). Disabled during uploads or session resets.
+- **Message queue:** Users can compose and submit messages while the CLI is actively responding. Queued messages are stored client-side in `chatMessageQueue` (Map of convId → array of `{ id, content, inFlight }`). They appear inline in the chat after the streaming bubble, styled as user messages with reduced opacity and an accent left border. Each queued message shows a "Queued" badge and has Edit and Delete buttons. Editing is inline via a textarea replacing the message content. In-flight messages (being dispatched to the CLI) show "Sending..." and cannot be edited or deleted. When a response completes successfully, the next queued message is automatically sent (FIFO). On error, the queue pauses and a banner appears with Resume and Clear buttons. The `chatQueuePaused` Set tracks paused conversations. Queuing a new message while paused un-pauses the queue. Queue state is per-conversation and purely client-side (not persisted to disk).
 
 ### File Handling
 
@@ -806,6 +807,7 @@ Update OAuth callback URLs to include the ngrok URL.
 | `test/chat.test.ts` | Chat routes: /input, SSE forwarding, turn boundaries, turn_complete event forwarding, tool activity persistence, parallel agent persistence, session overview aggregation, auto title update on session reset, usage event forwarding and persistence, file upload/serve, workspace instructions |
 | `test/chatService.test.ts` | ChatService CRUD, messages (including toolActivity persistence), sessions, generateAndUpdateTitle, usage tracking (addUsage, getUsage), workspace storage, migration, markdown export |
 | `test/draftState.test.ts` | Draft save/restore, key migration, cleanup, round-trip |
+| `test/messageQueue.test.ts` | Message queue: adding, deleting, rendering, in-flight protection, pause/resume, per-conversation isolation, send button state |
 | `test/graceful-shutdown.test.ts` | Server shutdown on SIGINT/SIGTERM |
 | `test/sessionStore.test.ts` | Session file-store persistence |
 | `test/updateService.test.ts` | Version comparison, status, trigger guards, interval management |

--- a/public/app.js
+++ b/public/app.js
@@ -144,6 +144,9 @@ let chatPendingFiles = []; // Each: { file, status: 'uploading'|'done'|'error', 
 let chatDraftState = new Map(); // convId|'__new__' -> { text, pendingFiles }
 let _ensureConvPromise = null;
 let chatConvLoadGen = 0; // generation counter for chatLoadConversations to discard stale responses
+let chatMessageQueue = new Map(); // convId -> [{ id, content, inFlight }]
+let chatQueuePaused = new Set(); // convIds where queue is paused due to error
+let chatQueueIdCounter = 0;
 
 function chatApiUrl(path) {
   return apiUrl('chat/' + path);
@@ -256,7 +259,9 @@ function chatWireEvents() {
 
   const sendBtn = document.getElementById('chat-send-btn');
   if (sendBtn) sendBtn.onclick = () => {
-    if (chatStreamingConvs.has(chatActiveConvId)) chatStopStreaming();
+    const ta = document.getElementById('chat-textarea');
+    const hasInput = ta && ta.value.trim();
+    if (chatStreamingConvs.has(chatActiveConvId) && !hasInput) chatStopStreaming();
     else chatSendMessage();
   };
 
@@ -875,15 +880,26 @@ function chatUpdateSendButtonState() {
   if (!sendBtn) return;
   const isStreaming = chatStreamingConvs.has(chatActiveConvId);
   const isResetting = chatResettingConvs.has(chatActiveConvId);
+  const ta = document.getElementById('chat-textarea');
+  const hasText = ta && ta.value.trim();
   if (isStreaming) {
-    sendBtn.disabled = false;
-    sendBtn.textContent = '■';
-    sendBtn.classList.add('stop');
+    if (hasText) {
+      // Show send arrow to queue the message
+      sendBtn.disabled = false;
+      sendBtn.textContent = '↑';
+      sendBtn.classList.remove('stop');
+      sendBtn.title = 'Queue message (Enter)';
+    } else {
+      // Show stop button
+      sendBtn.disabled = false;
+      sendBtn.textContent = '■';
+      sendBtn.classList.add('stop');
+      sendBtn.title = 'Stop streaming';
+    }
   } else {
     sendBtn.textContent = '↑';
     sendBtn.classList.remove('stop');
-    const ta = document.getElementById('chat-textarea');
-    const hasText = ta && ta.value.trim();
+    sendBtn.title = 'Send message (Enter)';
     const hasCompletedFiles = chatPendingFiles.some(e => e.status === 'done');
     const hasUploading = chatPendingFiles.some(e => e.status === 'uploading');
     sendBtn.disabled = isResetting || hasUploading || (!hasText && !hasCompletedFiles);
@@ -1224,6 +1240,9 @@ function chatRenderMessages() {
     }
     // else: default typing dots shown by chatAppendStreamingMessage
   }
+
+  // Render queued messages after all real messages and streaming bubble
+  chatRenderQueuedMessages();
 
   chatScrollToBottom();
 }
@@ -1585,6 +1604,196 @@ function chatWireMessageActions(container) {
   });
 }
 
+// ── Message Queue UI ─────────────────────────────────────────────────────────
+
+function chatRenderQueuedMessages() {
+  const container = document.getElementById('chat-messages');
+  if (!container) return;
+
+  // Remove any existing queued message elements
+  container.querySelectorAll('.chat-msg-queued').forEach(el => el.remove());
+  container.querySelectorAll('.chat-queue-paused-banner').forEach(el => el.remove());
+
+  const convId = chatActiveConvId;
+  if (!convId) return;
+  const queue = chatMessageQueue.get(convId);
+  if (!queue || queue.length === 0) return;
+
+  // If paused, show a banner before the queued messages
+  if (chatQueuePaused.has(convId)) {
+    const bannerEl = document.createElement('div');
+    bannerEl.className = 'chat-queue-paused-banner';
+    bannerEl.innerHTML = `
+      <span>Queue paused due to error.</span>
+      <button class="chat-queue-resume-btn" onclick="chatResumeQueue()">Resume queue</button>
+      <button class="chat-queue-clear-btn" onclick="chatClearQueue()">Clear queue</button>
+    `;
+    container.appendChild(bannerEl);
+  }
+
+  for (const item of queue) {
+    const el = document.createElement('div');
+    el.className = 'chat-msg user chat-msg-queued' + (item.inFlight ? ' chat-msg-in-flight' : '');
+    el.dataset.queueId = item.id;
+    const rendered = chatRenderMarkdown(item.content);
+    el.innerHTML = `
+      <div class="chat-msg-wrapper">
+        <div class="chat-msg-avatar">👤</div>
+        <div class="chat-msg-body">
+          <div class="chat-msg-role">You <span class="chat-queue-badge">${item.inFlight ? 'Sending...' : 'Queued'}</span></div>
+          <div class="chat-msg-content chat-queued-content">${rendered}</div>
+          ${!item.inFlight ? `<div class="chat-msg-actions chat-queue-actions" style="opacity:1;">
+            <button class="chat-msg-action" data-action="edit-queued" data-queue-id="${item.id}" title="Edit">Edit</button>
+            <button class="chat-msg-action" data-action="delete-queued" data-queue-id="${item.id}" title="Delete">Delete</button>
+          </div>` : ''}
+        </div>
+      </div>
+    `;
+    container.appendChild(el);
+  }
+
+  // Wire queue action buttons
+  container.querySelectorAll('[data-action="delete-queued"]').forEach(btn => {
+    btn.onclick = () => chatDeleteQueuedMessage(Number(btn.dataset.queueId));
+  });
+  container.querySelectorAll('[data-action="edit-queued"]').forEach(btn => {
+    btn.onclick = () => chatEditQueuedMessage(Number(btn.dataset.queueId));
+  });
+}
+
+function chatDeleteQueuedMessage(queueId) {
+  const convId = chatActiveConvId;
+  if (!convId) return;
+  const queue = chatMessageQueue.get(convId);
+  if (!queue) return;
+  const idx = queue.findIndex(item => item.id === queueId);
+  if (idx === -1 || queue[idx].inFlight) return;
+  queue.splice(idx, 1);
+  if (queue.length === 0) {
+    chatMessageQueue.delete(convId);
+    chatQueuePaused.delete(convId);
+  }
+  chatRenderQueuedMessages();
+  chatUpdateSendButtonState();
+}
+
+function chatEditQueuedMessage(queueId) {
+  const convId = chatActiveConvId;
+  if (!convId) return;
+  const queue = chatMessageQueue.get(convId);
+  if (!queue) return;
+  const item = queue.find(i => i.id === queueId);
+  if (!item || item.inFlight) return;
+
+  const container = document.getElementById('chat-messages');
+  if (!container) return;
+  const msgEl = container.querySelector(`.chat-msg-queued[data-queue-id="${queueId}"]`);
+  if (!msgEl) return;
+
+  const contentEl = msgEl.querySelector('.chat-queued-content');
+  const actionsEl = msgEl.querySelector('.chat-queue-actions');
+  if (!contentEl) return;
+
+  // Replace content with textarea for inline editing
+  const editArea = document.createElement('textarea');
+  editArea.className = 'chat-queue-edit-textarea';
+  editArea.value = item.content;
+  editArea.rows = Math.max(2, item.content.split('\n').length);
+
+  const editActions = document.createElement('div');
+  editActions.className = 'chat-queue-edit-actions';
+  editActions.innerHTML = `
+    <button class="chat-queue-edit-save">Save</button>
+    <button class="chat-queue-edit-cancel">Cancel</button>
+  `;
+
+  contentEl.replaceWith(editArea);
+  if (actionsEl) actionsEl.style.display = 'none';
+  editArea.parentElement.appendChild(editActions);
+  editArea.focus();
+  editArea.setSelectionRange(editArea.value.length, editArea.value.length);
+
+  editActions.querySelector('.chat-queue-edit-save').onclick = () => {
+    const newContent = editArea.value.trim();
+    if (newContent) {
+      item.content = newContent;
+    }
+    chatRenderQueuedMessages();
+  };
+
+  editActions.querySelector('.chat-queue-edit-cancel').onclick = () => {
+    chatRenderQueuedMessages();
+  };
+
+  editArea.onkeydown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      editActions.querySelector('.chat-queue-edit-save').click();
+    } else if (e.key === 'Escape') {
+      editActions.querySelector('.chat-queue-edit-cancel').click();
+    }
+  };
+}
+
+function chatResumeQueue() {
+  const convId = chatActiveConvId;
+  if (!convId) return;
+  chatQueuePaused.delete(convId);
+  chatRenderQueuedMessages();
+  // If not currently streaming, process the next message
+  if (!chatStreamingConvs.has(convId)) {
+    chatProcessNextQueuedMessage(convId);
+  }
+}
+window.chatResumeQueue = chatResumeQueue;
+
+function chatClearQueue() {
+  const convId = chatActiveConvId;
+  if (!convId) return;
+  const queue = chatMessageQueue.get(convId);
+  if (!queue) return;
+  // Keep in-flight messages, remove the rest
+  const inFlight = queue.filter(i => i.inFlight);
+  if (inFlight.length > 0) {
+    chatMessageQueue.set(convId, inFlight);
+  } else {
+    chatMessageQueue.delete(convId);
+  }
+  chatQueuePaused.delete(convId);
+  chatRenderQueuedMessages();
+  chatUpdateSendButtonState();
+}
+window.chatClearQueue = chatClearQueue;
+
+async function chatProcessNextQueuedMessage(convId) {
+  if (chatQueuePaused.has(convId)) return;
+  if (chatStreamingConvs.has(convId)) return;
+  const queue = chatMessageQueue.get(convId);
+  if (!queue || queue.length === 0) return;
+
+  const nextItem = queue[0];
+  nextItem.inFlight = true;
+  chatRenderQueuedMessages();
+
+  // Populate textarea with the queued content and send
+  const textarea = document.getElementById('chat-textarea');
+  if (textarea) {
+    textarea.value = nextItem.content;
+    chatAutoResize(textarea);
+  }
+
+  // Remove the item from queue before sending (it will become a real message)
+  queue.shift();
+  if (queue.length === 0) chatMessageQueue.delete(convId);
+  chatRenderQueuedMessages();
+
+  // Send the message — chatSendMessage will handle the rest
+  // We need to make sure we're on the right conversation
+  if (chatActiveConvId === convId) {
+    await chatSendMessage();
+  }
+}
+
 function chatScrollToBottom() {
   const container = document.getElementById('chat-messages');
   if (container) {
@@ -1617,7 +1826,7 @@ async function chatSendMessage() {
   const hasText = textarea && textarea.value.trim();
   const completedFiles = chatPendingFiles.filter(e => e.status === 'done');
   const hasFiles = completedFiles.length > 0;
-  if ((!hasText && !hasFiles) || chatStreamingConvs.has(chatActiveConvId) || chatResettingConvs.has(chatActiveConvId)) return;
+  if ((!hasText && !hasFiles) || chatResettingConvs.has(chatActiveConvId)) return;
   if (chatPendingFiles.some(e => e.status === 'uploading')) return;
 
   let content = textarea ? textarea.value.trim() : '';
@@ -1651,6 +1860,19 @@ async function chatSendMessage() {
       alert('Failed to create conversation: ' + err.message);
       return;
     }
+  }
+
+  // If currently streaming, queue the message instead of sending immediately
+  if (chatStreamingConvs.has(chatActiveConvId)) {
+    const queue = chatMessageQueue.get(chatActiveConvId) || [];
+    queue.push({ id: ++chatQueueIdCounter, content, inFlight: false });
+    chatMessageQueue.set(chatActiveConvId, queue);
+    // Un-pause queue if user queues a new message (they've seen the error)
+    chatQueuePaused.delete(chatActiveConvId);
+    chatRenderQueuedMessages();
+    chatUpdateSendButtonState();
+    chatScrollToBottom();
+    return;
   }
 
   chatDraftState.delete(chatActiveConvId);
@@ -1847,6 +2069,7 @@ async function chatSendMessage() {
             st.pendingInteraction = null;
             chatArchiveActiveState(st);
             st.planModeActive = false;
+            st._hadError = true;
             if (isStillActive) chatAppendError(event.error);
           } else if (event.type === 'done') {
             chatCleanupStreamState(targetConvId);
@@ -1860,7 +2083,12 @@ async function chatSendMessage() {
     if (err.name !== 'AbortError') {
       if (chatActiveConvId === targetConvId) chatAppendError(err.message);
     }
+    // Mark error for queue pause logic
+    const errSt = chatStreamingState.get(targetConvId);
+    if (errSt) errSt._hadError = true;
   } finally {
+    const finalSt = chatStreamingState.get(targetConvId);
+    const hadError = finalSt?._hadError;
     chatStreamingConvs.delete(targetConvId);
     // Force cleanup — stream has ended, no more events will arrive
     chatCleanupStreamState(targetConvId, { force: true });
@@ -1869,6 +2097,14 @@ async function chatSendMessage() {
     // Refresh conversation list from server to pick up title changes and message counts.
     // The generation counter in chatLoadConversations discards any stale in-flight responses.
     chatLoadConversations();
+
+    // Process message queue: pause on error, otherwise send next
+    if (hadError && chatMessageQueue.has(targetConvId)) {
+      chatQueuePaused.add(targetConvId);
+      chatRenderQueuedMessages();
+    } else {
+      chatProcessNextQueuedMessage(targetConvId);
+    }
   }
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1402,6 +1402,127 @@
 
   .chat-msg-action:hover { border-color: var(--border); color: var(--text); background: var(--surface); }
 
+  /* ── Queued Messages ─────────────────────────────────── */
+  .chat-msg-queued {
+    opacity: 0.65;
+    position: relative;
+  }
+
+  .chat-msg-queued .chat-msg-content {
+    border-left: 3px solid var(--accent-chat);
+    padding-left: 10px;
+  }
+
+  .chat-msg-in-flight {
+    opacity: 0.8;
+  }
+
+  .chat-msg-in-flight .chat-msg-content {
+    border-left-color: var(--muted);
+  }
+
+  .chat-queue-badge {
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--accent-chat);
+    background: color-mix(in srgb, var(--accent-chat) 12%, transparent);
+    padding: 1px 6px;
+    border-radius: 8px;
+    margin-left: 4px;
+  }
+
+  .chat-msg-in-flight .chat-queue-badge {
+    color: var(--muted);
+    background: var(--surface2);
+  }
+
+  .chat-queue-actions {
+    opacity: 1 !important;
+  }
+
+  .chat-queue-edit-textarea {
+    width: 100%;
+    min-height: 48px;
+    padding: 8px 10px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--surface);
+    color: var(--text);
+    font-family: inherit;
+    font-size: 14px;
+    line-height: 1.5;
+    resize: vertical;
+    outline: none;
+  }
+
+  .chat-queue-edit-textarea:focus {
+    border-color: var(--accent-chat);
+  }
+
+  .chat-queue-edit-actions {
+    display: flex;
+    gap: 6px;
+    margin-top: 6px;
+  }
+
+  .chat-queue-edit-save,
+  .chat-queue-edit-cancel {
+    padding: 4px 12px;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+  }
+
+  .chat-queue-edit-save:hover {
+    background: var(--accent-chat);
+    color: white;
+    border-color: var(--accent-chat);
+  }
+
+  .chat-queue-edit-cancel:hover {
+    background: var(--surface2);
+  }
+
+  .chat-queue-paused-banner {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    max-width: 800px;
+    margin: 8px auto;
+    padding: 8px 16px;
+    background: color-mix(in srgb, #dc2626 8%, var(--surface));
+    border: 1px solid color-mix(in srgb, #dc2626 25%, var(--border));
+    border-radius: 8px;
+    font-size: 13px;
+    color: var(--text);
+  }
+
+  .chat-queue-resume-btn,
+  .chat-queue-clear-btn {
+    padding: 3px 10px;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+  }
+
+  .chat-queue-resume-btn:hover {
+    background: var(--accent-chat);
+    color: white;
+    border-color: var(--accent-chat);
+  }
+
+  .chat-queue-clear-btn:hover {
+    background: color-mix(in srgb, #dc2626 15%, var(--surface));
+    border-color: #dc2626;
+    color: #dc2626;
+  }
+
   /* Session divider */
   .chat-session-divider {
     display: flex;

--- a/test/messageQueue.test.ts
+++ b/test/messageQueue.test.ts
@@ -1,0 +1,307 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// ── Globals & DOM setup ──────────────────────────────────────────────────────
+
+beforeEach(() => {
+  document.body.innerHTML = `
+    <div id="chat-messages"></div>
+    <textarea id="chat-textarea"></textarea>
+    <button id="chat-send-btn"></button>
+  `;
+
+  (global as any).chatActiveConvId = 'conv-1';
+  (global as any).chatMessageQueue = new Map();
+  (global as any).chatQueuePaused = new Set();
+  (global as any).chatQueueIdCounter = 0;
+  (global as any).chatStreamingConvs = new Set();
+  (global as any).chatPendingFiles = [];
+});
+
+// ── Stubs for functions called by queue logic ────────────────────────────────
+
+function chatAutoResize(_el: HTMLElement) { /* no-op */ }
+function chatRenderMarkdown(str: string) { return str; }
+function chatScrollToBottom() { /* no-op */ }
+function chatUpdateSendButtonState() { /* no-op */ }
+function esc(str: string) { return str; }
+
+// ── Extracted queue functions (mirroring app.js logic) ───────────────��───────
+
+function chatRenderQueuedMessages() {
+  const container = document.getElementById('chat-messages');
+  if (!container) return;
+
+  container.querySelectorAll('.chat-msg-queued').forEach(el => el.remove());
+  container.querySelectorAll('.chat-queue-paused-banner').forEach(el => el.remove());
+
+  const convId = (global as any).chatActiveConvId;
+  if (!convId) return;
+  const queue = (global as any).chatMessageQueue.get(convId);
+  if (!queue || queue.length === 0) return;
+
+  if ((global as any).chatQueuePaused.has(convId)) {
+    const bannerEl = document.createElement('div');
+    bannerEl.className = 'chat-queue-paused-banner';
+    bannerEl.innerHTML = '<span>Queue paused due to error.</span>';
+    container.appendChild(bannerEl);
+  }
+
+  for (const item of queue) {
+    const el = document.createElement('div');
+    el.className = 'chat-msg user chat-msg-queued' + (item.inFlight ? ' chat-msg-in-flight' : '');
+    el.dataset.queueId = String(item.id);
+    el.innerHTML = `
+      <div class="chat-msg-wrapper">
+        <div class="chat-msg-body">
+          <div class="chat-msg-role">You <span class="chat-queue-badge">${item.inFlight ? 'Sending...' : 'Queued'}</span></div>
+          <div class="chat-msg-content chat-queued-content">${chatRenderMarkdown(item.content)}</div>
+          ${!item.inFlight ? `<div class="chat-msg-actions chat-queue-actions">
+            <button class="chat-msg-action" data-action="edit-queued" data-queue-id="${item.id}">Edit</button>
+            <button class="chat-msg-action" data-action="delete-queued" data-queue-id="${item.id}">Delete</button>
+          </div>` : ''}
+        </div>
+      </div>
+    `;
+    container.appendChild(el);
+  }
+}
+
+function chatDeleteQueuedMessage(queueId: number) {
+  const convId = (global as any).chatActiveConvId;
+  if (!convId) return;
+  const queue = (global as any).chatMessageQueue.get(convId);
+  if (!queue) return;
+  const idx = queue.findIndex((item: any) => item.id === queueId);
+  if (idx === -1 || queue[idx].inFlight) return;
+  queue.splice(idx, 1);
+  if (queue.length === 0) {
+    (global as any).chatMessageQueue.delete(convId);
+    (global as any).chatQueuePaused.delete(convId);
+  }
+  chatRenderQueuedMessages();
+}
+
+function addToQueue(content: string) {
+  const convId = (global as any).chatActiveConvId;
+  const queue = (global as any).chatMessageQueue.get(convId) || [];
+  queue.push({ id: ++(global as any).chatQueueIdCounter, content, inFlight: false });
+  (global as any).chatMessageQueue.set(convId, queue);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Message Queue: adding messages', () => {
+  test('adds messages to the queue', () => {
+    addToQueue('Hello');
+    addToQueue('World');
+    const queue = (global as any).chatMessageQueue.get('conv-1');
+    expect(queue).toHaveLength(2);
+    expect(queue[0].content).toBe('Hello');
+    expect(queue[1].content).toBe('World');
+  });
+
+  test('assigns unique IDs to queued messages', () => {
+    addToQueue('A');
+    addToQueue('B');
+    const queue = (global as any).chatMessageQueue.get('conv-1');
+    expect(queue[0].id).not.toBe(queue[1].id);
+  });
+
+  test('new queue items default to inFlight false', () => {
+    addToQueue('msg');
+    const queue = (global as any).chatMessageQueue.get('conv-1');
+    expect(queue[0].inFlight).toBe(false);
+  });
+});
+
+describe('Message Queue: deleting messages', () => {
+  test('deletes a queued message by id', () => {
+    addToQueue('first');
+    addToQueue('second');
+    const queue = (global as any).chatMessageQueue.get('conv-1');
+    chatDeleteQueuedMessage(queue[0].id);
+    const remaining = (global as any).chatMessageQueue.get('conv-1');
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].content).toBe('second');
+  });
+
+  test('does not delete an in-flight message', () => {
+    addToQueue('in-flight-msg');
+    const queue = (global as any).chatMessageQueue.get('conv-1');
+    queue[0].inFlight = true;
+    chatDeleteQueuedMessage(queue[0].id);
+    expect((global as any).chatMessageQueue.get('conv-1')).toHaveLength(1);
+  });
+
+  test('cleans up queue map when last item deleted', () => {
+    addToQueue('only');
+    const queue = (global as any).chatMessageQueue.get('conv-1');
+    chatDeleteQueuedMessage(queue[0].id);
+    expect((global as any).chatMessageQueue.has('conv-1')).toBe(false);
+  });
+
+  test('clears paused state when queue becomes empty', () => {
+    addToQueue('paused-msg');
+    (global as any).chatQueuePaused.add('conv-1');
+    const queue = (global as any).chatMessageQueue.get('conv-1');
+    chatDeleteQueuedMessage(queue[0].id);
+    expect((global as any).chatQueuePaused.has('conv-1')).toBe(false);
+  });
+});
+
+describe('Message Queue: rendering', () => {
+  test('renders queued messages in the chat container', () => {
+    addToQueue('test message');
+    chatRenderQueuedMessages();
+    const els = document.querySelectorAll('.chat-msg-queued');
+    expect(els).toHaveLength(1);
+    expect(els[0].textContent).toContain('test message');
+    expect(els[0].textContent).toContain('Queued');
+  });
+
+  test('renders edit and delete buttons for non-in-flight messages', () => {
+    addToQueue('editable');
+    chatRenderQueuedMessages();
+    const editBtn = document.querySelector('[data-action="edit-queued"]');
+    const deleteBtn = document.querySelector('[data-action="delete-queued"]');
+    expect(editBtn).not.toBeNull();
+    expect(deleteBtn).not.toBeNull();
+  });
+
+  test('does not render edit/delete buttons for in-flight messages', () => {
+    addToQueue('sending');
+    const queue = (global as any).chatMessageQueue.get('conv-1');
+    queue[0].inFlight = true;
+    chatRenderQueuedMessages();
+    const editBtn = document.querySelector('[data-action="edit-queued"]');
+    const deleteBtn = document.querySelector('[data-action="delete-queued"]');
+    expect(editBtn).toBeNull();
+    expect(deleteBtn).toBeNull();
+  });
+
+  test('shows "Sending..." badge for in-flight messages', () => {
+    addToQueue('flying');
+    const queue = (global as any).chatMessageQueue.get('conv-1');
+    queue[0].inFlight = true;
+    chatRenderQueuedMessages();
+    const badge = document.querySelector('.chat-queue-badge');
+    expect(badge?.textContent).toBe('Sending...');
+  });
+
+  test('renders paused banner when queue is paused', () => {
+    addToQueue('paused');
+    (global as any).chatQueuePaused.add('conv-1');
+    chatRenderQueuedMessages();
+    const banner = document.querySelector('.chat-queue-paused-banner');
+    expect(banner).not.toBeNull();
+    expect(banner?.textContent).toContain('Queue paused');
+  });
+
+  test('does not render paused banner when queue is not paused', () => {
+    addToQueue('active');
+    chatRenderQueuedMessages();
+    const banner = document.querySelector('.chat-queue-paused-banner');
+    expect(banner).toBeNull();
+  });
+
+  test('clears old queued elements before re-rendering', () => {
+    addToQueue('msg1');
+    chatRenderQueuedMessages();
+    expect(document.querySelectorAll('.chat-msg-queued')).toHaveLength(1);
+
+    addToQueue('msg2');
+    chatRenderQueuedMessages();
+    expect(document.querySelectorAll('.chat-msg-queued')).toHaveLength(2);
+  });
+
+  test('renders nothing when queue is empty', () => {
+    chatRenderQueuedMessages();
+    expect(document.querySelectorAll('.chat-msg-queued')).toHaveLength(0);
+    expect(document.querySelectorAll('.chat-queue-paused-banner')).toHaveLength(0);
+  });
+
+  test('applies in-flight CSS class', () => {
+    addToQueue('sending');
+    const queue = (global as any).chatMessageQueue.get('conv-1');
+    queue[0].inFlight = true;
+    chatRenderQueuedMessages();
+    const el = document.querySelector('.chat-msg-queued');
+    expect(el?.classList.contains('chat-msg-in-flight')).toBe(true);
+  });
+});
+
+describe('Message Queue: send button state', () => {
+  test('chatUpdateSendButtonState shows arrow when streaming with text', () => {
+    // Replicate the logic inline for testing
+    const sendBtn = document.getElementById('chat-send-btn') as HTMLButtonElement;
+    const ta = document.getElementById('chat-textarea') as HTMLTextAreaElement;
+    ta.value = 'some text';
+    (global as any).chatStreamingConvs.add('conv-1');
+
+    // Inline logic from chatUpdateSendButtonState
+    const isStreaming = (global as any).chatStreamingConvs.has((global as any).chatActiveConvId);
+    const hasText = ta.value.trim();
+    if (isStreaming && hasText) {
+      sendBtn.textContent = '↑';
+      sendBtn.classList.remove('stop');
+    } else if (isStreaming) {
+      sendBtn.textContent = '■';
+      sendBtn.classList.add('stop');
+    }
+
+    expect(sendBtn.textContent).toBe('↑');
+    expect(sendBtn.classList.contains('stop')).toBe(false);
+  });
+
+  test('chatUpdateSendButtonState shows stop when streaming without text', () => {
+    const sendBtn = document.getElementById('chat-send-btn') as HTMLButtonElement;
+    const ta = document.getElementById('chat-textarea') as HTMLTextAreaElement;
+    ta.value = '';
+    (global as any).chatStreamingConvs.add('conv-1');
+
+    const isStreaming = (global as any).chatStreamingConvs.has((global as any).chatActiveConvId);
+    const hasText = ta.value.trim();
+    if (isStreaming && hasText) {
+      sendBtn.textContent = '↑';
+      sendBtn.classList.remove('stop');
+    } else if (isStreaming) {
+      sendBtn.textContent = '■';
+      sendBtn.classList.add('stop');
+    }
+
+    expect(sendBtn.textContent).toBe('■');
+    expect(sendBtn.classList.contains('stop')).toBe(true);
+  });
+});
+
+describe('Message Queue: pause and resume', () => {
+  test('pausing sets queue paused state', () => {
+    (global as any).chatQueuePaused.add('conv-1');
+    expect((global as any).chatQueuePaused.has('conv-1')).toBe(true);
+  });
+
+  test('adding to queue un-pauses', () => {
+    (global as any).chatQueuePaused.add('conv-1');
+    // Simulate chatSendMessage queue path: un-pause on new queue
+    (global as any).chatQueuePaused.delete('conv-1');
+    addToQueue('new msg');
+    expect((global as any).chatQueuePaused.has('conv-1')).toBe(false);
+  });
+});
+
+describe('Message Queue: per-conversation isolation', () => {
+  test('queues are isolated per conversation', () => {
+    addToQueue('conv1-msg');
+    (global as any).chatActiveConvId = 'conv-2';
+    addToQueue('conv2-msg');
+
+    expect((global as any).chatMessageQueue.get('conv-1')).toHaveLength(1);
+    expect((global as any).chatMessageQueue.get('conv-2')).toHaveLength(1);
+    expect((global as any).chatMessageQueue.get('conv-1')[0].content).toBe('conv1-msg');
+    expect((global as any).chatMessageQueue.get('conv-2')[0].content).toBe('conv2-msg');
+  });
+});


### PR DESCRIPTION
## Summary

- Users can now compose and submit messages while the CLI is actively responding — queued messages appear inline in the chat with Edit and Delete buttons
- When the current response completes, the next queued message is automatically dispatched (FIFO order)
- On error, the queue pauses and shows a banner with Resume and Clear options; in-flight messages cannot be edited or deleted
- Send button dynamically switches between queue (↑) and stop (■) based on textarea content during streaming

## Test plan

- [x] All 317 tests pass (296 existing + 21 new in `test/messageQueue.test.ts`)
- [ ] Manually verify queuing messages while a response is streaming
- [ ] Verify queued messages render inline with "Queued" badge and edit/delete buttons
- [ ] Verify inline edit (textarea replacement) with Save/Cancel and keyboard shortcuts
- [ ] Verify in-flight messages show "Sending..." and lack edit/delete controls
- [ ] Verify queue auto-processes next message on successful completion
- [ ] Verify queue pauses on error with Resume/Clear banner
- [ ] Verify send button shows ↑ when typing during stream, ■ when empty

Closes #79