### PR TITLE
feat: add model selection for Claude Code backend

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -90,6 +90,7 @@ All workspace hashes throughout the system use: `SHA-256(workspacePath).substrin
     id: string,                 // UUIDv4
     title: string,              // Auto-set from first user message (max 80 chars)
     backend: string,            // 'claude-code'
+    model?: string,             // Selected model alias (e.g. 'opus', 'sonnet', 'haiku'); absent = backend default
     currentSessionId: string,   // UUID of the active CLI session
     lastActivity: string,       // ISO 8601, updated on every message
     lastMessage: string|null,   // First 100 chars of last message content
@@ -169,6 +170,7 @@ Flat object assembled from workspace index + active session file:
   id: string,
   title: string,
   backend: string,
+  model?: string,               // Selected model alias (e.g. 'opus', 'sonnet', 'haiku')
   workingDir: string,           // The workspace path
   currentSessionId: string,
   sessionNumber: number,        // Active session number
@@ -204,6 +206,7 @@ Daily per-backend/model token usage records for global statistics:
   "sendBehavior": "enter",
   "systemPrompt": "",
   "defaultBackend": "claude-code",
+  "defaultModel": "sonnet",
   "workingDirectory": ""
 }
 ```
@@ -278,16 +281,16 @@ The queue is also included in the `GET /conversations/:id` response as `messageQ
 ```
 GET /backends
 ```
-Returns `{ backends: [{ id, label, icon, capabilities }] }` — metadata for every registered adapter.
+Returns `{ backends: [{ id, label, icon, capabilities, models? }] }` — metadata for every registered adapter. The optional `models` array lists available models: `[{ id, label, family, description?, costTier?, default? }]`. Backends without model selection (e.g. Kiro) omit this field.
 
 ### 3.7 Messaging and Streaming
 
 **Send message:**
 ```
 POST /conversations/:id/message  [CSRF]
