### PR TITLE
feat: display Kiro credits and context usage in header bar

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -98,7 +98,9 @@ All workspace hashes throughout the system use: `SHA-256(workspacePath).substrin
       outputTokens: number,
       cacheReadTokens: number,
       cacheWriteTokens: number,
-      costUsd: number
+      costUsd: number,
+      credits?: number,                // Kiro only: accumulated credits consumed (fractional)
+      contextUsagePercentage?: number  // Kiro only: context window usage snapshot (0–100)
     }|null,
     usageByBackend: {            // Per-backend usage breakdown (keyed by backend id)
       [backendId]: Usage
@@ -591,7 +593,7 @@ All detail objects include `tool`, `id` (block id or null), and `description`. L
 
 **Permission handling:** All `session/request_permission` messages are auto-approved with `allow_always`.
 
-**Usage tracking:** Kiro's `_kiro.dev/metadata` notifications are ignored — credits/contextUsage don't map to the `Usage` interface.
+**Usage tracking:** Kiro's `_kiro.dev/metadata` notifications are parsed for `credits` (accumulated) and `contextUsagePercentage` (snapshot, overwritten each update). These are persisted on the conversation and session `Usage` objects but **excluded from the daily usage ledger** — Kiro's credit-based billing is not comparable with token-based backends. The frontend header displays credits and context % instead of tokens when the conversation backend is `kiro`.
 
 **`generateSummary` / `generateTitle`:** Uses `kiro-cli chat --no-interactive --trust-all-tools` for one-shot LLM calls with 30s timeout. Falls back gracefully if kiro-cli is not installed or not authenticated.
 
@@ -779,7 +781,7 @@ Vanilla JavaScript SPA — no framework, no bundler, no build step. Frontend is 
 - **Plan approval:** renders plan as markdown with approve/reject buttons → sends `{ type: 'input', text: 'yes'|'no' }` via WebSocket
 - **User questions:** renders question text + option buttons → sends answer via WebSocket `input` frame
 - **Auto title update:** handles `title_updated` event by updating the active conversation title, the header, and the sidebar list in-place (no full reload needed).
-- **Usage display:** a small indicator in the conversation header shows **session-level** token count and USD cost. Updated in real-time when `usage` events arrive during streaming. Displays on hover a tooltip with session input/output/cache token breakdown and cost, plus conversation-level totals. Hidden when no usage data exists (e.g. new conversation).
+- **Usage display:** a small indicator in the conversation header shows **session-level** token count and USD cost. Updated in real-time when `usage` events arrive during streaming. Displays on hover a tooltip with session input/output/cache token breakdown and cost, plus conversation-level totals. Hidden when no usage data exists (e.g. new conversation). For **Kiro** conversations, shows credits consumed and context usage percentage instead of tokens/cost.
 - **Stream cleanup:** `chatCleanupStreamState()` accepts `{ force }` option. The `finally` block uses `force: true` to ensure cleanup even when a pending interaction was never resolved. Interaction response handlers also use forced cleanup when the stream has already ended.
 - **Send button state:** shows stop (■) when streaming with no text input, send (↑) when idle or when streaming with text input (to queue). Disabled during uploads or session resets.
 - **Message queue:** Users can compose and submit messages while the CLI is actively responding. Queued messages are stored client-side in `chatMessageQueue` (Map of convId → array of `{ id, content, inFlight }`) and **persisted server-side** as `messageQueue` (array of content strings) on the conversation entry. On every queue mutation (add, edit, delete, shift, clear), a sequential coalescing PUT syncs the current state to the server — at most one PUT in flight at a time, with a follow-up if mutations occur during the request. Queued messages appear inline in the chat after the streaming bubble, styled as user messages with reduced opacity and an accent left border. Each shows a "Queued" badge and has Edit and Delete buttons. In-flight messages show "Sending..." and cannot be edited or deleted. When a response completes successfully, the next queued message is automatically sent (FIFO). Queue has three states: **Active** (streaming, auto-execute on completion), **Paused** (error, banner with Resume/Clear), and **Suspended** (restored from server after page load). The `chatQueuePaused` Set tracks paused conversations; `chatQueueSuspended` tracks restored conversations. On loading a conversation with a non-empty persisted queue and no active stream, the queue is restored into client state and marked suspended. A banner reads "N queued messages from a previous session" with Resume and Clear buttons. Suspended queues do not auto-execute — the user must explicitly resume. Queue is automatically cleared on session reset and archive.
@@ -925,7 +927,7 @@ Update OAuth callback URLs to include the ngrok URL.
 | `test/backends.test.ts` | BaseBackendAdapter (including generateTitle), BackendRegistry (including shutdownAll), ClaudeCodeAdapter |
 | `test/kiroBackend.test.ts` | KiroAdapter metadata, lifecycle (shutdown, onSessionReset), extractKiroToolDetails tool name normalization, generateSummary/generateTitle fallbacks |
 | `test/chat.test.ts` | Chat routes: WebSocket streaming (text, tool_activity, stdin input, abort, assistant_message), WebSocket reconnection (replay buffered events, CLI survives disconnect, CLI crash buffers error, abort clears buffer, session reset clears buffer), turn boundaries, turn_complete event forwarding, tool activity persistence, parallel agent persistence, session overview aggregation, auto title update on session reset, usage event forwarding and persistence (including sessionUsage), usage stats endpoints (GET/DELETE), file upload/serve, workspace instructions, archive/restore endpoints, message queue persistence (GET/PUT/DELETE, included in conversation response, cleared on reset/archive) |
-| `test/chatService.test.ts` | ChatService CRUD, messages (including toolActivity persistence), sessions, generateAndUpdateTitle, archive/restore (flag set/remove, file preservation, list filtering, search filtering, delete-after-archive), usage tracking (addUsage with conversationUsage/sessionUsage, usageByBackend, daily ledger with backend+model dimensions, model separation, getUsage, getUsageStats, clearUsageStats), workspace storage, migration, markdown export |
+| `test/chatService.test.ts` | ChatService CRUD, messages (including toolActivity persistence), sessions, generateAndUpdateTitle, archive/restore (flag set/remove, file preservation, list filtering, search filtering, delete-after-archive), usage tracking (addUsage with conversationUsage/sessionUsage, usageByBackend, daily ledger with backend+model dimensions, model separation, getUsage, getUsageStats, clearUsageStats, Kiro credits accumulation, contextUsagePercentage snapshot, skipLedger option), workspace storage, migration, markdown export |
 | `test/draftState.test.ts` | Draft save/restore, key migration, cleanup, round-trip |
 | `test/messageQueue.test.ts` | Message queue: adding, deleting, rendering, in-flight protection, pause/resume, per-conversation isolation, send button state, suspended (restored) state |
 | `test/graceful-shutdown.test.ts` | Server shutdown on SIGINT/SIGTERM |

--- a/public/js/conversations.js
+++ b/public/js/conversations.js
@@ -729,9 +729,13 @@ export function chatUpdateUsageDisplay() {
   let el = document.getElementById('chat-header-usage');
   const convUsage = state.chatActiveConv?.usage;
   const sessUsage = state.chatActiveConv?.sessionUsage;
+  const isKiro = state.chatActiveConv?.backend === 'kiro';
 
-  const hasUsage = (sessUsage && (sessUsage.inputTokens > 0 || sessUsage.outputTokens > 0 || sessUsage.costUsd > 0))
-    || (convUsage && (convUsage.inputTokens > 0 || convUsage.outputTokens > 0 || convUsage.costUsd > 0));
+  // Kiro: check for credits; others: check for tokens/cost
+  const hasUsage = isKiro
+    ? (sessUsage?.credits > 0 || convUsage?.credits > 0 || sessUsage?.contextUsagePercentage > 0 || convUsage?.contextUsagePercentage > 0)
+    : ((sessUsage && (sessUsage.inputTokens > 0 || sessUsage.outputTokens > 0 || sessUsage.costUsd > 0))
+      || (convUsage && (convUsage.inputTokens > 0 || convUsage.outputTokens > 0 || convUsage.costUsd > 0)));
 
   if (!hasUsage) {
     if (el) el.style.display = 'none';
@@ -748,6 +752,33 @@ export function chatUpdateUsageDisplay() {
   }
 
   const displayUsage = sessUsage || convUsage;
+
+  if (isKiro) {
+    // ── Kiro: show credits + context usage ──
+    const credits = displayUsage.credits || 0;
+    const contextPct = displayUsage.contextUsagePercentage || 0;
+    const creditsStr = credits < 0.01 && credits > 0 ? credits.toFixed(4) : credits < 1 ? credits.toFixed(3) : credits.toFixed(2);
+    const contextStr = contextPct.toFixed(2);
+
+    let tooltipLines = ['\u2500\u2500 Session \u2500\u2500'];
+    tooltipLines.push(`Credits: ${creditsStr}`);
+    tooltipLines.push(`Context: ${contextStr}%`);
+
+    if (convUsage && convUsage !== displayUsage && convUsage.credits > 0) {
+      tooltipLines.push('');
+      tooltipLines.push('\u2500\u2500 Conversation \u2500\u2500');
+      const convCredits = convUsage.credits || 0;
+      tooltipLines.push(`Credits: ${convCredits < 1 ? convCredits.toFixed(3) : convCredits.toFixed(2)}`);
+    }
+
+    el.title = tooltipLines.join('\n');
+    el.innerHTML = `<span class="chat-usage-tokens">${creditsStr} credits</span>`
+      + (contextPct > 0 ? `<span class="chat-usage-cost">${contextStr}% context</span>` : '');
+    el.style.display = '';
+    return;
+  }
+
+  // ── Token-based backends (Claude Code, etc.) ──
   const sessionTokens = (displayUsage.inputTokens || 0) + (displayUsage.outputTokens || 0);
 
   let tooltipLines = ['\u2500\u2500 Session \u2500\u2500'];

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -151,7 +151,8 @@ export async function processStream(
       } else if (event.type === 'result') {
         resultText = event.content;
       } else if (event.type === 'usage') {
-        const updated = await chatService.addUsage(convId, event.usage, backend, event.model);
+        const skipLedger = backend === 'kiro';
+        const updated = await chatService.addUsage(convId, event.usage, backend, event.model, { skipLedger });
         if (!isClosed()) {
           emit({ type: 'usage', usage: updated?.conversationUsage || event.usage, sessionUsage: updated?.sessionUsage });
         }

--- a/src/services/backends/kiro.ts
+++ b/src/services/backends/kiro.ts
@@ -14,7 +14,7 @@ import type {
 
 // ── Icon ────────────���───────────────────────────────────────────────────────
 
-const KIRO_ICON = '<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="28" height="28" rx="6" fill="#232F3E"/><text x="14" y="19" text-anchor="middle" font-family="Arial,sans-serif" font-weight="bold" font-size="14" fill="#FF9900">K</text></svg>';
+const KIRO_ICON = '<svg width="28" height="28" viewBox="0 0 1200 1200" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="1200" height="1200" rx="260" fill="#9046FF"/><mask id="mask0_1106_4856" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="272" y="202" width="655" height="796"><path d="M926.578 202.793H272.637V997.857H926.578V202.793Z" fill="white"/></mask><g mask="url(#mask0_1106_4856)"><path d="M398.554 818.914C316.315 1001.03 491.477 1046.74 620.672 940.156C658.687 1059.66 801.052 970.473 852.234 877.795C964.787 673.567 919.318 465.357 907.64 422.374C827.637 129.443 427.623 128.946 358.8 423.865C342.651 475.544 342.402 534.18 333.458 595.051C328.986 625.86 325.507 645.488 313.83 677.785C306.873 696.424 297.68 712.819 282.773 740.645C259.915 783.881 269.604 867.113 387.87 823.883L399.051 818.914H398.554Z" fill="white"/><path d="M636.123 549.353C603.328 549.353 598.359 510.097 598.359 486.742C598.359 465.623 602.086 448.977 609.293 438.293C615.504 428.852 624.697 424.131 636.123 424.131C647.555 424.131 657.492 428.852 664.447 438.541C672.398 449.474 676.623 466.12 676.623 486.742C676.623 525.998 661.471 549.353 636.375 549.353H636.123Z" fill="black"/><path d="M771.24 549.353C738.445 549.353 733.477 510.097 733.477 486.742C733.477 465.623 737.203 448.977 744.41 438.293C750.621 428.852 759.814 424.131 771.24 424.131C782.672 424.131 792.609 428.852 799.564 438.541C807.516 449.474 811.74 466.12 811.74 486.742C811.74 525.998 796.588 549.353 771.492 549.353H771.24Z" fill="black"/></g></svg>';
 
 // ── Configuration ──────────���────────────────────────────────────────────────
 
@@ -563,6 +563,28 @@ export class KiroAdapter extends BaseBackendAdapter {
             const intSessionId = (notification.params as any)?.sessionId as string | undefined;
             if (intUpdate && intSessionId && intUpdate.toolCallId) {
               toolToSubagent.set(intUpdate.toolCallId as string, intSessionId);
+            }
+          }
+          // Extract credits and context usage from metadata
+          if (notification.method === '_kiro.dev/metadata') {
+            const meta = notification.params as Record<string, unknown> | undefined;
+            if (meta) {
+              const credits = typeof meta.credits === 'number' ? meta.credits : undefined;
+              const contextPct = typeof meta.contextUsagePercentage === 'number' ? meta.contextUsagePercentage : undefined;
+              if (credits !== undefined || contextPct !== undefined) {
+                yield {
+                  type: 'usage',
+                  usage: {
+                    inputTokens: 0,
+                    outputTokens: 0,
+                    cacheReadTokens: 0,
+                    cacheWriteTokens: 0,
+                    costUsd: 0,
+                    credits,
+                    contextUsagePercentage: contextPct,
+                  },
+                };
+              }
             }
           }
           continue;

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -961,9 +961,16 @@ export class ChatService {
     target.cacheReadTokens += source.cacheReadTokens || 0;
     target.cacheWriteTokens += source.cacheWriteTokens || 0;
     target.costUsd += source.costUsd || 0;
+    // Kiro-specific: credits accumulate, contextUsagePercentage is a snapshot (overwrite)
+    if (source.credits !== undefined) {
+      target.credits = (target.credits || 0) + source.credits;
+    }
+    if (source.contextUsagePercentage !== undefined) {
+      target.contextUsagePercentage = source.contextUsagePercentage;
+    }
   }
 
-  async addUsage(convId: string, usage: Usage, backend?: string, model?: string): Promise<{ conversationUsage: Usage; sessionUsage: Usage } | null> {
+  async addUsage(convId: string, usage: Usage, backend?: string, model?: string, options?: { skipLedger?: boolean }): Promise<{ conversationUsage: Usage; sessionUsage: Usage } | null> {
     if (!usage) return null;
     const result = await this._getConvFromIndex(convId);
     if (!result) return null;
@@ -995,9 +1002,12 @@ export class ChatService {
     await this._writeWorkspaceIndex(hash, index);
 
     // Record to daily ledger (fire-and-forget, don't block the response)
-    this._recordToLedger(backendId, model || 'unknown', usage).catch(err => {
-      console.error('[usage] Failed to write ledger:', (err as Error).message);
-    });
+    // Skip ledger for backends that don't provide token-based usage (e.g. Kiro)
+    if (!options?.skipLedger) {
+      this._recordToLedger(backendId, model || 'unknown', usage).catch(err => {
+        console.error('[usage] Failed to write ledger:', (err as Error).message);
+      });
+    }
 
     return { conversationUsage: convEntry.usage, sessionUsage };
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,10 @@ export interface Usage {
   cacheReadTokens: number;
   cacheWriteTokens: number;
   costUsd: number;
+  /** Kiro credits consumed (fractional, Kiro-specific unit). */
+  credits?: number;
+  /** Percentage of the model's context window used (0–100). Snapshot, not cumulative. */
+  contextUsagePercentage?: number;
 }
 
 // ── Usage Ledger (daily per-backend/model records) ──────────────────────────

--- a/test/chatService.test.ts
+++ b/test/chatService.test.ts
@@ -1259,6 +1259,50 @@ describe('addUsage', () => {
     expect(record).toBeDefined();
     expect(record!.model).toBe('unknown');
   });
+
+  test('accumulates Kiro credits across calls', async () => {
+    const conv = await service.createConversation('Kiro Credits');
+    await service.addUsage(conv.id, { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0, credits: 0.1 }, 'kiro');
+    const updated = await service.addUsage(conv.id, { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0, credits: 0.25 }, 'kiro');
+
+    expect(updated!.conversationUsage.credits).toBeCloseTo(0.35);
+    expect(updated!.sessionUsage.credits).toBeCloseTo(0.35);
+  });
+
+  test('contextUsagePercentage is overwritten (snapshot), not accumulated', async () => {
+    const conv = await service.createConversation('Kiro Context');
+    await service.addUsage(conv.id, { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0, contextUsagePercentage: 30 }, 'kiro');
+    const updated = await service.addUsage(conv.id, { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0, contextUsagePercentage: 55 }, 'kiro');
+
+    expect(updated!.conversationUsage.contextUsagePercentage).toBe(55);
+    expect(updated!.sessionUsage.contextUsagePercentage).toBe(55);
+  });
+
+  test('skipLedger option prevents ledger write', async () => {
+    const conv = await service.createConversation('Kiro Skip Ledger');
+    await service.addUsage(conv.id, { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0, credits: 0.5 }, 'kiro', undefined, { skipLedger: true });
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const ledger = await service.getUsageStats();
+    const today = new Date().toISOString().slice(0, 10);
+    const dayEntry = ledger.days.find((d: any) => d.date === today);
+    // No ledger entry should exist for kiro
+    if (dayEntry) {
+      const kiroRecord = dayEntry.records.find((r: any) => r.backend === 'kiro');
+      expect(kiroRecord).toBeUndefined();
+    }
+  });
+
+  test('skipLedger still persists usage on conversation and session', async () => {
+    const conv = await service.createConversation('Kiro Persist');
+    const updated = await service.addUsage(conv.id, { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0, credits: 0.3, contextUsagePercentage: 42 }, 'kiro', undefined, { skipLedger: true });
+
+    expect(updated!.conversationUsage.credits).toBeCloseTo(0.3);
+    expect(updated!.conversationUsage.contextUsagePercentage).toBe(42);
+    expect(updated!.sessionUsage.credits).toBeCloseTo(0.3);
+    expect(updated!.sessionUsage.contextUsagePercentage).toBe(42);
+  });
 });
 
 describe('getUsage', () => {


### PR DESCRIPTION
## Summary
- Parse `_kiro.dev/metadata` ACP notifications for `credits` (accumulated) and `contextUsagePercentage` (snapshot)
- Persist Kiro usage on conversation/session but exclude from the daily usage ledger (credit-based billing not comparable with token counts)
- Frontend header shows credits + context % for Kiro conversations instead of tokens + cost
- Update Kiro icon to official logo SVG

## Test plan
- [x] All 422 existing tests pass
- [x] 4 new tests: Kiro credits accumulation, contextUsagePercentage snapshot, skipLedger prevents ledger write, skipLedger still persists on conversation/session
- [ ] Manual: start a Kiro conversation, verify header shows credits and context % instead of tokens
- [ ] Manual: verify usage statistics modal does not include Kiro data
- [ ] Manual: verify Kiro icon renders as purple ghost character

Closes #96