### PR TITLE
fix: self-update interpreter verification

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -529,7 +529,7 @@ All detail objects include `tool`, `id` (block id or null), and `description`. L
   4. `git checkout main` (30s timeout)
   5. `git pull origin main` (60s timeout)
   6. `npm install` (120s timeout)
-  7. Verify interpreter — reads `ecosystem.config.js`, checks the configured interpreter binary exists on disk (prevents restart with missing dependencies)
+  7. Verify interpreter — reads `ecosystem.config.js` fresh from disk (via `fs.readFileSync`, not `require`, to avoid stale cache), checks the configured interpreter exists. Path-based interpreters (starting with `.` or `/`) are checked on disk; bare commands (e.g. `npx`, `node`) are resolved via `which` on PATH
   8. Write restart script to `data/restart.sh` (sets PATH, sleeps 2s, `pm2 delete` + `pm2 start`), launch via double-fork (`nohup ... &` in subshell) to survive PM2 treekill. Output logged to `data/update-restart.log`
 
 Returns `{ success, steps: [{ name, success, output }] }`. On failure, includes `error` field.

--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -106,15 +106,33 @@ export class UpdateService {
       // Verify the interpreter from ecosystem config exists after npm install
       const ecosystemPath = path.join(this._appRoot, 'ecosystem.config.js');
       try {
-        const ecoConfig = require(ecosystemPath);
+        // Read fresh from disk — require() caches modules and returns stale
+        // config even after git pull updates the file
+        const ecoSource = fs.readFileSync(ecosystemPath, 'utf8');
+        const mod: { exports: Record<string, unknown> } = { exports: {} };
+        new Function('module', 'exports', ecoSource)(mod, mod.exports);
+        const ecoConfig = mod.exports as { apps?: Array<{ interpreter?: string }> };
         const app = ecoConfig.apps?.[0];
         if (app?.interpreter) {
-          const interpreterPath = path.resolve(this._appRoot, app.interpreter);
-          if (!fs.existsSync(interpreterPath)) {
-            steps.push({ name: 'verify interpreter', success: false, output: `Interpreter not found: ${interpreterPath}` });
-            return { success: false, steps, error: `Interpreter not found after npm install: ${app.interpreter}. Dependencies may not have installed correctly.` };
+          // Relative or absolute paths: resolve against appRoot and check on disk
+          // Bare commands (e.g. "npx", "node"): look up via PATH
+          const isPath = app.interpreter.startsWith('.') || app.interpreter.startsWith('/');
+          if (isPath) {
+            const interpreterPath = path.resolve(this._appRoot, app.interpreter);
+            if (!fs.existsSync(interpreterPath)) {
+              steps.push({ name: 'verify interpreter', success: false, output: `Interpreter not found: ${interpreterPath}` });
+              return { success: false, steps, error: `Interpreter not found after npm install: ${app.interpreter}. Dependencies may not have installed correctly.` };
+            }
+            steps.push({ name: 'verify interpreter', success: true, output: `Found: ${interpreterPath}` });
+          } else {
+            try {
+              const resolved = await this._exec('which', [app.interpreter], 5000);
+              steps.push({ name: 'verify interpreter', success: true, output: `Found on PATH: ${resolved.trim()}` });
+            } catch {
+              steps.push({ name: 'verify interpreter', success: false, output: `Interpreter not found on PATH: ${app.interpreter}` });
+              return { success: false, steps, error: `Interpreter not found on PATH: ${app.interpreter}. Ensure it is installed and available.` };
+            }
           }
-          steps.push({ name: 'verify interpreter', success: true, output: `Found: ${interpreterPath}` });
         }
       } catch (err: unknown) {
         steps.push({ name: 'verify interpreter', success: false, output: (err as Error).message });

--- a/test/updateService.test.ts
+++ b/test/updateService.test.ts
@@ -21,6 +21,14 @@ jest.spyOn(fs, 'existsSync').mockImplementation((p: fs.PathLike) => {
   return originalExistsSync(p);
 });
 
+const originalReadFileSync = fs.readFileSync.bind(fs);
+let mockReadFileSyncOverrides: Record<string, string> = {};
+jest.spyOn(fs, 'readFileSync').mockImplementation((...args: Parameters<typeof fs.readFileSync>) => {
+  const pStr = String(args[0]);
+  if (pStr in mockReadFileSyncOverrides) return mockReadFileSyncOverrides[pStr];
+  return originalReadFileSync(...args);
+});
+
 const originalWriteFileSync = fs.writeFileSync.bind(fs);
 const mockWriteFileSync = jest.spyOn(fs, 'writeFileSync').mockImplementation((...args: Parameters<typeof fs.writeFileSync>) => {
   // Allow writing the temp ecosystem config for CI, mock everything else
@@ -69,10 +77,9 @@ describe('UpdateService', () => {
     mockSpawnFn.mockClear();
     mockWriteFileSync.mockClear();
     mockExistsSyncOverrides = {};
+    mockReadFileSyncOverrides = {};
     // Default: interpreter exists
     mockExistsSyncOverrides[interpreterPath] = true;
-    // Clear require cache so each test gets a fresh load
-    delete require.cache[require.resolve(ecosystemPath)];
   });
 
   afterEach(() => {
@@ -330,6 +337,44 @@ describe('UpdateService', () => {
       const result = await service.triggerUpdate({ hasActiveStreams: () => false });
       expect(result.success).toBe(false);
       expect(result.error).toMatch(/Interpreter not found/);
+      expect(result.steps.find(s => s.name === 'verify interpreter')?.success).toBe(false);
+      expect(mockSpawnFn).not.toHaveBeenCalled();
+    });
+
+    test('succeeds when interpreter is a bare command found on PATH', async () => {
+      // Override readFileSync to return a config with a bare command interpreter
+      mockReadFileSyncOverrides[ecosystemPath] = `module.exports = { apps: [{ script: 'server.ts', interpreter: 'node' }] };`;
+
+      mockExecFile([
+        { stdout: '' },                          // git status
+        { stdout: 'ok' },                        // git checkout
+        { stdout: 'ok' },                        // git pull
+        { stdout: 'ok' },                        // npm install
+        { stdout: '/usr/local/bin/node\n' },     // which node
+      ]);
+
+      const result = await service.triggerUpdate({ hasActiveStreams: () => false });
+      expect(result.success).toBe(true);
+      const verifyStep = result.steps.find(s => s.name === 'verify interpreter');
+      expect(verifyStep?.success).toBe(true);
+      expect(verifyStep?.output).toMatch(/Found on PATH/);
+    });
+
+    test('fails when bare command interpreter is not found on PATH', async () => {
+      // Override readFileSync to return a config with a bare command that won't be found
+      mockReadFileSyncOverrides[ecosystemPath] = `module.exports = { apps: [{ script: 'server.ts', interpreter: 'nonexistent-cmd' }] };`;
+
+      mockExecFile([
+        { stdout: '' },                          // git status
+        { stdout: 'ok' },                        // git checkout
+        { stdout: 'ok' },                        // git pull
+        { stdout: 'ok' },                        // npm install
+        { error: 'not found' },                  // which nonexistent-cmd
+      ]);
+
+      const result = await service.triggerUpdate({ hasActiveStreams: () => false });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not found on PATH/);
       expect(result.steps.find(s => s.name === 'verify interpreter')?.success).toBe(false);
       expect(mockSpawnFn).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary
- Replace `require()` with `fs.readFileSync` + `new Function` for reading `ecosystem.config.js` during self-update, preventing stale module cache from returning outdated config after `git pull`
- Support bare command interpreters (e.g. `npx`, `node`) by resolving them via `which` on PATH, instead of only checking relative/absolute file paths on disk
- Add tests for both PATH-found and PATH-missing bare command scenarios

## Test plan
- [x] All 28 updateService tests pass (including 2 new tests)
- [x] Full test suite passes (333 tests, 8 suites)
- [x] Verified `new Function` evaluation works correctly for ecosystem config format