-Body: { content: string, backend?: string }
+Body: { content: string, backend?: string, model?: string }
 ```
-- Saves user message, updates backend if changed
+- Saves user message, updates backend and/or model if changed
 - Determines if new CLI session (`messageCount === 0`) or resume
 - New sessions: prepends workspace context injection (not stored in messages)
 - Spawns CLI process, stores in `activeStreams` map
@@ -446,7 +449,7 @@ Unauthenticated requests redirect to `/auth/login`.
 | Method | Description |
 |--------|-------------|
 | `initialize()` | Runs migration if legacy `conversations/` dir exists, builds convId→workspace lookup map. |
-| `createConversation(title, workingDir, backend)` | Creates entry in workspace index + empty session-1.json. Falls back to `_defaultWorkspace`. `backend` defaults to the registry's first registered adapter. |
+| `createConversation(title, workingDir, backend, model?)` | Creates entry in workspace index + empty session-1.json. Falls back to `_defaultWorkspace`. `backend` defaults to the registry's first registered adapter. `model` is the optional model alias to persist. |
 | `getConversation(id)` | Returns API-compatible object with messages, or `null`. |
 | `listConversations(opts?)` | Scans all workspace indexes. Returns summaries sorted by `lastActivity` desc, each with `workspaceHash`. Pass `{ archived: true }` to list only archived; default returns active only. |
 | `renameConversation(id, newTitle)` | Updates title in workspace index. Returns full conversation or `null`. |
@@ -454,6 +457,7 @@ Unauthenticated requests redirect to `/auth/login`.
 | `restoreConversation(id)` | Removes `archived` flag from conversation entry. Returns `true` or `false` if not found. |
 | `deleteConversation(id)` | Removes from index, deletes session folder + artifacts, removes from lookup map. Works on both active and archived conversations. |
 | `updateConversationBackend(convId, backend)` | Updates backend field in workspace index. |
+| `updateConversationModel(convId, model)` | Updates model field in workspace index. Pass `null` to clear. |
 | `addMessage(convId, role, content, backend, thinking, toolActivity)` | Appends to active session + updates index metadata. Auto-titles on first user message (session 1 only; post-reset sessions rely on LLM title generation). `thinking` omitted if falsy. `toolActivity` omitted if falsy or empty array. |
 | `updateMessageContent(convId, messageId, newContent)` | Truncates after target message, adds edited content as new message. |
 | `generateAndUpdateTitle(convId, userMessage)` | Generates a new title via the backend adapter's `generateTitle()` and persists it. Returns the new title or `null`. |
@@ -497,8 +501,8 @@ The CLI backend layer uses a **pluggable adapter pattern**. New CLI tools can be
 #### BaseBackendAdapter (`src/services/backends/base.ts`)
 
 Abstract base class. Every backend must implement:
-- **`get metadata`** — returns `{ id, label, icon, capabilities }` where capabilities: `{ thinking, planMode, agents, toolActivity, userQuestions, stdinInput }` (all booleans)
-- **`sendMessage(message, options)`** — returns `{ stream, abort, sendInput }` where `stream` is an async generator yielding events matching the stream event contract in Section 3. `options` includes `{ sessionId, conversationId, isNewSession, workingDir, systemPrompt, externalSessionId }`. `conversationId` is the stable conversation ID (does not change on session reset) — used by backends like Kiro that key long-lived processes by conversation.
+- **`get metadata`** — returns `{ id, label, icon, capabilities, models? }` where capabilities: `{ thinking, planMode, agents, toolActivity, userQuestions, stdinInput }` (all booleans). `models` is an optional array of `{ id, label, family, description?, costTier?, default? }` for backends that support model selection.
+- **`sendMessage(message, options)`** — returns `{ stream, abort, sendInput }` where `stream` is an async generator yielding events matching the stream event contract in Section 3. `options` includes `{ sessionId, conversationId, isNewSession, workingDir, systemPrompt, externalSessionId, model? }`. `conversationId` is the stable conversation ID (does not change on session reset) — used by backends like Kiro that key long-lived processes by conversation. `model` is the model alias or ID to use for this invocation (backends that don't support model selection ignore it).
 - **`generateSummary(messages, fallback)`** — returns a one-line summary string
 - **`generateTitle(userMessage, fallback)`** — returns a short conversation title. Base class provides a default that truncates the user message to 80 chars.
 - **`shutdown()`** — called during server shutdown. Override to kill long-lived processes. No-op by default.
@@ -525,10 +529,10 @@ Shared helpers used by all backend adapters. Extracted for cross-adapter reuse �
 
 #### ClaudeCodeAdapter (`src/services/backends/claudeCode.ts`)
 
-**Metadata:** `id: 'claude-code'`, all capabilities enabled.
+**Metadata:** `id: 'claude-code'`, all capabilities enabled. Exposes `models` array with `opus`, `sonnet` (default), `haiku`, `opus[1m]`, and `sonnet[1m]` options using aliases so they auto-resolve to the latest version.
 
 **`sendMessage(message, options)`:**
-- `options`: `{ sessionId, isNewSession, workingDir, systemPrompt }`
+- `options`: `{ sessionId, isNewSession, workingDir, systemPrompt, model? }`
 - Returns `{ stream, abort, sendInput }`
 - `abort()` sends SIGTERM to CLI process
 - `sendInput(text)` writes to stdin (safe after abort)
@@ -540,6 +544,7 @@ claude --print \
   --permission-mode bypassPermissions \
   --output-format stream-json \
   --verbose \
+  [--model <alias|id>]              # if model specified (e.g. opus, sonnet, haiku)
   [--session-id <uuid>]              # if isNewSession
   [--append-system-prompt <prompt>]  # if isNewSession and systemPrompt
   [--resume <uuid>]                  # if not isNewSession
@@ -750,12 +755,12 @@ Vanilla JavaScript SPA — no framework, no bundler, no build step. Frontend is 
 
 - Flexbox: sidebar (fixed 280px) + main area (flex: 1)
 - Sidebar: new chat button, search, conversation list grouped by workspace, settings, sign out, version label
-- Main area: header with title + usage indicator + action buttons, messages container, input area with backend selector + file chips + textarea
+- Main area: header with title + usage indicator + action buttons, messages container, input area with backend selector + model selector + file chips + textarea
 - Responsive: below ~768px sidebar overlays content
 
 ### Conversation Management
 
-- **New conversation:** folder picker modal (via `/browse` API) → user selects directory → POST creates conversation with the user's `defaultBackend` from settings
+- **New conversation:** folder picker modal (via `/browse` API) → user selects directory → POST creates conversation with the user's `defaultBackend` and `defaultModel` from settings
 - **Sidebar list:** grouped by workspace (last 2 path segments of `workingDir`), sorted by `updatedAt` desc. Groups are collapsible (state in localStorage). Each group header has a pencil icon for workspace instructions.
 - **Context menu:** right-click on conversation items for rename/archive/delete (active view) or restore/delete (archive view)
 - **Archive:** conversations can be archived via context menu. Archived conversations are hidden from the main sidebar but all files (sessions, artifacts) remain on disk. A toggle at the bottom of the sidebar switches between active and archived views. Archived conversations can be browsed, searched, restored, or permanently deleted.
@@ -763,7 +768,7 @@ Vanilla JavaScript SPA — no framework, no bundler, no build step. Frontend is 
 
 ### Messaging & Streaming
 
-- `chatSendMessage()` gathers completed file paths from pending uploads, appends `[Uploaded files: ...]` to content, opens WebSocket, POSTs message, receives stream events via WS. When the selected backend differs from the stored `defaultBackend` setting, it auto-saves the new choice via `PUT /settings` (fire-and-forget) so future new conversations use it.
+- `chatSendMessage()` gathers completed file paths from pending uploads, appends `[Uploaded files: ...]` to content, opens WebSocket, POSTs message (with `backend` and `model`), receives stream events via WS. When the selected backend or model differs from the stored defaults, it auto-saves the new choice via `PUT /settings` (fire-and-forget) so future new conversations use it.
 - Streaming uses `fetch` with manual ReadableStream parsing (not EventSource API)
 - **Streaming state persistence:** `chatStreamingState` Map stores per-conversation state (accumulated text, thinking, tools, agents, tool/agent history, pending interactions). State survives conversation switches — on return, the streaming bubble is recreated and restored.
 - **WebSocket auto-reconnect:** On unexpected WS close during streaming, the client automatically attempts reconnection with exponential backoff (1s base, up to 5 attempts). On reconnect, the server replays buffered events wrapped in `replay_start`/`replay_end`. The client resets streaming state on `replay_start` (clears accumulated text/thinking/tools) and reprocesses replayed events from scratch. `assistant_message` events are deduplicated by message ID. `done` events during replay are ignored to prevent stale streams from destroying the current streaming state. After max attempts exhausted, `_doneResolve` is called to clean up. `chatDisconnectWs()` clears reconnect attempts to prevent auto-reconnect on deliberate close. Session reset clears the server-side event buffer to prevent stale events from replaying into the new session.
@@ -819,6 +824,7 @@ Tabbed layout with two tabs:
 - Send behavior: Enter or Shift+Enter
 - System prompt textarea (global)
 - Default backend selector (also auto-updated when user sends a message with a different backend)
+- Default model selector (shown only when the selected backend has models; auto-updated with backend changes)
 - Working directory
 
 **Usage Stats tab:**
@@ -924,10 +930,10 @@ Update OAuth callback URLs to include the ngrok URL.
 | File | Focus |
 |------|-------|
 | `test/toolUtils.test.ts` | Shared backend helpers: extractToolDetails, extractToolOutcome, extractUsage, shortenPath, sanitizeSystemPrompt, isApiError |
-| `test/backends.test.ts` | BaseBackendAdapter (including generateTitle), BackendRegistry (including shutdownAll), ClaudeCodeAdapter |
+| `test/backends.test.ts` | BaseBackendAdapter (including generateTitle), BackendRegistry (including shutdownAll), ClaudeCodeAdapter (metadata models, --model flag passthrough) |
 | `test/kiroBackend.test.ts` | KiroAdapter metadata, lifecycle (shutdown, onSessionReset), extractKiroToolDetails tool name normalization, generateSummary/generateTitle fallbacks |
-| `test/chat.test.ts` | Chat routes: WebSocket streaming (text, tool_activity, stdin input, abort, assistant_message), WebSocket reconnection (replay buffered events, CLI survives disconnect, CLI crash buffers error, abort clears buffer, session reset clears buffer), turn boundaries, turn_complete event forwarding, tool activity persistence, parallel agent persistence, session overview aggregation, auto title update on session reset, usage event forwarding and persistence (including sessionUsage), usage stats endpoints (GET/DELETE), file upload/serve, workspace instructions, archive/restore endpoints, message queue persistence (GET/PUT/DELETE, included in conversation response, cleared on reset/archive) |
-| `test/chatService.test.ts` | ChatService CRUD, messages (including toolActivity persistence), sessions, generateAndUpdateTitle, archive/restore (flag set/remove, file preservation, list filtering, search filtering, delete-after-archive), usage tracking (addUsage with conversationUsage/sessionUsage, usageByBackend, daily ledger with backend+model dimensions, model separation, getUsage, getUsageStats, clearUsageStats, Kiro credits accumulation, contextUsagePercentage snapshot, skipLedger option), workspace storage, migration, markdown export |
+| `test/chat.test.ts` | Chat routes: WebSocket streaming (text, tool_activity, stdin input, abort, assistant_message), WebSocket reconnection (replay buffered events, CLI survives disconnect, CLI crash buffers error, abort clears buffer, session reset clears buffer), turn boundaries, turn_complete event forwarding, tool activity persistence, parallel agent persistence, session overview aggregation, auto title update on session reset, usage event forwarding and persistence (including sessionUsage), usage stats endpoints (GET/DELETE), file upload/serve, workspace instructions, archive/restore endpoints, message queue persistence (GET/PUT/DELETE, included in conversation response, cleared on reset/archive), model passthrough (explicit model, stored model, model update) |
+| `test/chatService.test.ts` | ChatService CRUD, messages (including toolActivity persistence), sessions, generateAndUpdateTitle, archive/restore (flag set/remove, file preservation, list filtering, search filtering, delete-after-archive), usage tracking (addUsage with conversationUsage/sessionUsage, usageByBackend, daily ledger with backend+model dimensions, model separation, getUsage, getUsageStats, clearUsageStats, Kiro credits accumulation, contextUsagePercentage snapshot, skipLedger option), model selection (create with model, updateConversationModel, listConversations model), workspace storage, migration, markdown export |
 | `test/draftState.test.ts` | Draft save/restore, key migration, cleanup, round-trip |
 | `test/messageQueue.test.ts` | Message queue: adding, deleting, rendering, in-flight protection, pause/resume, per-conversation isolation, send button state, suspended (restored) state |
 | `test/graceful-shutdown.test.ts` | Server shutdown on SIGINT/SIGTERM |

--- a/public/index.html
+++ b/public/index.html
@@ -61,6 +61,9 @@
           <select class="chat-model-select" id="chat-backend-select">
             <!-- Populated dynamically from /api/chat/backends -->
           </select>
+          <select class="chat-model-select" id="chat-model-select" style="display:none;">
+            <!-- Populated dynamically based on selected backend's models -->
+          </select>
         </div>
         <div id="chat-file-chips" class="chat-file-chips" style="display:none;"></div>
         <div class="chat-input-box">

--- a/public/js/backends.js
+++ b/public/js/backends.js
@@ -10,13 +10,16 @@ export async function loadBackends() {
     for (const b of data.backends) {
       state.BACKEND_CAPABILITIES[b.id] = b.capabilities || {};
       state.BACKEND_ICONS[b.id] = b.icon || null;
+      state.BACKEND_MODELS[b.id] = b.models || null;
     }
     populateBackendSelects();
+    populateModelSelect();
   } catch (err) {
     console.error('[loadBackends]', err);
     // Fallback so the UI still works
     state.CHAT_BACKENDS = [{ id: 'claude-code', label: 'Claude Code' }];
     populateBackendSelects();
+    populateModelSelect();
   }
 }
 
@@ -30,6 +33,40 @@ export function populateBackendSelects() {
     if (current && [...sel.options].some(o => o.value === current)) {
       sel.value = current;
     }
+  }
+}
+
+/**
+ * Populate the model dropdown based on the currently selected backend.
+ * If the backend has no models array, hide the dropdown.
+ */
+export function populateModelSelect(selectedModel) {
+  const modelSelect = document.getElementById('chat-model-select');
+  if (!modelSelect) return;
+
+  const backendSelect = document.getElementById('chat-backend-select');
+  const backendId = backendSelect?.value || (state.CHAT_BACKENDS[0]?.id || 'claude-code');
+  const models = state.BACKEND_MODELS[backendId];
+
+  if (!models || models.length === 0) {
+    modelSelect.style.display = 'none';
+    modelSelect.innerHTML = '';
+    return;
+  }
+
+  modelSelect.style.display = '';
+  const current = selectedModel || modelSelect.value;
+  modelSelect.innerHTML = models.map(m => {
+    const costLabel = m.costTier === 'high' ? ' \u25cf' : m.costTier === 'low' ? ' \u25cb' : '';
+    return `<option value="${esc(m.id)}"${m.default ? ' data-default="true"' : ''}>${esc(m.label)}${costLabel}</option>`;
+  }).join('');
+
+  // Restore previous selection, or use model from conversation, or default
+  if (current && [...modelSelect.options].some(o => o.value === current)) {
+    modelSelect.value = current;
+  } else {
+    const defaultModel = models.find(m => m.default);
+    if (defaultModel) modelSelect.value = defaultModel.id;
   }
 }
 

--- a/public/js/conversations.js
+++ b/public/js/conversations.js
@@ -2,6 +2,7 @@ import { state, chatFetch, fetchCsrfToken, chatApiUrl, chatSyncQueueToServer } f
 import { esc, chatFormatFileSize, chatFormatTokenCount, chatFormatCost } from './utils.js';
 import { chatRenderMessages, chatRenderMarkdown, chatAutoResize, chatScrollToBottom } from './rendering.js';
 import { chatShowModal, chatCloseModal } from './modal.js';
+import { populateModelSelect } from './backends.js';
 
 // ── File attachment helpers ──────────────────────────────────────────────────
 
@@ -352,6 +353,7 @@ export async function chatCreateConversationWithDir(workingDir) {
     if (backendSelect && conv.backend) {
       backendSelect.value = conv.backend;
     }
+    populateModelSelect(state.chatSettingsData?.defaultModel);
     const textarea = document.getElementById('chat-textarea');
     if (textarea) textarea.focus();
   } catch (err) {
@@ -618,6 +620,7 @@ export async function chatSelectConversation(id) {
     if (backendSelect && state.chatActiveConv.backend) {
       backendSelect.value = state.chatActiveConv.backend;
     }
+    populateModelSelect(state.chatActiveConv.model);
   } catch (err) {
     alert('Failed to load conversation: ' + err.message);
   }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2,7 +2,7 @@ import { state, chatFetch, apiUrl, DEFAULT_BACKEND_ICON } from './state.js';
 import { esc, chatFormatTokenCount, chatFormatCost } from './utils.js';
 import { applyTheme } from './theme.js';
 import { chatShowModal, chatCloseModal } from './modal.js';
-import { loadBackends, getBackendIcon, getBackendCapabilities } from './backends.js';
+import { loadBackends, getBackendIcon, getBackendCapabilities, populateModelSelect } from './backends.js';
 import { setStreamEventHandler } from './websocket.js';
 import {
   chatRenderMessages, chatAutoResize, chatRenderMarkdown, chatHighlightCode,
@@ -46,6 +46,7 @@ window.chatResumeSuspendedQueue = chatResumeSuspendedQueue;
 window.chatClearQueue = chatClearQueue;
 window.chatRetryLast = chatRetryLast;
 window.chatSaveSettings = chatSaveSettings;
+window.chatSettingsBackendChanged = chatSettingsBackendChanged;
 window.chatUpdateUsageStats = chatUpdateUsageStats;
 window.chatClearUsageStats = chatClearUsageStats;
 window.chatSaveWorkspaceInstructions = chatSaveWorkspaceInstructions;
@@ -87,6 +88,7 @@ function chatInit() {
   chatFetch('settings').then(res => res.json()).then(s => {
     state.chatSettingsData = s;
     applyTheme(s.theme || 'system');
+    if (s.defaultModel) populateModelSelect(s.defaultModel);
   }).catch(() => {});
 }
 
@@ -133,6 +135,14 @@ function chatWireEvents() {
 
   const toggleBtn = document.getElementById('chat-header-toggle');
   if (toggleBtn) toggleBtn.onclick = () => chatToggleSidebar();
+
+  const backendSel = document.getElementById('chat-backend-select');
+  if (backendSel && !backendSel._modelWired) {
+    backendSel._modelWired = true;
+    backendSel.addEventListener('change', () => {
+      populateModelSelect();
+    });
+  }
 
   const sendBtn = document.getElementById('chat-send-btn');
   if (sendBtn) sendBtn.onclick = () => {
@@ -514,8 +524,14 @@ async function chatShowSettings(initialTab) {
         </div>
         <div class="chat-settings-group">
           <div class="chat-settings-label">Default Backend</div>
-          <select class="chat-settings-select" id="chat-settings-backend">
+          <select class="chat-settings-select" id="chat-settings-backend" onchange="chatSettingsBackendChanged()">
             ${state.CHAT_BACKENDS.map(b => `<option value="${b.id}"${s.defaultBackend === b.id ? ' selected' : ''}>${esc(b.label)}</option>`).join('')}
+          </select>
+        </div>
+        <div class="chat-settings-group" id="chat-settings-model-group"${(() => { const models = state.BACKEND_MODELS[s.defaultBackend]; return (!models || models.length === 0) ? ' style="display:none;"' : ''; })()}>
+          <div class="chat-settings-label">Default Model</div>
+          <select class="chat-settings-select" id="chat-settings-model">
+            ${(() => { const models = state.BACKEND_MODELS[s.defaultBackend] || []; return models.map(m => `<option value="${m.id}"${s.defaultModel === m.id ? ' selected' : (m.default && !s.defaultModel ? ' selected' : '')}>${esc(m.label)}</option>`).join(''); })()}
           </select>
         </div>
         <div class="chat-settings-group">
@@ -564,11 +580,33 @@ async function chatShowSettings(initialTab) {
   }
 }
 
+function chatSettingsBackendChanged() {
+  const backendId = document.getElementById('chat-settings-backend')?.value;
+  const modelGroup = document.getElementById('chat-settings-model-group');
+  const modelSelect = document.getElementById('chat-settings-model');
+  if (!modelGroup || !modelSelect) return;
+
+  const models = state.BACKEND_MODELS[backendId];
+  if (!models || models.length === 0) {
+    modelGroup.style.display = 'none';
+    modelSelect.innerHTML = '';
+    return;
+  }
+  modelGroup.style.display = '';
+  modelSelect.innerHTML = models.map(m =>
+    `<option value="${esc(m.id)}"${m.default ? ' selected' : ''}>${esc(m.label)}</option>`
+  ).join('');
+}
+
 function chatSaveSettings() {
+  const defaultBackend = document.getElementById('chat-settings-backend')?.value || (state.CHAT_BACKENDS[0]?.id || 'claude-code');
+  const modelEl = document.getElementById('chat-settings-model');
+  const defaultModel = (modelEl && modelEl.closest('.chat-settings-group')?.style.display !== 'none') ? modelEl.value : undefined;
   const settings = {
     theme: document.getElementById('chat-settings-theme')?.value || 'system',
     sendBehavior: document.getElementById('chat-settings-send')?.value || 'enter',
-    defaultBackend: document.getElementById('chat-settings-backend')?.value || (state.CHAT_BACKENDS[0]?.id || 'claude-code'),
+    defaultBackend,
+    defaultModel,
     systemPrompt: document.getElementById('chat-settings-system-prompt')?.value || '',
   };
   applyTheme(settings.theme);

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -34,6 +34,7 @@ export const state = {
   CHAT_BACKENDS: [],
   BACKEND_CAPABILITIES: {},
   BACKEND_ICONS: {},
+  BACKEND_MODELS: {},  // backendId -> ModelOption[] | null
 };
 
 // ─── Queue sync ─────────────────────────────────────────────────────────────

--- a/public/js/streaming.js
+++ b/public/js/streaming.js
@@ -151,12 +151,24 @@ export async function chatSendMessage() {
 
   state.chatDraftState.delete(state.chatActiveConvId);
   const backend = document.getElementById('chat-backend-select')?.value || (state.CHAT_BACKENDS[0]?.id || 'claude-code');
+  const modelSelect = document.getElementById('chat-model-select');
+  const model = (modelSelect && modelSelect.style.display !== 'none') ? modelSelect.value : undefined;
   const targetConvId = state.chatActiveConvId;
 
-  // Persist selected backend as the default for new conversations
-  if (state.chatSettingsData && state.chatSettingsData.defaultBackend !== backend) {
-    state.chatSettingsData.defaultBackend = backend;
-    chatFetch('settings', { method: 'PUT', body: state.chatSettingsData }).catch(() => {});
+  // Persist selected backend (and model) as the default for new conversations
+  if (state.chatSettingsData) {
+    let dirty = false;
+    if (state.chatSettingsData.defaultBackend !== backend) {
+      state.chatSettingsData.defaultBackend = backend;
+      dirty = true;
+    }
+    if (model !== undefined && state.chatSettingsData.defaultModel !== model) {
+      state.chatSettingsData.defaultModel = model;
+      dirty = true;
+    }
+    if (dirty) {
+      chatFetch('settings', { method: 'PUT', body: state.chatSettingsData }).catch(() => {});
+    }
   }
 
   state.chatStreamingConvs.add(targetConvId);
@@ -194,7 +206,7 @@ export async function chatSendMessage() {
         'x-csrf-token': state.csrfToken || '',
       },
       credentials: 'same-origin',
-      body: JSON.stringify({ content, backend }),
+      body: JSON.stringify({ content, backend, model }),
     });
 
     if (!response.ok) {

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -387,7 +387,7 @@ export function createChatRouter({ chatService, backendRegistry, updateService }
   // ── Create conversation ────────────────────────────────────────────────────
   router.post('/conversations', csrfGuard, async (req: Request, res: Response) => {
     try {
-      const conv = await chatService.createConversation(req.body.title, req.body.workingDir, req.body.backend);
+      const conv = await chatService.createConversation(req.body.title, req.body.workingDir, req.body.backend, req.body.model);
       res.json(conv);
     } catch (err: unknown) {
       res.status(500).json({ error: (err as Error).message });
@@ -567,7 +567,7 @@ export function createChatRouter({ chatService, backendRegistry, updateService }
   // ── Send message + stream response ────────────────────────────────────────
   router.post('/conversations/:id/message', csrfGuard, async (req: Request, res: Response) => {
     const convId = param(req, 'id');
-    const { content, backend } = req.body as { content?: string; backend?: string };
+    const { content, backend, model } = req.body as { content?: string; backend?: string; model?: string };
 
     if (!content || typeof content !== 'string' || !content.trim()) {
       return res.status(400).json({ error: 'Message content required' });
@@ -578,6 +578,9 @@ export function createChatRouter({ chatService, backendRegistry, updateService }
 
     if (backend && backend !== conv.backend) {
       await chatService.updateConversationBackend(convId, backend);
+    }
+    if (model !== undefined && model !== (conv.model || undefined)) {
+      await chatService.updateConversationModel(convId, model || null);
     }
 
     const userMsg = await chatService.addMessage(convId, 'user', content.trim(), backend || conv.backend);
@@ -614,6 +617,7 @@ export function createChatRouter({ chatService, backendRegistry, updateService }
       workingDir: conv.workingDir || null,
       systemPrompt,
       externalSessionId: conv.externalSessionId || null,
+      model: model || conv.model || undefined,
     });
     const needsTitleUpdate = isNewSession && conv.sessionNumber > 1;
     activeStreams.set(convId, { stream, abort, sendInput, backend: backendId, needsTitleUpdate, titleUpdateMessage: needsTitleUpdate ? content.trim() : null });

--- a/src/services/backends/claudeCode.ts
+++ b/src/services/backends/claudeCode.ts
@@ -53,6 +53,44 @@ export class ClaudeCodeAdapter extends BaseBackendAdapter {
         userQuestions: true,
         stdinInput: true,
       },
+      models: [
+        {
+          id: 'opus',
+          label: 'Opus 4.6',
+          family: 'opus',
+          description: 'Most capable — complex reasoning, architecture, nuanced tasks',
+          costTier: 'high',
+        },
+        {
+          id: 'sonnet',
+          label: 'Sonnet 4.6',
+          family: 'sonnet',
+          description: 'Balanced — fast and capable for most coding tasks',
+          costTier: 'medium',
+          default: true,
+        },
+        {
+          id: 'haiku',
+          label: 'Haiku 4.5',
+          family: 'haiku',
+          description: 'Fastest and cheapest — simple tasks, quick iterations',
+          costTier: 'low',
+        },
+        {
+          id: 'opus[1m]',
+          label: 'Opus 4.6 (1M context)',
+          family: 'opus',
+          description: 'Extended context window for large codebases',
+          costTier: 'high',
+        },
+        {
+          id: 'sonnet[1m]',
+          label: 'Sonnet 4.6 (1M context)',
+          family: 'sonnet',
+          description: 'Extended context window with balanced performance',
+          costTier: 'medium',
+        },
+      ],
     };
   }
 
@@ -131,7 +169,7 @@ export class ClaudeCodeAdapter extends BaseBackendAdapter {
     options: SendMessageOptions,
     state: StreamState,
   ): AsyncGenerator<StreamEvent> {
-    const { sessionId, isNewSession, workingDir, systemPrompt } = options;
+    const { sessionId, isNewSession, workingDir, systemPrompt, model } = options;
 
     const args = [
       '--print',
@@ -139,6 +177,10 @@ export class ClaudeCodeAdapter extends BaseBackendAdapter {
       '--output-format', 'stream-json',
       '--verbose',
     ];
+
+    if (model) {
+      args.push('--model', model);
+    }
 
     if (isNewSession) {
       args.push('--session-id', sessionId);

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -181,7 +181,7 @@ export class ChatService {
 
   // ── Conversation CRUD ──────────────────────────────────────────────────────
 
-  async createConversation(title?: string, workingDir?: string, backend?: string): Promise<Conversation> {
+  async createConversation(title?: string, workingDir?: string, backend?: string, model?: string): Promise<Conversation> {
     const id = this._newId();
     const now = new Date().toISOString();
     const sessionId = this._newId();
@@ -198,6 +198,7 @@ export class ChatService {
       id,
       title: title || 'New Chat',
       backend: backend || defaultBackend,
+      model: model || undefined,
       currentSessionId: sessionId,
       lastActivity: now,
       lastMessage: null,
@@ -229,6 +230,7 @@ export class ChatService {
       id,
       title: convEntry.title,
       backend: convEntry.backend,
+      model: convEntry.model,
       workingDir: workspacePath,
       currentSessionId: sessionId,
       sessionNumber: 1,
@@ -251,6 +253,7 @@ export class ChatService {
       id: convEntry.id,
       title: convEntry.title,
       backend: convEntry.backend,
+      model: convEntry.model,
       workingDir: index.workspacePath,
       currentSessionId: convEntry.currentSessionId,
       sessionNumber,
@@ -286,6 +289,7 @@ export class ChatService {
           title: conv.title,
           updatedAt: conv.lastActivity,
           backend: conv.backend,
+          model: conv.model,
           workingDir: index.workspacePath,
           workspaceHash: hash,
           messageCount: activeSession ? activeSession.messageCount : 0,
@@ -361,6 +365,14 @@ export class ChatService {
     if (!result) return;
     const { hash, index, convEntry } = result;
     convEntry.backend = backend;
+    await this._writeWorkspaceIndex(hash, index);
+  }
+
+  async updateConversationModel(convId: string, model: string | null): Promise<void> {
+    const result = await this._getConvFromIndex(convId);
+    if (!result) return;
+    const { hash, index, convEntry } = result;
+    convEntry.model = model || undefined;
     await this._writeWorkspaceIndex(hash, index);
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -98,6 +98,7 @@ export interface ConversationEntry {
   id: string;
   title: string;
   backend: string;
+  model?: string;
   currentSessionId: string;
   lastActivity: string;
   lastMessage: string | null;
@@ -118,6 +119,7 @@ export interface Conversation {
   id: string;
   title: string;
   backend: string;
+  model?: string;
   workingDir: string;
   currentSessionId: string;
   sessionNumber: number;
@@ -134,6 +136,7 @@ export interface ConversationListItem {
   title: string;
   updatedAt: string;
   backend: string;
+  model?: string;
   workingDir: string;
   workspaceHash: string;
   messageCount: number;
@@ -149,6 +152,7 @@ export interface Settings {
   sendBehavior: 'enter' | 'ctrlEnter';
   systemPrompt: string;
   defaultBackend: string;
+  defaultModel?: string;
   workingDirectory?: string;
   customInstructions?: {
     aboutUser?: string;
@@ -245,11 +249,21 @@ export interface BackendCapabilities {
   stdinInput: boolean;
 }
 
+export interface ModelOption {
+  id: string;
+  label: string;
+  family: string;
+  description?: string;
+  costTier?: 'high' | 'medium' | 'low';
+  default?: boolean;
+}
+
 export interface BackendMetadata {
   id: string;
   label: string;
   icon: string | null;
   capabilities: BackendCapabilities;
+  models?: ModelOption[];
 }
 
 export interface SendMessageOptions {
@@ -261,6 +275,8 @@ export interface SendMessageOptions {
   systemPrompt: string;
   /** Backend-managed session ID from a previous session, for resume/rehydration. */
   externalSessionId?: string | null;
+  /** Model ID or alias (e.g., 'opus', 'claude-sonnet-4-6'). Backends that don't support model selection ignore this. */
+  model?: string;
 }
 
 export interface SendMessageResult {

--- a/test/backends.test.ts
+++ b/test/backends.test.ts
@@ -132,6 +132,29 @@ describe('ClaudeCodeAdapter', () => {
     });
   });
 
+  test('metadata includes models array', () => {
+    const adapter = new ClaudeCodeAdapter({ workingDir: '/tmp' });
+    const meta = adapter.metadata;
+    expect(meta.models).toBeDefined();
+    expect(Array.isArray(meta.models)).toBe(true);
+    expect(meta.models!.length).toBeGreaterThanOrEqual(3);
+
+    const opus = meta.models!.find(m => m.id === 'opus');
+    expect(opus).toBeDefined();
+    expect(opus!.label).toBe('Opus 4.6');
+    expect(opus!.family).toBe('opus');
+    expect(opus!.costTier).toBe('high');
+
+    const sonnet = meta.models!.find(m => m.id === 'sonnet');
+    expect(sonnet).toBeDefined();
+    expect(sonnet!.default).toBe(true);
+    expect(sonnet!.costTier).toBe('medium');
+
+    const haiku = meta.models!.find(m => m.id === 'haiku');
+    expect(haiku).toBeDefined();
+    expect(haiku!.costTier).toBe('low');
+  });
+
   test('uses default working directory', () => {
     const adapter = new ClaudeCodeAdapter();
     expect(adapter.workingDir).toContain('.openclaw');
@@ -166,6 +189,83 @@ describe('ClaudeCodeAdapter sendMessage', () => {
     }
     await sleep(500);
   }, 10000);
+
+  test('passes --model flag when model option is set', async () => {
+    let capturedArgs: string[] | undefined;
+    let streamRef: AsyncGenerator<any>;
+    jest.isolateModules(() => {
+      jest.mock('child_process', () => ({
+        spawn: (_cmd: string, args: string[]) => {
+          capturedArgs = args;
+          const { EventEmitter } = require('events');
+          const proc = new EventEmitter();
+          proc.stdout = new EventEmitter();
+          proc.stderr = new EventEmitter();
+          proc.stdin = { write: () => {}, destroyed: false };
+          proc.kill = () => {};
+          setTimeout(() => proc.emit('close', 0, null), 10);
+          return proc;
+        },
+        execFile: () => {},
+      }));
+      const { ClaudeCodeAdapter: IsolatedAdapter } = require('../src/services/backends/claudeCode');
+      const adapter = new IsolatedAdapter({ workingDir: '/tmp' });
+      const { stream } = adapter.sendMessage('hello', {
+        sessionId: 'test-model',
+        isNewSession: true,
+        workingDir: '/tmp',
+        systemPrompt: '',
+        model: 'opus',
+      });
+      streamRef = stream;
+    });
+
+    for await (const event of streamRef!) {
+      if (event.type === 'done') break;
+    }
+
+    expect(capturedArgs).toBeDefined();
+    const idx = capturedArgs!.indexOf('--model');
+    expect(idx).toBeGreaterThan(-1);
+    expect(capturedArgs![idx + 1]).toBe('opus');
+  });
+
+  test('omits --model flag when model option is not set', async () => {
+    let capturedArgs: string[] | undefined;
+    let streamRef: AsyncGenerator<any>;
+    jest.isolateModules(() => {
+      jest.mock('child_process', () => ({
+        spawn: (_cmd: string, args: string[]) => {
+          capturedArgs = args;
+          const { EventEmitter } = require('events');
+          const proc = new EventEmitter();
+          proc.stdout = new EventEmitter();
+          proc.stderr = new EventEmitter();
+          proc.stdin = { write: () => {}, destroyed: false };
+          proc.kill = () => {};
+          setTimeout(() => proc.emit('close', 0, null), 10);
+          return proc;
+        },
+        execFile: () => {},
+      }));
+      const { ClaudeCodeAdapter: IsolatedAdapter } = require('../src/services/backends/claudeCode');
+      const adapter = new IsolatedAdapter({ workingDir: '/tmp' });
+      const { stream } = adapter.sendMessage('hello', {
+        sessionId: 'test-no-model',
+        isNewSession: true,
+        workingDir: '/tmp',
+        systemPrompt: '',
+      });
+      streamRef = stream;
+    });
+
+    for await (const event of streamRef!) {
+      if (event.type === 'done') break;
+    }
+
+    expect(capturedArgs).toBeDefined();
+    expect(capturedArgs).not.toContain('--model');
+  });
 
   test('includes --append-system-prompt for new sessions with systemPrompt', async () => {
     let capturedArgs: string[] | undefined;

--- a/test/chat.test.ts
+++ b/test/chat.test.ts
@@ -1059,6 +1059,55 @@ describe('sendMessage options passthrough', () => {
 
     expect(mockBackend._lastOptions!.externalSessionId).toBeNull();
   });
+
+  test('passes model to backend adapter', async () => {
+    const conv = await chatService.createConversation('Test');
+    mockBackend.setMockEvents([
+      { type: 'text', content: 'Hi', streaming: true },
+      { type: 'done' },
+    ] as StreamEvent[]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'Hello',
+      backend: 'claude-code',
+      model: 'opus',
+    });
+
+    expect(mockBackend._lastOptions!.model).toBe('opus');
+  });
+
+  test('uses stored conversation model when not in request', async () => {
+    const conv = await chatService.createConversation('Test', undefined, undefined, 'haiku');
+    mockBackend.setMockEvents([
+      { type: 'text', content: 'Hi', streaming: true },
+      { type: 'done' },
+    ] as StreamEvent[]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'Hello',
+      backend: 'claude-code',
+    });
+
+    expect(mockBackend._lastOptions!.model).toBe('haiku');
+  });
+
+  test('updates stored model when request includes different model', async () => {
+    const conv = await chatService.createConversation('Test', undefined, undefined, 'haiku');
+    mockBackend.setMockEvents([
+      { type: 'text', content: 'Hi', streaming: true },
+      { type: 'done' },
+    ] as StreamEvent[]);
+
+    await makeRequest('POST', `/api/chat/conversations/${conv.id}/message`, {
+      content: 'Hello',
+      backend: 'claude-code',
+      model: 'opus',
+    });
+
+    expect(mockBackend._lastOptions!.model).toBe('opus');
+    const loaded = await chatService.getConversation(conv.id);
+    expect(loaded!.model).toBe('opus');
+  });
 });
 
 // ── PATCH /conversations/:id/archive ─────────────────────────────────────────

--- a/test/chatService.test.ts
+++ b/test/chatService.test.ts
@@ -340,6 +340,43 @@ describe('updateConversationBackend', () => {
   });
 });
 
+describe('model selection', () => {
+  test('creates conversation with model', async () => {
+    const conv = await service.createConversation('Test', undefined, undefined, 'opus');
+    expect(conv.model).toBe('opus');
+
+    const loaded = await service.getConversation(conv.id);
+    expect(loaded!.model).toBe('opus');
+  });
+
+  test('creates conversation without model', async () => {
+    const conv = await service.createConversation('Test');
+    expect(conv.model).toBeUndefined();
+  });
+
+  test('updateConversationModel sets model', async () => {
+    const conv = await service.createConversation('Test');
+    await service.updateConversationModel(conv.id, 'haiku');
+
+    const loaded = await service.getConversation(conv.id);
+    expect(loaded!.model).toBe('haiku');
+  });
+
+  test('updateConversationModel clears model with null', async () => {
+    const conv = await service.createConversation('Test', undefined, undefined, 'opus');
+    await service.updateConversationModel(conv.id, null);
+
+    const loaded = await service.getConversation(conv.id);
+    expect(loaded!.model).toBeUndefined();
+  });
+
+  test('model appears in listConversations', async () => {
+    await service.createConversation('Test', undefined, undefined, 'sonnet');
+    const list = await service.listConversations();
+    expect(list[0].model).toBe('sonnet');
+  });
+});
+
 // ── Messages ─────────────────────────────────────────────────────────────────
 
 describe('addMessage', () => {


### PR DESCRIPTION
## Summary

- Add per-conversation model selection (Opus, Sonnet, Haiku + 1M context variants) for the Claude Code backend
- Models exposed via `BackendMetadata.models` array, persisted in conversation index, passed to CLI via `--model` flag
- Frontend model dropdown appears next to backend selector (hidden for backends without models), syncs on conversation switch
- Default model configurable in Settings modal, auto-saved when user sends with a different model

## Test plan

- [x] All 431 existing tests pass
- [x] 10 new tests: model metadata shape, `--model` CLI flag passthrough/omission, ChatService CRUD for model, route model passthrough/fallback/update
- [ ] Manual: select different models in dropdown, verify `--model` flag in CLI spawn logs
- [ ] Manual: switch conversations, verify model dropdown restores correctly
- [ ] Manual: change default model in Settings, verify new conversations use it

Closes #102