### PR TITLE
feat: persist message queue across browser restarts

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -104,6 +104,7 @@ All workspace hashes throughout the system use: `SHA-256(workspacePath).substrin
       [backendId]: Usage
     }|null,
     archived: boolean|undefined, // true when conversation is archived; absent/false = active
+    messageQueue: string[]|undefined, // Persisted follow-up message queue (content strings); absent when empty
     sessions: [{
       number: number,           // 1-based session number
       sessionId: string,        // UUID passed to CLI
@@ -245,29 +246,39 @@ Recursively deletes directory. Refuses filesystem root. Returns `{ deleted, pare
 | PATCH | `/conversations/:id/archive` | Yes | Sets `archived: true` on the conversation. Aborts active stream. Files remain on disk. `404` if not found. |
 | PATCH | `/conversations/:id/restore` | Yes | Removes `archived` flag, restoring the conversation to the active list. `404` if not found. |
 
-### 3.3 Download
+### 3.3 Message Queue
+
+| Method | Path | CSRF | Description |
+|--------|------|------|-------------|
+| GET | `/conversations/:id/queue` | — | Returns `{ queue: string[] }`. Empty array if none persisted. |
+| PUT | `/conversations/:id/queue` | Yes | `{ queue: string[] }` → replaces the full queue. `400` if body is invalid. `404` if conversation not found. |
+| DELETE | `/conversations/:id/queue` | Yes | Clears the queue. `404` if conversation not found. |
+
+The queue is also included in the `GET /conversations/:id` response as `messageQueue` (omitted when empty). Queue is automatically cleared on session reset and archive.
+
+### 3.4 Download
 
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/conversations/:id/download` | Full conversation as `.md` attachment. |
 | GET | `/conversations/:id/sessions/:num/download` | Single session as `.md` attachment. |
 
-### 3.4 Sessions
+### 3.5 Sessions
 
 | Method | Path | CSRF | Description |
 |--------|------|------|-------------|
 | GET | `/conversations/:id/sessions` | — | Session list with `isCurrent` flag and `summary`. |
 | GET | `/conversations/:id/sessions/:num/messages` | — | Messages for a specific session. `400`/`404` on error. |
-| POST | `/conversations/:id/reset` | Yes | Archives active session (generates LLM summary), creates new session, resets title to "New Chat". `409` if streaming. Clears any stale WebSocket event buffer for the conversation. Returns `{ conversation, newSessionNumber, archivedSession }`. |
+| POST | `/conversations/:id/reset` | Yes | Archives active session (generates LLM summary), creates new session, resets title to "New Chat", clears message queue. `409` if streaming. Clears any stale WebSocket event buffer for the conversation. Returns `{ conversation, newSessionNumber, archivedSession }`. |
 
-### 3.5 Backends
+### 3.6 Backends
 
 ```
 GET /backends
 ```
 Returns `{ backends: [{ id, label, icon, capabilities }] }` — metadata for every registered adapter.
 
-### 3.6 Messaging and Streaming
+### 3.7 Messaging and Streaming
 
 **Send message:**
 ```
@@ -349,7 +360,7 @@ ws(s)://host/api/chat/conversations/:id/ws
 4. Session reset → new session with fresh UUID
 5. `isNewSession` determined by `messageCount === 0`
 
-### 3.7 File Upload
+### 3.8 File Upload
 
 ```
 POST /conversations/:id/upload  [CSRF]
@@ -368,21 +379,21 @@ GET /conversations/:id/files/:filename
 ```
 Serves file via `res.sendFile()`. Path traversal guard. No CSRF (used by `<img>` tags).
 
-### 3.8 Settings
+### 3.9 Settings
 
 | Method | Path | CSRF | Description |
 |--------|------|------|-------------|
 | GET | `/settings` | — | Returns settings (defaults if file missing). |
 | PUT | `/settings` | Yes | Writes full body to `settings.json`. |
 
-### 3.9 Usage Statistics
+### 3.10 Usage Statistics
 
 | Method | Path | CSRF | Description |
 |--------|------|------|-------------|
 | GET | `/usage-stats` | — | Returns the usage ledger (`{ days: [...] }`). |
 | DELETE | `/usage-stats` | Yes | Clears all usage statistics (resets ledger to empty). |
 
-### 3.10 Workspace Instructions
+### 3.11 Workspace Instructions
 
 Per-workspace instructions appended to the global system prompt on new sessions. Stored in workspace `index.json` under `instructions`.
 
@@ -397,7 +408,7 @@ Per-workspace instructions appended to the global system prompt on new sessions.
 
 Concatenated with `\n\n` and passed as `--append-system-prompt`. Not sent on session resume.
 
-### 3.10 Version & Self-Update
+### 3.12 Version & Self-Update
 
 | Method | Path | CSRF | Description |
 |--------|------|------|-------------|
@@ -406,7 +417,7 @@ Concatenated with `\n\n` and passed as `--append-system-prompt`. Not sent on ses
 | POST | `/check-version` | Yes | Triggers immediate remote check, returns status. |
 | POST | `/update-trigger` | Yes | Full update sequence (see Section 4, UpdateService). |
 
-### 3.11 Error Response Patterns
+### 3.13 Error Response Patterns
 
 | Status | Meaning | Body |
 |--------|---------|------|
@@ -771,7 +782,7 @@ Vanilla JavaScript SPA — no framework, no bundler, no build step. Frontend is 
 - **Usage display:** a small indicator in the conversation header shows **session-level** token count and USD cost. Updated in real-time when `usage` events arrive during streaming. Displays on hover a tooltip with session input/output/cache token breakdown and cost, plus conversation-level totals. Hidden when no usage data exists (e.g. new conversation).
 - **Stream cleanup:** `chatCleanupStreamState()` accepts `{ force }` option. The `finally` block uses `force: true` to ensure cleanup even when a pending interaction was never resolved. Interaction response handlers also use forced cleanup when the stream has already ended.
 - **Send button state:** shows stop (■) when streaming with no text input, send (↑) when idle or when streaming with text input (to queue). Disabled during uploads or session resets.
-- **Message queue:** Users can compose and submit messages while the CLI is actively responding. Queued messages are stored client-side in `chatMessageQueue` (Map of convId → array of `{ id, content, inFlight }`). They appear inline in the chat after the streaming bubble, styled as user messages with reduced opacity and an accent left border. Each queued message shows a "Queued" badge and has Edit and Delete buttons. Editing is inline via a textarea replacing the message content. In-flight messages (being dispatched to the CLI) show "Sending..." and cannot be edited or deleted. When a response completes successfully, the next queued message is automatically sent (FIFO). On error, the queue pauses and a banner appears with Resume and Clear buttons. The `chatQueuePaused` Set tracks paused conversations. Queuing a new message while paused un-pauses the queue. Queue state is per-conversation and purely client-side (not persisted to disk).
+- **Message queue:** Users can compose and submit messages while the CLI is actively responding. Queued messages are stored client-side in `chatMessageQueue` (Map of convId → array of `{ id, content, inFlight }`) and **persisted server-side** as `messageQueue` (array of content strings) on the conversation entry. On every queue mutation (add, edit, delete, shift, clear), a sequential coalescing PUT syncs the current state to the server — at most one PUT in flight at a time, with a follow-up if mutations occur during the request. Queued messages appear inline in the chat after the streaming bubble, styled as user messages with reduced opacity and an accent left border. Each shows a "Queued" badge and has Edit and Delete buttons. In-flight messages show "Sending..." and cannot be edited or deleted. When a response completes successfully, the next queued message is automatically sent (FIFO). Queue has three states: **Active** (streaming, auto-execute on completion), **Paused** (error, banner with Resume/Clear), and **Suspended** (restored from server after page load). The `chatQueuePaused` Set tracks paused conversations; `chatQueueSuspended` tracks restored conversations. On loading a conversation with a non-empty persisted queue and no active stream, the queue is restored into client state and marked suspended. A banner reads "N queued messages from a previous session" with Resume and Clear buttons. Suspended queues do not auto-execute — the user must explicitly resume. Queue is automatically cleared on session reset and archive.
 
 ### File Handling
 
@@ -913,10 +924,10 @@ Update OAuth callback URLs to include the ngrok URL.
 | `test/toolUtils.test.ts` | Shared backend helpers: extractToolDetails, extractToolOutcome, extractUsage, shortenPath, sanitizeSystemPrompt, isApiError |
 | `test/backends.test.ts` | BaseBackendAdapter (including generateTitle), BackendRegistry (including shutdownAll), ClaudeCodeAdapter |
 | `test/kiroBackend.test.ts` | KiroAdapter metadata, lifecycle (shutdown, onSessionReset), extractKiroToolDetails tool name normalization, generateSummary/generateTitle fallbacks |
-| `test/chat.test.ts` | Chat routes: WebSocket streaming (text, tool_activity, stdin input, abort, assistant_message), WebSocket reconnection (replay buffered events, CLI survives disconnect, CLI crash buffers error, abort clears buffer, session reset clears buffer), turn boundaries, turn_complete event forwarding, tool activity persistence, parallel agent persistence, session overview aggregation, auto title update on session reset, usage event forwarding and persistence (including sessionUsage), usage stats endpoints (GET/DELETE), file upload/serve, workspace instructions, archive/restore endpoints |
+| `test/chat.test.ts` | Chat routes: WebSocket streaming (text, tool_activity, stdin input, abort, assistant_message), WebSocket reconnection (replay buffered events, CLI survives disconnect, CLI crash buffers error, abort clears buffer, session reset clears buffer), turn boundaries, turn_complete event forwarding, tool activity persistence, parallel agent persistence, session overview aggregation, auto title update on session reset, usage event forwarding and persistence (including sessionUsage), usage stats endpoints (GET/DELETE), file upload/serve, workspace instructions, archive/restore endpoints, message queue persistence (GET/PUT/DELETE, included in conversation response, cleared on reset/archive) |
 | `test/chatService.test.ts` | ChatService CRUD, messages (including toolActivity persistence), sessions, generateAndUpdateTitle, archive/restore (flag set/remove, file preservation, list filtering, search filtering, delete-after-archive), usage tracking (addUsage with conversationUsage/sessionUsage, usageByBackend, daily ledger with backend+model dimensions, model separation, getUsage, getUsageStats, clearUsageStats), workspace storage, migration, markdown export |
 | `test/draftState.test.ts` | Draft save/restore, key migration, cleanup, round-trip |
-| `test/messageQueue.test.ts` | Message queue: adding, deleting, rendering, in-flight protection, pause/resume, per-conversation isolation, send button state |
+| `test/messageQueue.test.ts` | Message queue: adding, deleting, rendering, in-flight protection, pause/resume, per-conversation isolation, send button state, suspended (restored) state |
 | `test/graceful-shutdown.test.ts` | Server shutdown on SIGINT/SIGTERM |
 | `test/sessionStore.test.ts` | Session file-store persistence |
 | `test/updateService.test.ts` | Version comparison, status, trigger guards, interval management, interpreter verification, PATH setup for restart |

--- a/public/js/conversations.js
+++ b/public/js/conversations.js
@@ -1,4 +1,4 @@
-import { state, chatFetch, fetchCsrfToken, chatApiUrl } from './state.js';
+import { state, chatFetch, fetchCsrfToken, chatApiUrl, chatSyncQueueToServer } from './state.js';
 import { esc, chatFormatFileSize, chatFormatTokenCount, chatFormatCost } from './utils.js';
 import { chatRenderMessages, chatRenderMarkdown, chatAutoResize, chatScrollToBottom } from './rendering.js';
 import { chatShowModal, chatCloseModal } from './modal.js';
@@ -591,8 +591,22 @@ export async function chatSelectConversation(id) {
     const res = await chatFetch(`conversations/${id}`);
     state.chatActiveConv = await res.json();
     state.chatActiveConvId = id;
+
+    // Restore persisted queue if present and no active stream
+    if (state.chatActiveConv.messageQueue && state.chatActiveConv.messageQueue.length > 0
+        && !state.chatStreamingConvs.has(id) && !state.chatMessageQueue.has(id)) {
+      const restored = state.chatActiveConv.messageQueue.map(content => ({
+        id: ++state.chatQueueIdCounter,
+        content,
+        inFlight: false,
+      }));
+      state.chatMessageQueue.set(id, restored);
+      state.chatQueueSuspended.add(id);
+    }
+
     chatRenderConvList();
     chatRenderMessages();
+    chatRenderQueuedMessages();
     chatUpdateHeader();
     chatRestoreDraft(id);
     const resetBtn = document.getElementById('chat-reset-btn');
@@ -822,13 +836,23 @@ export function chatRenderQueuedMessages() {
 
   container.querySelectorAll('.chat-msg-queued').forEach(el => el.remove());
   container.querySelectorAll('.chat-queue-paused-banner').forEach(el => el.remove());
+  container.querySelectorAll('.chat-queue-suspended-banner').forEach(el => el.remove());
 
   const convId = state.chatActiveConvId;
   if (!convId) return;
   const queue = state.chatMessageQueue.get(convId);
   if (!queue || queue.length === 0) return;
 
-  if (state.chatQueuePaused.has(convId)) {
+  if (state.chatQueueSuspended.has(convId)) {
+    const bannerEl = document.createElement('div');
+    bannerEl.className = 'chat-queue-suspended-banner';
+    bannerEl.innerHTML = `
+      <span>${queue.length} queued message${queue.length !== 1 ? 's' : ''} from a previous session</span>
+      <button class="chat-queue-resume-btn" onclick="chatResumeSuspendedQueue()">Resume</button>
+      <button class="chat-queue-clear-btn" onclick="chatClearQueue()">Clear</button>
+    `;
+    container.appendChild(bannerEl);
+  } else if (state.chatQueuePaused.has(convId)) {
     const bannerEl = document.createElement('div');
     bannerEl.className = 'chat-queue-paused-banner';
     bannerEl.innerHTML = `
@@ -879,9 +903,11 @@ export function chatDeleteQueuedMessage(queueId) {
   if (queue.length === 0) {
     state.chatMessageQueue.delete(convId);
     state.chatQueuePaused.delete(convId);
+    state.chatQueueSuspended.delete(convId);
   }
   chatRenderQueuedMessages();
   chatUpdateSendButtonState();
+  chatSyncQueueToServer(convId);
 }
 
 export function chatEditQueuedMessage(queueId) {
@@ -925,6 +951,7 @@ export function chatEditQueuedMessage(queueId) {
       item.content = newContent;
     }
     chatRenderQueuedMessages();
+    chatSyncQueueToServer(convId);
   };
 
   editActions.querySelector('.chat-queue-edit-cancel').onclick = () => {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -21,7 +21,7 @@ import {
 } from './conversations.js';
 import {
   chatSendMessage, chatStopStreaming, chatRetryLast,
-  chatResumeQueue, chatClearQueue, chatHandleStreamEvent,
+  chatResumeQueue, chatResumeSuspendedQueue, chatClearQueue, chatHandleStreamEvent,
   chatShowPlanApproval, chatShowUserQuestion,
 } from './streaming.js';
 
@@ -42,6 +42,7 @@ window.chatToggleCodeBlock = chatToggleCodeBlock;
 window.chatOpenLightbox = chatOpenLightbox;
 window.chatCloseLightbox = chatCloseLightbox;
 window.chatResumeQueue = chatResumeQueue;
+window.chatResumeSuspendedQueue = chatResumeSuspendedQueue;
 window.chatClearQueue = chatClearQueue;
 window.chatRetryLast = chatRetryLast;
 window.chatSaveSettings = chatSaveSettings;

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -24,7 +24,10 @@ export const state = {
   chatConvLoadGen: 0, // generation counter for chatLoadConversations to discard stale responses
   chatMessageQueue: new Map(), // convId -> [{ id, content, inFlight }]
   chatQueuePaused: new Set(), // convIds where queue is paused due to error
+  chatQueueSuspended: new Set(), // convIds where queue was restored from server
   chatQueueIdCounter: 0,
+  _queueSyncInFlight: false,
+  _queueSyncDirty: false,
   chatWebSockets: new Map(), // convId -> WebSocket
   chatReconnectAttempts: new Map(), // convId -> attempt count
   _usageStatsCache: null,
@@ -32,6 +35,31 @@ export const state = {
   BACKEND_CAPABILITIES: {},
   BACKEND_ICONS: {},
 };
+
+// ─── Queue sync ─────────────────────────────────────────────────────────────
+// Sequential coalescing: at most one PUT in flight; if mutations happen during
+// the in-flight request, a single follow-up PUT sends the latest state.
+
+export function chatSyncQueueToServer(convId) {
+  if (!convId) return;
+  if (state._queueSyncInFlight) {
+    state._queueSyncDirty = true;
+    return;
+  }
+  const queue = state.chatMessageQueue.get(convId);
+  const contents = queue ? queue.filter(i => !i.inFlight).map(i => i.content) : [];
+  state._queueSyncInFlight = true;
+  chatFetch(`conversations/${convId}/queue`, {
+    method: 'PUT',
+    body: { queue: contents },
+  }).catch(() => {}).finally(() => {
+    state._queueSyncInFlight = false;
+    if (state._queueSyncDirty) {
+      state._queueSyncDirty = false;
+      chatSyncQueueToServer(convId);
+    }
+  });
+}
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 export const CHAT_MAX_RECONNECT_ATTEMPTS = 5;

--- a/public/js/streaming.js
+++ b/public/js/streaming.js
@@ -1,4 +1,4 @@
-import { state, chatFetch, chatApiUrl, fetchCsrfToken } from './state.js';
+import { state, chatFetch, chatApiUrl, fetchCsrfToken, chatSyncQueueToServer } from './state.js';
 import { esc, escWithCode } from './utils.js';
 import {
   chatRenderMessages, chatRenderMarkdown, chatAutoResize, chatScrollToBottom,
@@ -17,6 +17,7 @@ import {
 
 export async function chatProcessNextQueuedMessage(convId) {
   if (state.chatQueuePaused.has(convId)) return;
+  if (state.chatQueueSuspended.has(convId)) return;
   if (state.chatStreamingConvs.has(convId)) return;
   const queue = state.chatMessageQueue.get(convId);
   if (!queue || queue.length === 0) return;
@@ -34,6 +35,7 @@ export async function chatProcessNextQueuedMessage(convId) {
   queue.shift();
   if (queue.length === 0) state.chatMessageQueue.delete(convId);
   chatRenderQueuedMessages();
+  chatSyncQueueToServer(convId);
 
   if (state.chatActiveConvId === convId) {
     await chatSendMessage();
@@ -44,6 +46,16 @@ export function chatResumeQueue() {
   const convId = state.chatActiveConvId;
   if (!convId) return;
   state.chatQueuePaused.delete(convId);
+  chatRenderQueuedMessages();
+  if (!state.chatStreamingConvs.has(convId)) {
+    chatProcessNextQueuedMessage(convId);
+  }
+}
+
+export function chatResumeSuspendedQueue() {
+  const convId = state.chatActiveConvId;
+  if (!convId) return;
+  state.chatQueueSuspended.delete(convId);
   chatRenderQueuedMessages();
   if (!state.chatStreamingConvs.has(convId)) {
     chatProcessNextQueuedMessage(convId);
@@ -62,8 +74,10 @@ export function chatClearQueue() {
     state.chatMessageQueue.delete(convId);
   }
   state.chatQueuePaused.delete(convId);
+  state.chatQueueSuspended.delete(convId);
   chatRenderQueuedMessages();
   chatUpdateSendButtonState();
+  chatSyncQueueToServer(convId);
 }
 
 // ── Stream cleanup ───────────────────────────────────────────────────────────
@@ -131,6 +145,7 @@ export async function chatSendMessage() {
     chatRenderQueuedMessages();
     chatUpdateSendButtonState();
     chatScrollToBottom();
+    chatSyncQueueToServer(state.chatActiveConvId);
     return;
   }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1500,6 +1500,20 @@
     color: var(--text);
   }
 
+  .chat-queue-suspended-banner {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    max-width: 800px;
+    margin: 8px auto;
+    padding: 8px 16px;
+    background: color-mix(in srgb, #f59e0b 8%, var(--surface));
+    border: 1px solid color-mix(in srgb, #f59e0b 25%, var(--border));
+    border-radius: 8px;
+    font-size: 13px;
+    color: var(--text);
+  }
+
   .chat-queue-resume-btn,
   .chat-queue-clear-btn {
     padding: 3px 10px;

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -447,6 +447,40 @@ export function createChatRouter({ chatService, backendRegistry, updateService }
     }
   });
 
+  // ── Message queue persistence ──────────────────────────────────────────────
+  router.get('/conversations/:id/queue', async (req: Request, res: Response) => {
+    try {
+      const queue = await chatService.getQueue(param(req, 'id'));
+      res.json({ queue });
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  router.put('/conversations/:id/queue', csrfGuard, async (req: Request, res: Response) => {
+    try {
+      const { queue } = req.body as { queue?: string[] };
+      if (!Array.isArray(queue) || !queue.every(item => typeof item === 'string')) {
+        return res.status(400).json({ error: 'queue must be an array of strings' });
+      }
+      const ok = await chatService.setQueue(param(req, 'id'), queue);
+      if (!ok) return res.status(404).json({ error: 'Conversation not found' });
+      res.json({ ok: true });
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  router.delete('/conversations/:id/queue', csrfGuard, async (req: Request, res: Response) => {
+    try {
+      const ok = await chatService.clearQueue(param(req, 'id'));
+      if (!ok) return res.status(404).json({ error: 'Conversation not found' });
+      res.json({ ok: true });
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
   // ── Download conversation as markdown ──────────────────────────────────────
   router.get('/conversations/:id/download', async (req: Request, res: Response) => {
     try {

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -258,6 +258,7 @@ export class ChatService {
       usage: convEntry.usage || this._emptyUsage(),
       sessionUsage: activeSession?.usage || this._emptyUsage(),
       externalSessionId: activeSession?.externalSessionId || null,
+      messageQueue: convEntry.messageQueue || undefined,
     };
   }
 
@@ -315,6 +316,7 @@ export class ChatService {
     if (!result) return false;
     const { hash, index, convEntry } = result;
     convEntry.archived = true;
+    delete convEntry.messageQueue;
     await this._writeWorkspaceIndex(hash, index);
     return true;
   }
@@ -479,6 +481,31 @@ export class ChatService {
     return newTitle;
   }
 
+  // ── Message Queue Persistence ──────────────────────────────────────────────
+
+  async getQueue(convId: string): Promise<string[]> {
+    const result = await this._getConvFromIndex(convId);
+    if (!result) return [];
+    return result.convEntry.messageQueue || [];
+  }
+
+  async setQueue(convId: string, queue: string[]): Promise<boolean> {
+    const result = await this._getConvFromIndex(convId);
+    if (!result) return false;
+    const { hash, index, convEntry } = result;
+    if (queue.length === 0) {
+      delete convEntry.messageQueue;
+    } else {
+      convEntry.messageQueue = queue;
+    }
+    await this._writeWorkspaceIndex(hash, index);
+    return true;
+  }
+
+  async clearQueue(convId: string): Promise<boolean> {
+    return this.setQueue(convId, []);
+  }
+
   // ── Session Management ─────────────────────────────────────────────────────
 
   async resetSession(convId: string): Promise<ResetSessionResult | null> {
@@ -511,6 +538,7 @@ export class ChatService {
     const newSessionNumber = currentSessionNumber + 1;
     const newSessionId = this._newId();
 
+    delete convEntry.messageQueue;
     convEntry.currentSessionId = newSessionId;
     convEntry.title = 'New Chat';
     convEntry.sessions.push({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -101,6 +101,7 @@ export interface ConversationEntry {
   usageByBackend?: Record<string, Usage>;
   sessions: SessionEntry[];
   archived?: boolean;
+  messageQueue?: string[];
 }
 
 export interface WorkspaceIndex {
@@ -121,6 +122,7 @@ export interface Conversation {
   sessionUsage?: Usage;
   /** Backend-managed session ID from the active session, for resume/rehydration. */
   externalSessionId?: string | null;
+  messageQueue?: string[];
 }
 
 export interface ConversationListItem {

--- a/test/chat.test.ts
+++ b/test/chat.test.ts
@@ -2069,3 +2069,77 @@ describe('WebSocket reconnection', () => {
     ws2.close();
   });
 });
+
+// ── Message Queue Persistence ──────────────────────────────────────────────
+
+describe('Message Queue API', () => {
+  test('GET /conversations/:id/queue returns empty array by default', async () => {
+    const conv = (await makeRequest('POST', '/api/chat/conversations', { title: 'Queue Test' })).body;
+    const res = await makeRequest('GET', `/api/chat/conversations/${conv.id}/queue`);
+    expect(res.status).toBe(200);
+    expect(res.body.queue).toEqual([]);
+  });
+
+  test('PUT /conversations/:id/queue persists and GET retrieves', async () => {
+    const conv = (await makeRequest('POST', '/api/chat/conversations', { title: 'Queue Test' })).body;
+    const putRes = await makeRequest('PUT', `/api/chat/conversations/${conv.id}/queue`, { queue: ['msg1', 'msg2'] });
+    expect(putRes.status).toBe(200);
+    expect(putRes.body.ok).toBe(true);
+
+    const getRes = await makeRequest('GET', `/api/chat/conversations/${conv.id}/queue`);
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.queue).toEqual(['msg1', 'msg2']);
+  });
+
+  test('DELETE /conversations/:id/queue clears the queue', async () => {
+    const conv = (await makeRequest('POST', '/api/chat/conversations', { title: 'Queue Test' })).body;
+    await makeRequest('PUT', `/api/chat/conversations/${conv.id}/queue`, { queue: ['msg1'] });
+
+    const delRes = await makeRequest('DELETE', `/api/chat/conversations/${conv.id}/queue`);
+    expect(delRes.status).toBe(200);
+    expect(delRes.body.ok).toBe(true);
+
+    const getRes = await makeRequest('GET', `/api/chat/conversations/${conv.id}/queue`);
+    expect(getRes.body.queue).toEqual([]);
+  });
+
+  test('PUT /conversations/:id/queue returns 400 for invalid body', async () => {
+    const conv = (await makeRequest('POST', '/api/chat/conversations', { title: 'Queue Test' })).body;
+    const res = await makeRequest('PUT', `/api/chat/conversations/${conv.id}/queue`, { queue: [123] });
+    expect(res.status).toBe(400);
+  });
+
+  test('PUT /conversations/:id/queue returns 404 for unknown conversation', async () => {
+    const res = await makeRequest('PUT', '/api/chat/conversations/nonexistent/queue', { queue: ['msg'] });
+    expect(res.status).toBe(404);
+  });
+
+  test('queue is included in GET /conversations/:id response', async () => {
+    const conv = (await makeRequest('POST', '/api/chat/conversations', { title: 'Queue Test' })).body;
+    await makeRequest('PUT', `/api/chat/conversations/${conv.id}/queue`, { queue: ['hello', 'world'] });
+
+    const getRes = await makeRequest('GET', `/api/chat/conversations/${conv.id}`);
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.messageQueue).toEqual(['hello', 'world']);
+  });
+
+  test('queue is cleared on session reset', async () => {
+    const conv = (await makeRequest('POST', '/api/chat/conversations', { title: 'Queue Test' })).body;
+    await makeRequest('PUT', `/api/chat/conversations/${conv.id}/queue`, { queue: ['pending msg'] });
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/reset`);
+
+    const getRes = await makeRequest('GET', `/api/chat/conversations/${conv.id}/queue`);
+    expect(getRes.body.queue).toEqual([]);
+  });
+
+  test('queue is cleared on archive', async () => {
+    const conv = (await makeRequest('POST', '/api/chat/conversations', { title: 'Queue Test' })).body;
+    await makeRequest('PUT', `/api/chat/conversations/${conv.id}/queue`, { queue: ['pending msg'] });
+
+    await makeRequest('PATCH', `/api/chat/conversations/${conv.id}/archive`);
+
+    const getRes = await makeRequest('GET', `/api/chat/conversations/${conv.id}/queue`);
+    expect(getRes.body.queue).toEqual([]);
+  });
+});

