### PR TITLE
feat: conversation archival with dedicated archive UI

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -101,6 +101,7 @@ All workspace hashes throughout the system use: `SHA-256(workspacePath).substrin
     usageByBackend: {            // Per-backend usage breakdown (keyed by backend id)
       [backendId]: Usage
     }|null,
+    archived: boolean|undefined, // true when conversation is archived; absent/false = active
     sessions: [{
       number: number,           // 1-based session number
       sessionId: string,        // UUID passed to CLI
@@ -231,11 +232,13 @@ Recursively deletes directory. Refuses filesystem root. Returns `{ deleted, pare
 
 | Method | Path | CSRF | Description |
 |--------|------|------|-------------|
-| GET | `/conversations?q=<search>` | — | List all, sorted by `updatedAt` desc. Each summary includes `workspaceHash`. |
+| GET | `/conversations?q=<search>&archived=true` | — | List all, sorted by `updatedAt` desc. Each summary includes `workspaceHash`. Pass `archived=true` to list only archived conversations (default: active only). |
 | GET | `/conversations/:id` | — | Full conversation object. `404` if not found. |
 | POST | `/conversations` | Yes | `{ title?, workingDir? }` → creates conversation with initial session. |
 | PUT | `/conversations/:id` | Yes | `{ title }` → rename. `404` if not found. |
-| DELETE | `/conversations/:id` | Yes | Aborts active stream, removes from workspace index, deletes session folder + artifacts. |
+| DELETE | `/conversations/:id` | Yes | Aborts active stream, removes from workspace index, deletes session folder + artifacts. Works on both active and archived conversations. |
+| PATCH | `/conversations/:id/archive` | Yes | Sets `archived: true` on the conversation. Aborts active stream. Files remain on disk. `404` if not found. |
+| PATCH | `/conversations/:id/restore` | Yes | Removes `archived` flag, restoring the conversation to the active list. `404` if not found. |
 
 ### 3.3 Download
 
@@ -427,9 +430,11 @@ Unauthenticated requests redirect to `/auth/login`.
 | `initialize()` | Runs migration if legacy `conversations/` dir exists, builds convId→workspace lookup map. |
 | `createConversation(title, workingDir)` | Creates entry in workspace index + empty session-1.json. Falls back to `_defaultWorkspace`. |
 | `getConversation(id)` | Returns API-compatible object with messages, or `null`. |
-| `listConversations()` | Scans all workspace indexes. Returns summaries sorted by `lastActivity` desc, each with `workspaceHash`. |
+| `listConversations(opts?)` | Scans all workspace indexes. Returns summaries sorted by `lastActivity` desc, each with `workspaceHash`. Pass `{ archived: true }` to list only archived; default returns active only. |
 | `renameConversation(id, newTitle)` | Updates title in workspace index. Returns full conversation or `null`. |
-| `deleteConversation(id)` | Removes from index, deletes session folder + artifacts, removes from lookup map. |
+| `archiveConversation(id)` | Sets `archived: true` on conversation entry in workspace index. Returns `true` or `false` if not found. Files remain on disk. |
+| `restoreConversation(id)` | Removes `archived` flag from conversation entry. Returns `true` or `false` if not found. |
+| `deleteConversation(id)` | Removes from index, deletes session folder + artifacts, removes from lookup map. Works on both active and archived conversations. |
 | `updateConversationBackend(convId, backend)` | Updates backend field in workspace index. |
 | `addMessage(convId, role, content, backend, thinking, toolActivity)` | Appends to active session + updates index metadata. Auto-titles on first user message (session 1 only; post-reset sessions rely on LLM title generation). `thinking` omitted if falsy. `toolActivity` omitted if falsy or empty array. |
 | `updateMessageContent(convId, messageId, newContent)` | Truncates after target message, adds edited content as new message. |
@@ -443,7 +448,7 @@ Unauthenticated requests redirect to `/auth/login`.
 | `setWorkspaceInstructions(hash, instructions)` | Saves to workspace index. Returns string or `null`. |
 | `getWorkspaceHashForConv(convId)` | Returns workspace hash or `null`. |
 | `getWorkspaceContext(convId)` | **Synchronous.** Returns injection prompt string or `null`. |
-| `searchConversations(query)` | Case-insensitive: checks title/lastMessage first, then deep-searches session files. |
+| `searchConversations(query, opts?)` | Case-insensitive: checks title/lastMessage first, then deep-searches session files. Respects `{ archived }` filter same as `listConversations`. |
 | `getSettings()` | Returns settings from disk or defaults. |
 | `saveSettings(settings)` | Writes settings to disk. |
 
@@ -692,8 +697,9 @@ Vanilla JavaScript SPA — no framework, no bundler, no build step. Frontend is 
 
 - **New conversation:** folder picker modal (via `/browse` API) → user selects directory → POST creates conversation
 - **Sidebar list:** grouped by workspace (last 2 path segments of `workingDir`), sorted by `updatedAt` desc. Groups are collapsible (state in localStorage). Each group header has a pencil icon for workspace instructions.
-- **Context menu:** right-click on conversation items for rename/delete
-- **Search:** debounced, case-insensitive search across titles, last messages, and full content
+- **Context menu:** right-click on conversation items for rename/archive/delete (active view) or restore/delete (archive view)
+- **Archive:** conversations can be archived via context menu. Archived conversations are hidden from the main sidebar but all files (sessions, artifacts) remain on disk. A toggle at the bottom of the sidebar switches between active and archived views. Archived conversations can be browsed, searched, restored, or permanently deleted.
+- **Search:** debounced, case-insensitive search across titles, last messages, and full content. Respects active/archive view filter.
 
 ### Messaging & Streaming
 
@@ -858,8 +864,8 @@ Update OAuth callback URLs to include the ngrok URL.
 | File | Focus |
 |------|-------|
 | `test/backends.test.ts` | BaseBackendAdapter (including generateTitle), BackendRegistry, ClaudeCodeAdapter, extractToolDetails, extractToolOutcome, extractUsage |
-| `test/chat.test.ts` | Chat routes: WebSocket streaming (text, tool_activity, stdin input, abort, assistant_message), WebSocket reconnection (replay buffered events, CLI survives disconnect, CLI crash buffers error, abort clears buffer, session reset clears buffer), turn boundaries, turn_complete event forwarding, tool activity persistence, parallel agent persistence, session overview aggregation, auto title update on session reset, usage event forwarding and persistence (including sessionUsage), usage stats endpoints (GET/DELETE), file upload/serve, workspace instructions |
-| `test/chatService.test.ts` | ChatService CRUD, messages (including toolActivity persistence), sessions, generateAndUpdateTitle, usage tracking (addUsage with conversationUsage/sessionUsage, usageByBackend, daily ledger with backend+model dimensions, model separation, getUsage, getUsageStats, clearUsageStats), workspace storage, migration, markdown export |
+| `test/chat.test.ts` | Chat routes: WebSocket streaming (text, tool_activity, stdin input, abort, assistant_message), WebSocket reconnection (replay buffered events, CLI survives disconnect, CLI crash buffers error, abort clears buffer, session reset clears buffer), turn boundaries, turn_complete event forwarding, tool activity persistence, parallel agent persistence, session overview aggregation, auto title update on session reset, usage event forwarding and persistence (including sessionUsage), usage stats endpoints (GET/DELETE), file upload/serve, workspace instructions, archive/restore endpoints |
+| `test/chatService.test.ts` | ChatService CRUD, messages (including toolActivity persistence), sessions, generateAndUpdateTitle, archive/restore (flag set/remove, file preservation, list filtering, search filtering, delete-after-archive), usage tracking (addUsage with conversationUsage/sessionUsage, usageByBackend, daily ledger with backend+model dimensions, model separation, getUsage, getUsageStats, clearUsageStats), workspace storage, migration, markdown export |
 | `test/draftState.test.ts` | Draft save/restore, key migration, cleanup, round-trip |
 | `test/messageQueue.test.ts` | Message queue: adding, deleting, rendering, in-flight protection, pause/resume, per-conversation isolation, send button state |
 | `test/graceful-shutdown.test.ts` | Server shutdown on SIGINT/SIGTERM |

--- a/public/js/conversations.js
+++ b/public/js/conversations.js
@@ -196,8 +196,11 @@ export function chatToggleSidebar() {
 export async function chatLoadConversations(query) {
   const gen = ++state.chatConvLoadGen;
   try {
-    const q = query ? `?q=${encodeURIComponent(query)}` : '';
-    const res = await chatFetch(`conversations${q}`);
+    const params = new URLSearchParams();
+    if (query) params.set('q', query);
+    if (state.chatViewingArchive) params.set('archived', 'true');
+    const qs = params.toString() ? `?${params.toString()}` : '';
+    const res = await chatFetch(`conversations${qs}`);
     if (gen !== state.chatConvLoadGen) return;
     const data = await res.json();
     state.chatConversations = data.conversations || [];
@@ -243,8 +246,10 @@ export function chatRenderConvList() {
   const list = document.getElementById('chat-conv-list');
   if (!list) return;
 
+  const emptyMsg = state.chatViewingArchive ? 'No archived conversations' : 'No conversations yet';
   if (state.chatConversations.length === 0) {
-    list.innerHTML = '<div style="padding:20px;text-align:center;color:var(--muted);font-size:12px;">No conversations yet</div>';
+    list.innerHTML = `<div style="padding:20px;text-align:center;color:var(--muted);font-size:12px;">${emptyMsg}</div>`;
+    chatRenderArchiveToggle();
     return;
   }
 
@@ -278,11 +283,49 @@ export function chatRenderConvList() {
     }
   }
   list.innerHTML = html;
+  chatRenderArchiveToggle();
+}
+
+function chatRenderArchiveToggle() {
+  const sidebar = document.getElementById('chat-sidebar');
+  if (!sidebar) return;
+  let toggle = sidebar.querySelector('.chat-archive-toggle');
+  if (!toggle) {
+    toggle = document.createElement('button');
+    toggle.className = 'chat-archive-toggle';
+    toggle.addEventListener('click', chatToggleArchiveView);
+    const settingsBtn = document.getElementById('chat-settings-btn');
+    if (settingsBtn) {
+      sidebar.insertBefore(toggle, settingsBtn);
+    } else {
+      sidebar.appendChild(toggle);
+    }
+  }
+  if (state.chatViewingArchive) {
+    toggle.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M6 12L2 8l4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M2 8h12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg> Back to conversations';
+  } else {
+    toggle.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="none"><rect x="1.5" y="2.5" width="13" height="11" rx="1.5" stroke="currentColor" stroke-width="1.3"/><path d="M1.5 5.5h13" stroke="currentColor" stroke-width="1.3"/><path d="M6 8.5h4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg> Archive';
+  }
+}
+
+export function chatToggleArchiveView() {
+  state.chatViewingArchive = !state.chatViewingArchive;
+  if (state.chatViewingArchive) {
+    state.chatActiveConvId = null;
+    state.chatActiveConv = null;
+    chatRenderMessages();
+    chatUpdateHeader();
+  }
+  chatLoadConversations();
 }
 
 // ── Conversation operations ───────────────────────────────────────────────────
 
 export async function chatNewConversation() {
+  if (state.chatViewingArchive) {
+    state.chatViewingArchive = false;
+    chatLoadConversations();
+  }
   chatShowFolderPicker();
 }
 
@@ -596,6 +639,37 @@ export async function chatDeleteConversation(id) {
   }
 }
 
+export async function chatArchiveConversation(id) {
+  try {
+    await chatFetch(`conversations/${id}/archive`, { method: 'PATCH' });
+    state.chatDraftState.delete(id);
+    if (state.chatActiveConvId === id) {
+      for (const entry of state.chatPendingFiles) {
+        if (entry.status === 'uploading' && entry.xhr) entry.xhr.abort();
+      }
+      state.chatPendingFiles = [];
+      chatRenderFileChips();
+      state.chatActiveConvId = null;
+      state.chatActiveConv = null;
+      chatRenderMessages();
+      chatUpdateHeader();
+      chatUpdateSendButtonState();
+    }
+    chatLoadConversations();
+  } catch (err) {
+    alert('Failed to archive: ' + err.message);
+  }
+}
+
+export async function chatRestoreConversation(id) {
+  try {
+    await chatFetch(`conversations/${id}/restore`, { method: 'PATCH' });
+    chatLoadConversations();
+  } catch (err) {
+    alert('Failed to restore: ' + err.message);
+  }
+}
+
 // ── Header / usage display ───────────────────────────────────────────────────
 
 export function chatUpdateHeader() {
@@ -691,10 +765,18 @@ export function chatShowContextMenu(e, convId) {
   chatCloseContextMenu();
   const menu = document.createElement('div');
   menu.className = 'chat-context-menu';
-  menu.innerHTML = `
-    <button class="chat-context-menu-item" data-action="rename">Rename</button>
-    <button class="chat-context-menu-item danger" data-action="delete">Delete</button>
-  `;
+  if (state.chatViewingArchive) {
+    menu.innerHTML = `
+      <button class="chat-context-menu-item" data-action="restore">Restore</button>
+      <button class="chat-context-menu-item danger" data-action="delete">Delete</button>
+    `;
+  } else {
+    menu.innerHTML = `
+      <button class="chat-context-menu-item" data-action="rename">Rename</button>
+      <button class="chat-context-menu-item" data-action="archive">Archive</button>
+      <button class="chat-context-menu-item danger" data-action="delete">Delete</button>
+    `;
+  }
   menu.style.left = e.clientX + 'px';
   menu.style.top = e.clientY + 'px';
 
@@ -703,6 +785,8 @@ export function chatShowContextMenu(e, convId) {
       chatCloseContextMenu();
       if (item.dataset.action === 'rename') chatRenameConversation(convId);
       else if (item.dataset.action === 'delete') chatDeleteConversation(convId);
+      else if (item.dataset.action === 'archive') chatArchiveConversation(convId);
+      else if (item.dataset.action === 'restore') chatRestoreConversation(convId);
     };
   });
 

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -12,6 +12,7 @@ export const state = {
   chatStreamingState: new Map(), // convId -> { assistantContent, assistantThinking, activeTools, activeAgents, planModeActive, pendingInteraction, streamingMsgEl }
   chatAbortController: null,
   chatSidebarCollapsed: false,
+  chatViewingArchive: false,
   chatSearchTimeout: null,
   chatContextMenuEl: null,
   chatSettingsData: null,

--- a/public/styles.css
+++ b/public/styles.css
@@ -1843,6 +1843,25 @@
   .chat-context-menu-item.danger { color: var(--danger); }
   .chat-context-menu-item.danger:hover { background: rgba(220,38,38,0.08); }
 
+  /* ── Archive Toggle ──────────────────────────────────────── */
+  .chat-archive-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 10px 16px;
+    font-size: 12px;
+    color: var(--muted);
+    background: none;
+    border: none;
+    border-top: 1px solid var(--border);
+    cursor: pointer;
+    text-align: left;
+    flex-shrink: 0;
+  }
+  .chat-archive-toggle:hover { color: var(--text); background: var(--surface2); }
+  .chat-archive-toggle svg { flex-shrink: 0; }
+
   /* ── Settings Modal ───────────────────────────────────────── */
   .chat-modal-overlay {
     position: fixed;

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -363,7 +363,9 @@ export function createChatRouter({ chatService, backendRegistry, updateService }
   router.get('/conversations', async (req: Request, res: Response) => {
     try {
       const q = (req.query.q as string) || '';
-      const convs = q ? await chatService.searchConversations(q) : await chatService.listConversations();
+      const archived = req.query.archived === 'true';
+      const opts = { archived };
+      const convs = q ? await chatService.searchConversations(q, opts) : await chatService.listConversations(opts);
       res.json({ conversations: convs });
     } catch (err: unknown) {
       res.status(500).json({ error: (err as Error).message });
@@ -411,6 +413,33 @@ export function createChatRouter({ chatService, backendRegistry, updateService }
         activeStreams.delete(param(req, 'id'));
       }
       const ok = await chatService.deleteConversation(param(req, 'id'));
+      if (!ok) return res.status(404).json({ error: 'Conversation not found' });
+      res.json({ ok: true });
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // ── Archive conversation ───────────────────────────────────────────────────
+  router.patch('/conversations/:id/archive', csrfGuard, async (req: Request, res: Response) => {
+    try {
+      const entry = activeStreams.get(param(req, 'id'));
+      if (entry) {
+        entry.abort();
+        activeStreams.delete(param(req, 'id'));
+      }
+      const ok = await chatService.archiveConversation(param(req, 'id'));
+      if (!ok) return res.status(404).json({ error: 'Conversation not found' });
+      res.json({ ok: true });
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // ── Restore conversation ──────────────────────────────────────────────────
+  router.patch('/conversations/:id/restore', csrfGuard, async (req: Request, res: Response) => {
+    try {
+      const ok = await chatService.restoreConversation(param(req, 'id'));
       if (!ok) return res.status(404).json({ error: 'Conversation not found' });
       res.json({ ok: true });
     } catch (err: unknown) {

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -259,7 +259,8 @@ export class ChatService {
     };
   }
 
-  async listConversations(): Promise<ConversationListItem[]> {
+  async listConversations(opts?: { archived?: boolean }): Promise<ConversationListItem[]> {
+    const wantArchived = opts?.archived === true;
     const convs: ConversationListItem[] = [];
     let dirs: string[];
     try {
@@ -274,6 +275,8 @@ export class ChatService {
       const index = await this._readWorkspaceIndex(hash);
       if (!index || !index.conversations) continue;
       for (const conv of index.conversations) {
+        const isArchived = !!conv.archived;
+        if (isArchived !== wantArchived) continue;
         const activeSession = conv.sessions.find(s => s.active);
         convs.push({
           id: conv.id,
@@ -285,6 +288,7 @@ export class ChatService {
           messageCount: activeSession ? activeSession.messageCount : 0,
           lastMessage: conv.lastMessage,
           usage: conv.usage || null,
+          archived: conv.archived,
         });
       }
     }
@@ -302,6 +306,24 @@ export class ChatService {
     await this._writeWorkspaceIndex(hash, index);
 
     return this.getConversation(id);
+  }
+
+  async archiveConversation(id: string): Promise<boolean> {
+    const result = await this._getConvFromIndex(id);
+    if (!result) return false;
+    const { hash, index, convEntry } = result;
+    convEntry.archived = true;
+    await this._writeWorkspaceIndex(hash, index);
+    return true;
+  }
+
+  async restoreConversation(id: string): Promise<boolean> {
+    const result = await this._getConvFromIndex(id);
+    if (!result) return false;
+    const { hash, index, convEntry } = result;
+    delete convEntry.archived;
+    await this._writeWorkspaceIndex(hash, index);
+    return true;
   }
 
   async deleteConversation(id: string): Promise<boolean> {
@@ -673,10 +695,10 @@ export class ChatService {
 
   // ── Search ─────────────────────────────────────────────────────────────────
 
-  async searchConversations(query: string): Promise<ConversationListItem[]> {
-    if (!query) return this.listConversations();
+  async searchConversations(query: string, opts?: { archived?: boolean }): Promise<ConversationListItem[]> {
+    if (!query) return this.listConversations(opts);
     const q = query.toLowerCase();
-    const all = await this.listConversations();
+    const all = await this.listConversations(opts);
     const results: ConversationListItem[] = [];
 
     for (const c of all) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -98,6 +98,7 @@ export interface ConversationEntry {
   usage?: Usage;
   usageByBackend?: Record<string, Usage>;
   sessions: SessionEntry[];
+  archived?: boolean;
 }
 
 export interface WorkspaceIndex {
@@ -128,6 +129,7 @@ export interface ConversationListItem {
   messageCount: number;
   lastMessage: string | null;
   usage: Usage | null;
+  archived?: boolean;
 }
 
 // ── Settings ─────────────────────────────────────────────────────────────────

--- a/test/chat.test.ts
+++ b/test/chat.test.ts
@@ -84,7 +84,7 @@ function makeRequest(method: string, urlPath: string, body?: any): Promise<{ sta
       method,
       hostname: url.hostname,
       port: url.port,
-      path: url.pathname,
+      path: url.pathname + url.search,
       headers: {
         'x-csrf-token': CSRF_TOKEN,
         'Content-Type': 'application/json',
@@ -1003,7 +1003,71 @@ describe('System prompt passthrough', () => {
   });
 });
 
-// ── DELETE /conversations/:id/upload/:filename ────────────────────────────────
+// ── PATCH /conversations/:id/archive ───────────────────��─────────────────────
+
+describe('PATCH /conversations/:id/archive', () => {
+  test('archives a conversation', async () => {
+    const conv = await chatService.createConversation('Test');
+    const res = await makeRequest('PATCH', `/api/chat/conversations/${conv.id}/archive`);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+
+    // Should not appear in default list
+    const listRes = await makeRequest('GET', '/api/chat/conversations');
+    expect(listRes.body.conversations.find((c: any) => c.id === conv.id)).toBeUndefined();
+
+    // Should appear in archived list
+    const archiveRes = await makeRequest('GET', '/api/chat/conversations?archived=true');
+    expect(archiveRes.body.conversations.find((c: any) => c.id === conv.id)).toBeDefined();
+  });
+
+  test('returns 404 for non-existent conversation', async () => {
+    const res = await makeRequest('PATCH', '/api/chat/conversations/nope/archive');
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── PATCH /conversations/:id/restore ─────────────────────────────────────────
+
+describe('PATCH /conversations/:id/restore', () => {
+  test('restores an archived conversation', async () => {
+    const conv = await chatService.createConversation('Test');
+    await chatService.archiveConversation(conv.id);
+
+    const res = await makeRequest('PATCH', `/api/chat/conversations/${conv.id}/restore`);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+
+    // Should appear in default list again
+    const listRes = await makeRequest('GET', '/api/chat/conversations');
+    expect(listRes.body.conversations.find((c: any) => c.id === conv.id)).toBeDefined();
+  });
+
+  test('returns 404 for non-existent conversation', async () => {
+    const res = await makeRequest('PATCH', '/api/chat/conversations/nope/restore');
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── GET /conversations?archived=true ──────��─────────────────────────────────
+
+describe('GET /conversations?archived=true', () => {
+  test('returns only archived conversations', async () => {
+    const c1 = await chatService.createConversation('Active');
+    const c2 = await chatService.createConversation('Archived');
+    await chatService.archiveConversation(c2.id);
+
+    const activeRes = await makeRequest('GET', '/api/chat/conversations');
+    expect(activeRes.body.conversations).toHaveLength(1);
+    expect(activeRes.body.conversations[0].id).toBe(c1.id);
+
+    const archivedRes = await makeRequest('GET', '/api/chat/conversations?archived=true');
+    expect(archivedRes.body.conversations).toHaveLength(1);
+    expect(archivedRes.body.conversations[0].id).toBe(c2.id);
+  });
+});
+
+// ── DELETE /conversations/:id/upload/:filename ─────────────────────────────��──
 
 describe('DELETE /conversations/:id/upload/:filename', () => {
   test('deletes an uploaded file', async () => {

--- a/test/chatService.test.ts
+++ b/test/chatService.test.ts
@@ -183,6 +183,121 @@ describe('deleteConversation', () => {
   });
 });
 
+// ── Archive / Restore ───────────────────────────────────────────────────────
+
+describe('archiveConversation', () => {
+  test('sets archived flag on conversation', async () => {
+    const conv = await service.createConversation('Archive Me');
+    expect(await service.archiveConversation(conv.id)).toBe(true);
+
+    // Should not appear in default list
+    const active = await service.listConversations();
+    expect(active.find(c => c.id === conv.id)).toBeUndefined();
+
+    // Should appear in archived list
+    const archived = await service.listConversations({ archived: true });
+    expect(archived).toHaveLength(1);
+    expect(archived[0].id).toBe(conv.id);
+  });
+
+  test('returns false for non-existent id', async () => {
+    expect(await service.archiveConversation('nope')).toBe(false);
+  });
+
+  test('does not delete session files or artifacts', async () => {
+    const conv = await service.createConversation('Keep Files', '/tmp/work');
+    await service.addMessage(conv.id, 'user', 'Hello', 'claude-code');
+    const artifactDir = path.join(tmpDir, 'data', 'chat', 'artifacts', conv.id);
+    fs.mkdirSync(artifactDir, { recursive: true });
+    fs.writeFileSync(path.join(artifactDir, 'test.txt'), 'hello');
+
+    await service.archiveConversation(conv.id);
+
+    const hash = workspaceHash('/tmp/work');
+    const sessionPath = path.join(tmpDir, 'data', 'chat', 'workspaces', hash, conv.id, 'session-1.json');
+    expect(fs.existsSync(sessionPath)).toBe(true);
+    expect(fs.existsSync(path.join(artifactDir, 'test.txt'))).toBe(true);
+  });
+});
+
+describe('restoreConversation', () => {
+  test('restores archived conversation to active list', async () => {
+    const conv = await service.createConversation('Restore Me');
+    await service.archiveConversation(conv.id);
+
+    expect(await service.restoreConversation(conv.id)).toBe(true);
+
+    const active = await service.listConversations();
+    expect(active.find(c => c.id === conv.id)).toBeDefined();
+
+    const archived = await service.listConversations({ archived: true });
+    expect(archived.find(c => c.id === conv.id)).toBeUndefined();
+  });
+
+  test('returns false for non-existent id', async () => {
+    expect(await service.restoreConversation('nope')).toBe(false);
+  });
+});
+
+describe('listConversations with archived filter', () => {
+  test('default excludes archived', async () => {
+    const c1 = await service.createConversation('Active');
+    const c2 = await service.createConversation('Archived');
+    await service.archiveConversation(c2.id);
+
+    const list = await service.listConversations();
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe(c1.id);
+  });
+
+  test('archived=true returns only archived', async () => {
+    const c1 = await service.createConversation('Active');
+    const c2 = await service.createConversation('Archived');
+    await service.archiveConversation(c2.id);
+
+    const list = await service.listConversations({ archived: true });
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe(c2.id);
+  });
+});
+
+describe('searchConversations with archived filter', () => {
+  test('default search excludes archived', async () => {
+    await service.createConversation('Alpha Active');
+    const c2 = await service.createConversation('Alpha Archived');
+    await service.archiveConversation(c2.id);
+
+    const results = await service.searchConversations('alpha');
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe('Alpha Active');
+  });
+
+  test('archived search finds only archived', async () => {
+    await service.createConversation('Alpha Active');
+    const c2 = await service.createConversation('Alpha Archived');
+    await service.archiveConversation(c2.id);
+
+    const results = await service.searchConversations('alpha', { archived: true });
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe('Alpha Archived');
+  });
+});
+
+describe('deleteConversation on archived conversation', () => {
+  test('deletes an archived conversation and removes files', async () => {
+    const conv = await service.createConversation('Archive Then Delete', '/tmp/work');
+    await service.addMessage(conv.id, 'user', 'Hello', 'claude-code');
+    await service.archiveConversation(conv.id);
+
+    expect(await service.deleteConversation(conv.id)).toBe(true);
+    expect(await service.getConversation(conv.id)).toBeNull();
+
+    const hash = workspaceHash('/tmp/work');
+    const convDir = path.join(tmpDir, 'data', 'chat', 'workspaces', hash, conv.id);
+    expect(fs.existsSync(convDir)).toBe(false);
+  });
+});
+
 describe('updateConversationBackend', () => {
   test('updates backend in workspace index', async () => {
     const conv = await service.createConversation('Test');


### PR DESCRIPTION
## Summary

- Adds ability to archive conversations instead of only deleting them. Archived conversations are hidden from the main sidebar but all files (sessions, artifacts) remain on disk.
- New `PATCH /conversations/:id/archive` and `PATCH /conversations/:id/restore` endpoints; `GET /conversations` accepts `?archived=true` filter.
- Sidebar toggle button (above Settings) switches between active and archived views. Context menu shows Archive in active view, Restore in archive view.
- 15 new tests covering archive, restore, list filtering, search filtering, and delete-after-archive flows.

Closes #55

## Test plan

- [x] All 353 existing + new tests pass (`npx jest`)
- [ ] Manually verify archiving a conversation removes it from sidebar
- [ ] Verify clicking "Archive" toggle shows archived conversations
- [ ] Verify restoring moves conversation back to active list
- [ ] Verify deleting an archived conversation permanently removes files