### PR TITLE
fix: prepend node_modules/.bin to PATH in self-update restart

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -519,8 +519,7 @@ All detail objects include `tool`, `id` (block id or null), and `description`. L
   5. `git pull origin main` (60s timeout)
   6. `npm install` (120s timeout)
   7. Verify interpreter — reads `ecosystem.config.js`, checks the configured interpreter binary exists on disk (prevents restart with missing dependencies)
-  8. Resolve pm2 — resolves full path to `pm2` via `which`, falls back to `node_modules/.bin/pm2` (ensures detached shell can find it)
-  9. `pm2 delete` + `pm2 start` using resolved path (fire-and-forget, detached spawn, output logged to `data/update-restart.log`)
+  8. `pm2 delete` + `pm2 start` (fire-and-forget, detached spawn with `node_modules/.bin` prepended to PATH, output logged to `data/update-restart.log`)
 
 Returns `{ success, steps: [{ name, success, output }] }`. On failure, includes `error` field.
 
@@ -812,7 +811,7 @@ Update OAuth callback URLs to include the ngrok URL.
 | `test/messageQueue.test.ts` | Message queue: adding, deleting, rendering, in-flight protection, pause/resume, per-conversation isolation, send button state |
 | `test/graceful-shutdown.test.ts` | Server shutdown on SIGINT/SIGTERM |
 | `test/sessionStore.test.ts` | Session file-store persistence |
-| `test/updateService.test.ts` | Version comparison, status, trigger guards, interval management, interpreter verification, pm2 resolution fallback |
+| `test/updateService.test.ts` | Version comparison, status, trigger guards, interval management, interpreter verification, PATH setup for restart |
 
 ### CI/CD
 

--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -121,30 +121,16 @@ export class UpdateService {
         return { success: false, steps, error: 'Failed to read ecosystem config: ' + (err as Error).message };
       }
 
-      // Resolve pm2 binary path so the detached shell can find it
-      let pm2Bin: string;
-      try {
-        pm2Bin = (await this._exec('which', ['pm2'])).trim();
-        if (!pm2Bin) throw new Error('pm2 not found in PATH');
-        steps.push({ name: 'resolve pm2', success: true, output: pm2Bin });
-      } catch {
-        // Fallback: look for pm2 in node_modules
-        const localPm2 = path.join(this._appRoot, 'node_modules', '.bin', 'pm2');
-        if (fs.existsSync(localPm2)) {
-          pm2Bin = localPm2;
-          steps.push({ name: 'resolve pm2', success: true, output: `fallback: ${pm2Bin}` });
-        } else {
-          steps.push({ name: 'resolve pm2', success: false, output: 'pm2 not found in PATH or node_modules' });
-          return { success: false, steps, error: 'Cannot find pm2 binary to restart the server.' };
-        }
-      }
-
       // Delete + start in a single detached shell so pm2 picks up config
       // changes (interpreter, script name, env vars). Must be one detached
       // command because pm2 delete kills the current process.
-      // Log output to a file so restart failures leave a trace.
+      //
+      // Prepend node_modules/.bin to PATH so the detached shell can always
+      // find pm2 (a project dependency) without relying on global installs
+      // or npx. Log output so restart failures leave a trace.
+      const binDir = path.join(this._appRoot, 'node_modules', '.bin');
       const logFile = path.join(this._appRoot, 'data', 'update-restart.log');