--- a/test/messageQueue.test.ts
+++ b/test/messageQueue.test.ts
@@ -16,6 +16,7 @@ beforeEach(() => {
   (global as any).chatActiveConvId = 'conv-1';
   (global as any).chatMessageQueue = new Map();
   (global as any).chatQueuePaused = new Set();
+  (global as any).chatQueueSuspended = new Set();
   (global as any).chatQueueIdCounter = 0;
   (global as any).chatStreamingConvs = new Set();
   (global as any).chatPendingFiles = [];
@@ -37,13 +38,19 @@ function chatRenderQueuedMessages() {
 
   container.querySelectorAll('.chat-msg-queued').forEach(el => el.remove());
   container.querySelectorAll('.chat-queue-paused-banner').forEach(el => el.remove());
+  container.querySelectorAll('.chat-queue-suspended-banner').forEach(el => el.remove());
 
   const convId = (global as any).chatActiveConvId;
   if (!convId) return;
   const queue = (global as any).chatMessageQueue.get(convId);
   if (!queue || queue.length === 0) return;
 
-  if ((global as any).chatQueuePaused.has(convId)) {
+  if ((global as any).chatQueueSuspended.has(convId)) {
+    const bannerEl = document.createElement('div');
+    bannerEl.className = 'chat-queue-suspended-banner';
+    bannerEl.innerHTML = `<span>${queue.length} queued message${queue.length !== 1 ? 's' : ''} from a previous session</span>`;
+    container.appendChild(bannerEl);
+  } else if ((global as any).chatQueuePaused.has(convId)) {
     const bannerEl = document.createElement('div');
     bannerEl.className = 'chat-queue-paused-banner';
     bannerEl.innerHTML = '<span>Queue paused due to error.</span>';
@@ -81,6 +88,7 @@ function chatDeleteQueuedMessage(queueId: number) {
   if (queue.length === 0) {
     (global as any).chatMessageQueue.delete(convId);
     (global as any).chatQueuePaused.delete(convId);
+    (global as any).chatQueueSuspended.delete(convId);
   }
   chatRenderQueuedMessages();
 }
@@ -303,5 +311,85 @@ describe('Message Queue: per-conversation isolation', () => {
     expect((global as any).chatMessageQueue.get('conv-2')).toHaveLength(1);
     expect((global as any).chatMessageQueue.get('conv-1')[0].content).toBe('conv1-msg');
     expect((global as any).chatMessageQueue.get('conv-2')[0].content).toBe('conv2-msg');
+  });
+});
+
+describe('Message Queue: suspended (restored) state', () => {
+  function restoreQueue(contents: string[]) {
+    const convId = (global as any).chatActiveConvId;
+    const restored = contents.map(content => ({
+      id: ++(global as any).chatQueueIdCounter,
+      content,
+      inFlight: false,
+    }));
+    (global as any).chatMessageQueue.set(convId, restored);
+    (global as any).chatQueueSuspended.add(convId);
+  }
+
+  test('restore populates queue and marks as suspended', () => {
+    restoreQueue(['msg1', 'msg2']);
+    const convId = (global as any).chatActiveConvId;
+    expect((global as any).chatMessageQueue.get(convId)).toHaveLength(2);
+    expect((global as any).chatQueueSuspended.has(convId)).toBe(true);
+  });
+
+  test('renders suspended banner with correct count', () => {
+    restoreQueue(['a', 'b', 'c']);
+    chatRenderQueuedMessages();
+    const banner = document.querySelector('.chat-queue-suspended-banner');
+    expect(banner).not.toBeNull();
+    expect(banner?.textContent).toContain('3 queued messages from a previous session');
+  });
+
+  test('renders singular form for single message', () => {
+    restoreQueue(['only']);
+    chatRenderQueuedMessages();
+    const banner = document.querySelector('.chat-queue-suspended-banner');
+    expect(banner?.textContent).toContain('1 queued message from a previous session');
+  });
+
+  test('suspended banner takes priority over paused banner', () => {
+    restoreQueue(['msg']);
+    (global as any).chatQueuePaused.add('conv-1');
+    chatRenderQueuedMessages();
+    expect(document.querySelector('.chat-queue-suspended-banner')).not.toBeNull();
+    expect(document.querySelector('.chat-queue-paused-banner')).toBeNull();
+  });
+
+  test('queued messages are still rendered below suspended banner', () => {
+    restoreQueue(['hello', 'world']);
+    chatRenderQueuedMessages();
+    const msgs = document.querySelectorAll('.chat-msg-queued');
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].textContent).toContain('hello');
+    expect(msgs[1].textContent).toContain('world');
+  });
+
+  test('resume clears suspended state', () => {
+    restoreQueue(['msg']);
+    const convId = (global as any).chatActiveConvId;
+    (global as any).chatQueueSuspended.delete(convId);
+    expect((global as any).chatQueueSuspended.has(convId)).toBe(false);
+    // Queue items remain
+    expect((global as any).chatMessageQueue.get(convId)).toHaveLength(1);
+  });
+
+  test('clear removes suspended state and empties queue', () => {
+    restoreQueue(['msg1', 'msg2']);
+    const convId = (global as any).chatActiveConvId;
+    // Simulate chatClearQueue behavior
+    (global as any).chatMessageQueue.delete(convId);
+    (global as any).chatQueueSuspended.delete(convId);
+    expect((global as any).chatQueueSuspended.has(convId)).toBe(false);
+    expect((global as any).chatMessageQueue.has(convId)).toBe(false);
+  });
+
+  test('deleting last item clears suspended state', () => {
+    restoreQueue(['only']);
+    const convId = (global as any).chatActiveConvId;
+    const queue = (global as any).chatMessageQueue.get(convId);
+    chatDeleteQueuedMessage(queue[0].id);
+    expect((global as any).chatQueueSuspended.has(convId)).toBe(false);
+    expect((global as any).chatMessageQueue.has(convId)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Add `messageQueue` (string array) to conversation entries in `index.json` for server-side persistence
- New API endpoints: `GET/PUT/DELETE /conversations/:id/queue`
- Client syncs queue to server on every mutation (add, edit, delete, shift, clear) using sequential coalescing (at most one PUT in flight)
- On loading a conversation with a persisted queue and no active stream, queue is restored into a **suspended** state with an amber banner: "N queued messages from a previous session" with Resume/Clear buttons
- Suspended queues do not auto-execute — user must explicitly resume
- Queue is automatically cleared on session reset and archive

## Test plan

- [x] 8 new server tests: GET/PUT/DELETE queue, validation, 404, included in conversation response, cleared on reset/archive
- [x] 7 new client tests: restore populates state, suspended banner rendering, singular/plural, priority over paused, resume/clear behavior
- [x] All 418 tests pass

Closes #98