-      const pm2 = spawn('sh', ['-c', `("${pm2Bin}" delete "${ecosystemPath}" 2>/dev/null; "${pm2Bin}" start "${ecosystemPath}") >> "${logFile}" 2>&1`], {
+      const pm2 = spawn('sh', ['-c', `export PATH="${binDir}:$PATH"; (pm2 delete "${ecosystemPath}" 2>/dev/null; pm2 start "${ecosystemPath}") >> "${logFile}" 2>&1`], {
         cwd: this._appRoot,
         detached: true,
         stdio: 'ignore',

--- a/test/updateService.test.ts
+++ b/test/updateService.test.ts
@@ -238,14 +238,13 @@ describe('UpdateService', () => {
         { stdout: 'Already on \'main\'\n' },
         { stdout: 'Already up to date.\n' },
         { stdout: 'up to date\n' },
-        { stdout: '/usr/local/bin/pm2\n' }, // which pm2
       ]);
 
       const result = await service.triggerUpdate({
         hasActiveStreams: () => false,
       });
       expect(result.success).toBe(true);
-      expect(result.steps).toHaveLength(6);
+      expect(result.steps).toHaveLength(5);
       expect(mockSpawnFn).toHaveBeenCalled();
     });
 
@@ -255,20 +254,18 @@ describe('UpdateService', () => {
         { stdout: 'Already on \'main\'\n' },     // git checkout
         { stdout: 'Updating abc..def\n' },        // git pull
         { stdout: 'added 0 packages\n' },         // npm install
-        { stdout: '/usr/local/bin/pm2\n' },        // which pm2
       ]);
 
       const result = await service.triggerUpdate({
         hasActiveStreams: () => false,
       });
       expect(result.success).toBe(true);
-      expect(result.steps).toHaveLength(6);
+      expect(result.steps).toHaveLength(5);
       expect(result.steps[0].name).toBe('git checkout main');
       expect(result.steps[1].name).toBe('git pull origin main');
       expect(result.steps[2].name).toBe('npm install');
       expect(result.steps[3].name).toBe('verify interpreter');
-      expect(result.steps[4].name).toBe('resolve pm2');
-      expect(result.steps[5].name).toBe('pm2 restart');
+      expect(result.steps[4].name).toBe('pm2 restart');
       result.steps.forEach(s => expect(s.success).toBe(true));
       expect(mockSpawnFn).toHaveBeenCalledWith('sh', expect.arrayContaining(['-c']), expect.objectContaining({ detached: true }));
       expect(mockSpawnResult.unref).toHaveBeenCalled();
@@ -307,7 +304,6 @@ describe('UpdateService', () => {
         { stdout: 'ok' },
         { stdout: 'ok' },
         { stdout: 'ok' },
-        { stdout: '/usr/local/bin/pm2\n' },
       ]);
 
       await service.triggerUpdate({ hasActiveStreams: () => false });
@@ -330,55 +326,19 @@ describe('UpdateService', () => {
       expect(mockSpawnFn).not.toHaveBeenCalled();
     });
 
-    test('fails when pm2 binary cannot be found', async () => {
-      const localPm2 = path.join(appRoot, 'node_modules', '.bin', 'pm2');
-      mockExistsSyncOverrides[localPm2] = false;
+    test('prepends node_modules/.bin to PATH in spawn command', async () => {
       mockExecFile([
         { stdout: '' },
         { stdout: 'ok' },
         { stdout: 'ok' },
         { stdout: 'ok' },
-        { error: 'not found' }, // which pm2 fails
-      ]);
-
-      const result = await service.triggerUpdate({ hasActiveStreams: () => false });
-      expect(result.success).toBe(false);
-      expect(result.error).toMatch(/Cannot find pm2/);
-      expect(result.steps.find(s => s.name === 'resolve pm2')?.success).toBe(false);
-      expect(mockSpawnFn).not.toHaveBeenCalled();
-    });
-
-    test('falls back to local pm2 when which fails', async () => {
-      const localPm2 = path.join(appRoot, 'node_modules', '.bin', 'pm2');
-      mockExistsSyncOverrides[localPm2] = true;
-      mockExecFile([
-        { stdout: '' },
-        { stdout: 'ok' },
-        { stdout: 'ok' },
-        { stdout: 'ok' },
-        { error: 'not found' }, // which pm2 fails
-      ]);
-
-      const result = await service.triggerUpdate({ hasActiveStreams: () => false });
-      expect(result.success).toBe(true);
-      const resolveStep = result.steps.find(s => s.name === 'resolve pm2');
-      expect(resolveStep?.success).toBe(true);
-      expect(resolveStep?.output).toContain('fallback');
-      expect(mockSpawnFn).toHaveBeenCalled();
-    });
-
-    test('uses resolved pm2 path in spawn command', async () => {
-      mockExecFile([
-        { stdout: '' },
-        { stdout: 'ok' },
-        { stdout: 'ok' },
-        { stdout: 'ok' },
-        { stdout: '/opt/homebrew/bin/pm2\n' },
       ]);
 
       await service.triggerUpdate({ hasActiveStreams: () => false });
       const spawnArgs = mockSpawnFn.mock.calls[0] as unknown[];
-      expect((spawnArgs[1] as string[])[1]).toContain('/opt/homebrew/bin/pm2');
+      const shellCmd = (spawnArgs[1] as string[])[1];
+      expect(shellCmd).toContain('node_modules/.bin');
+      expect(shellCmd).toMatch(/export PATH=.*node_modules\/\.bin/);
     });
 
     test('logs restart output to data/update-restart.log', async () => {
@@ -387,7 +347,6 @@ describe('UpdateService', () => {
         { stdout: 'ok' },
         { stdout: 'ok' },
         { stdout: 'ok' },
-        { stdout: '/usr/local/bin/pm2\n' },
       ]);
 
       await service.triggerUpdate({ hasActiveStreams: () => false });


### PR DESCRIPTION
## Summary
- Replace TypeScript-level pm2 path resolution with a shell-level `export PATH="node_modules/.bin:$PATH"` in the detached restart command
- This fixes the root cause: during self-update, the **old** code is still in memory when the restart spawns, so any TypeScript-level fixes only take effect on the *next* update — the shell command itself must be resilient
- Removed the `which pm2` + fallback logic (no longer needed)

## Test plan
- [x] Typecheck passes
- [x] All 320 tests pass
- [x] Dev server running and responding on port 3335