### PR TITLE
feat: file delivery with inline cards and viewer panel

### DIFF
--- a/docs/spec-api-endpoints.md
+++ b/docs/spec-api-endpoints.md
@@ -227,11 +227,14 @@ Per-workspace instructions appended to the global system prompt on new sessions.
 | GET | `/workspaces/:hash/kb/reflections` | — | List all reflections. Returns `{ reflections: [{ reflectionId, title, type, summary, citationCount, createdAt, isStale }] }`. Stale detection: a reflection is stale if any cited entry was re-digested or deleted since the reflection was created. |
 | GET | `/workspaces/:hash/kb/reflections/:reflectionId` | — | Single reflection detail. Returns `{ reflectionId, title, type, summary, content, createdAt, citationCount, citedEntries: KbEntry[] }`. `404` if not found. |
 
+| GET | `/workspaces/:hash/files` | — | Serves a file from the workspace's working directory for the file delivery feature. Required query param `path` (absolute file path). Optional `mode`: `view` returns `{ content, filename, language }` JSON (capped at 2 MB), `download` (default) streams the file with `Content-Disposition: attachment`. Path traversal protection: resolved path must be under the workspace root. `400` if path missing or not a file. `403` if path is outside workspace. `404` if file or workspace not found. `413` if file exceeds 2 MB in view mode. |
+
 **System prompt composition on new sessions:**
 1. Global system prompt (from `settings.json`)
 2. Workspace instructions (from workspace `index.json`)
 3. **Memory MCP addendum** — appended for every backend whenever `memoryEnabled` is true. Instructs the CLI to call `memory_note` via the `agent-cockpit-memory` MCP server for durable user/feedback/project/reference facts it encounters during the session. Claude Code gets this addendum too — its native `#` flow handles explicit saves, but `memory_note` captures incidental facts mentioned conversationally.
 4. **KB Tools addendum** — appended for every backend whenever `kbEnabled` is true. Teaches the CLI that KB search tools are available via the `agent-cockpit-kb-search` MCP server: `search_topics`, `search_entries`, `get_topic`, `find_similar_topics`, `find_unconnected_similar`, and `kb_ingest`. Includes the filesystem layout for direct reads (`entries/<entryId>/entry.md`, `synthesis/*.md`, `synthesis/reflections/*.md`, `state.db`) and the intended workflow: use search tools to find relevant knowledge, then read entry files for full content. The absolute path to the workspace's `knowledge/` directory is interpolated at runtime.
+5. **File delivery addendum** — always appended on new sessions. Instructs the CLI to output `<!-- FILE_DELIVERY:/absolute/path --> ` markers when the user explicitly asks for a downloadable file. The marker is stripped by the frontend and replaced with a file card (View + Download buttons). Not used for normal coding file operations.
 
 Concatenated with `\n\n` and passed as the backend's system prompt. Not sent on session resume.
 

--- a/docs/spec-frontend.md
+++ b/docs/spec-frontend.md
@@ -59,6 +59,14 @@ Vanilla JavaScript SPA — no framework, no bundler, no build step. Frontend is 
 - At send time: completed file paths embedded as `[Uploaded files: /path/to/file1, ...]`
 - **Inline images:** `chatRenderUploadedFiles()` replaces `[Uploaded files: ...]` with `<img>` tags for image extensions (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`, `.bmp`). Click opens lightbox overlay.
 
+## File Delivery
+
+- **Trigger:** The CLI outputs `<!-- FILE_DELIVERY:/path/to/file -->` markers when the user explicitly requests a deliverable file (e.g. "give me a CSV", "create a report"). The system prompt instructs all backends to use this marker only for user-requested deliverables, not for routine file edits.
+- **Marker extraction:** `chatExtractFileDeliveries(text)` runs as a pre-processing step before markdown rendering. Strips all `FILE_DELIVERY` HTML comments from the text and returns the list of file paths. Runs in both streaming and static message rendering paths (via `chatRenderMarkdown`).
+- **File cards:** `chatRenderFileCards(files)` renders inline cards for each delivered file, showing a file icon, filename, and two buttons: **View** (opens the side panel) and **Download** (direct browser download via `Content-Disposition: attachment`). Both buttons hit `GET /workspaces/:hash/files?path=...&mode=view|download`.
+- **Viewer panel:** A right-side panel (`.chat-file-viewer`) that slides in when the user clicks View. Shows the file's text content with syntax highlighting (via highlight.js). Capped at 2 MB on the server side. Closed via the X button or automatically on conversation switch. On mobile (≤768px), the panel overlays the full chat area.
+- **Multi-file support:** Multiple `FILE_DELIVERY` markers in one message render multiple file cards. The View panel swaps content when opening a different file.
+
 ## Draft Persistence
 
 - `chatSaveDraft()` / `chatRestoreDraft()` — per-conversation drafts stored in `chatDraftState` Map keyed by convId (or `'__new__'` for unsaved conversations)

--- a/public/index.html
+++ b/public/index.html
@@ -89,6 +89,16 @@
       </div>
     </div>
   </div>
+  <!-- File viewer panel — slides in from the right when the user clicks
+       "View" on a file delivery card. Closed via the X button or when
+       switching conversations. -->
+  <div class="chat-file-viewer" id="chat-file-viewer">
+    <div class="chat-file-viewer-header">
+      <span class="chat-file-viewer-title" id="chat-file-viewer-title"></span>
+      <button class="chat-file-viewer-close" onclick="chatCloseFileViewer()" title="Close">&times;</button>
+    </div>
+    <div class="chat-file-viewer-content" id="chat-file-viewer-content"></div>
+  </div>
 </div>
 
 <!-- Lightbox overlay for full-size images -->

--- a/public/js/conversations.js
+++ b/public/js/conversations.js
@@ -1,6 +1,6 @@
 import { state, chatFetch, fetchCsrfToken, chatApiUrl, chatSyncQueueToServer, ICON_ARCHIVE, ICON_SETTINGS, ICON_SEND, ICON_STOP, ICON_WORKSPACE, ICON_TOKEN, ICON_USER } from './state.js';
 import { esc, chatFormatFileSize, chatFormatTokenCount, chatFormatCost } from './utils.js';
-import { chatRenderMessages, chatRenderMarkdown, chatAutoResize, chatScrollToBottom } from './rendering.js';
+import { chatRenderMessages, chatRenderMarkdown, chatAutoResize, chatScrollToBottom, chatCloseFileViewer } from './rendering.js';
 import { chatShowModal, chatCloseModal } from './modal.js';
 import { populateModelSelect } from './backends.js';
 
@@ -597,6 +597,7 @@ export function chatRestoreDraft(convId) {
 
 export async function chatSelectConversation(id) {
   if (id === state.chatActiveConvId) return;
+  chatCloseFileViewer();
   chatSaveDraft();
   for (const entry of state.chatPendingFiles) {
     if (entry.status === 'uploading' && entry.xhr) entry.xhr.abort();

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -8,6 +8,7 @@ import {
   chatRenderMessages, chatAutoResize, chatRenderMarkdown, chatHighlightCode,
   chatScrollToBottom, chatOpenLightbox, chatCloseLightbox, chatCopyCode,
   chatToggleCodeBlock, chatRenderThinkingBlock, chatRenderToolActivityBlock,
+  chatOpenFileViewer, chatCloseFileViewer,
   setRenderingCallbacks,
 } from './rendering.js';
 import {
@@ -41,6 +42,8 @@ window.chatCopyCode = chatCopyCode;
 window.chatToggleCodeBlock = chatToggleCodeBlock;
 window.chatOpenLightbox = chatOpenLightbox;
 window.chatCloseLightbox = chatCloseLightbox;
+window.chatOpenFileViewer = chatOpenFileViewer;
+window.chatCloseFileViewer = chatCloseFileViewer;
 window.chatResumeQueue = chatResumeQueue;
 window.chatResumeSuspendedQueue = chatResumeSuspendedQueue;
 window.chatClearQueue = chatClearQueue;

--- a/public/js/rendering.js
+++ b/public/js/rendering.js
@@ -483,8 +483,49 @@ export function chatRenderUploadedFiles(html) {
 
 // ── Markdown / code ──────────────────────────────────────────────────────────
 
+// ── File delivery markers ───────────────────────────────────────────────────
+// The CLI outputs <!-- FILE_DELIVERY:/path/to/file --> when the user asks for
+// a deliverable file. We extract these markers before markdown parsing (since
+// marked strips HTML comments) and replace them with file card HTML.
+
+const FILE_DELIVERY_RE = /<!--\s*FILE_DELIVERY:(.*?)\s*-->/g;
+
+const FILE_CARD_ICON = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>';
+
+function chatExtractFileDeliveries(text) {
+  const files = [];
+  const cleaned = text.replace(FILE_DELIVERY_RE, (_, filePath) => {
+    files.push(filePath.trim());
+    return ''; // remove marker from text
+  });
+  return { cleaned, files };
+}
+
+function chatRenderFileCards(files) {
+  if (!files.length) return '';
+  const wsHash = state.chatActiveConv?.workspaceHash || '';
+  return files.map(filePath => {
+    const filename = filePath.split('/').pop() || filePath;
+    const viewUrl = chatApiUrl(`workspaces/${wsHash}/files?path=${encodeURIComponent(filePath)}&mode=view`);
+    const downloadUrl = chatApiUrl(`workspaces/${wsHash}/files?path=${encodeURIComponent(filePath)}&mode=download`);
+    return `<div class="chat-file-card" data-file-path="${esc(filePath)}">
+      <div class="chat-file-card-icon">${FILE_CARD_ICON}</div>
+      <div class="chat-file-card-name" title="${esc(filePath)}">${esc(filename)}</div>
+      <div class="chat-file-card-actions">
+        <button class="chat-file-card-btn chat-file-card-view" data-view-url="${esc(viewUrl)}" data-filename="${esc(filename)}" data-file-path="${esc(filePath)}" onclick="chatOpenFileViewer(this)">View</button>
+        <a class="chat-file-card-btn chat-file-card-download" href="${esc(downloadUrl)}" download="${esc(filename)}">Download</a>
+      </div>
+    </div>`;
+  }).join('');
+}
+
 export function chatRenderMarkdown(text) {
   if (!text) return '';
+
+  // Extract FILE_DELIVERY markers before markdown parsing
+  const { cleaned, files } = chatExtractFileDeliveries(text);
+  const fileCardsHtml = chatRenderFileCards(files);
+
   if (typeof marked !== 'undefined') {
     const renderer = new marked.Renderer();
     const origCode = renderer.code;
@@ -509,11 +550,11 @@ export function chatRenderMarkdown(text) {
         ${collapsible ? '<div class="chat-code-expand" onclick="chatToggleCodeBlock(this)">Show more</div>' : ''}
       </div>`;
     };
-    let html = marked.parse(text, { renderer, breaks: true });
-    return chatRenderUploadedFiles(html);
+    let html = marked.parse(cleaned, { renderer, breaks: true });
+    return chatRenderUploadedFiles(html) + fileCardsHtml;
   }
-  let html = esc(text).replace(/\n/g, '<br>');
-  return chatRenderUploadedFiles(html);
+  let html = esc(cleaned).replace(/\n/g, '<br>');
+  return chatRenderUploadedFiles(html) + fileCardsHtml;
 }
 
 // ── Lightbox ─────────────────────────────────────────────────────────────────
@@ -862,4 +903,41 @@ export function chatStartActivityTimer(convId) {
       chatUpdateStreamingContent(st.streamingMsgEl, st);
     }
   }, 1000);
+}
+
+// ── File viewer panel ───────────────────────────────────────────────────────
+
+export async function chatOpenFileViewer(btn) {
+  const viewUrl = btn.dataset.viewUrl;
+  const filename = btn.dataset.filename;
+  const panel = document.getElementById('chat-file-viewer');
+  const titleEl = document.getElementById('chat-file-viewer-title');
+  const contentEl = document.getElementById('chat-file-viewer-content');
+  if (!panel || !titleEl || !contentEl) return;
+
+  titleEl.textContent = filename;
+  contentEl.textContent = 'Loading...';
+  panel.classList.add('active');
+
+  try {
+    const res = await fetch(viewUrl, { credentials: 'same-origin' });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ error: res.statusText }));
+      contentEl.textContent = `Error: ${err.error || res.statusText}`;
+      return;
+    }
+    const data = await res.json();
+    const lang = data.language || '';
+    contentEl.innerHTML = `<pre><code class="${lang ? 'language-' + esc(lang) : ''}">${esc(data.content)}</code></pre>`;
+    if (typeof hljs !== 'undefined') {
+      contentEl.querySelectorAll('pre code').forEach(el => hljs.highlightElement(el));
+    }
+  } catch (err) {
+    contentEl.textContent = `Error: ${err.message}`;
+  }
+}
+
+export function chatCloseFileViewer() {
+  const panel = document.getElementById('chat-file-viewer');
+  if (panel) panel.classList.remove('active');
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -760,6 +760,120 @@
     box-shadow: 0 4px 40px rgba(0, 0, 0, 0.5);
   }
 
+  /* ── File delivery cards ──────────────────────────────────────── */
+  .chat-file-card {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    margin: 8px 0;
+    padding: 12px 16px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    max-width: 360px;
+  }
+  .chat-file-card-icon {
+    flex-shrink: 0;
+    color: var(--accent, #6366f1);
+    display: flex;
+    align-items: center;
+  }
+  .chat-file-card-name {
+    flex: 1;
+    min-width: 0;
+    font-size: 13px;
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .chat-file-card-actions {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+  .chat-file-card-btn {
+    font-size: 12px;
+    padding: 4px 10px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--fg);
+    cursor: pointer;
+    text-decoration: none;
+    line-height: 1.4;
+    transition: background 0.15s;
+  }
+  .chat-file-card-btn:hover {
+    background: var(--hover);
+  }
+  .chat-file-card-view {
+    border-color: var(--accent, #6366f1);
+    color: var(--accent, #6366f1);
+  }
+
+  /* ── File viewer panel ─────────────────────────────────────── */
+  .chat-file-viewer {
+    display: none;
+    width: 0;
+    flex-shrink: 0;
+    flex-direction: column;
+    border-left: 1px solid var(--border);
+    background: var(--bg);
+    overflow: hidden;
+    transition: width 0.25s ease;
+  }
+  .chat-file-viewer.active {
+    display: flex;
+    width: 480px;
+  }
+  .chat-file-viewer-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+    flex-shrink: 0;
+  }
+  .chat-file-viewer-title {
+    font-size: 13px;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+  .chat-file-viewer-close {
+    background: none;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+    color: var(--muted);
+    padding: 0 4px;
+    line-height: 1;
+    flex-shrink: 0;
+  }
+  .chat-file-viewer-close:hover {
+    color: var(--fg);
+  }
+  .chat-file-viewer-content {
+    flex: 1;
+    overflow: auto;
+    padding: 16px;
+    font-size: 13px;
+    line-height: 1.6;
+  }
+  .chat-file-viewer-content pre {
+    margin: 0;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+  }
+  .chat-file-viewer-content code {
+    font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+    font-size: 12px;
+  }
+
   /* Code blocks */
   .chat-code-block {
     margin: 10px 0;
@@ -2646,6 +2760,14 @@
     .chat-sidebar.collapsed { margin-left: -100%; }
     .chat-msg { padding-left: 12px; padding-right: 12px; }
     .chat-input-area { padding: 8px 12px 12px; }
+    .chat-file-viewer.active {
+      position: absolute;
+      right: 0;
+      top: 0;
+      height: 100%;
+      width: 100%;
+      z-index: 200;
+    }
   }
 
   /* ── KB Browser ──────────────────────────────────────────────────────────

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -901,7 +901,17 @@ export function createChatRouter({ chatService, backendRegistry, updateService }
             ].join('\n');
           })()
         : '';
-      const parts = [globalPrompt, wsInstructions, memoryMcpAddendum, kbMcpAddendum].filter(Boolean);
+      const fileDeliveryAddendum = [
+        '# File delivery',
+        'When the user explicitly asks you to create, generate, or give them a downloadable file (e.g. "give me a CSV", "create a report file", "export this as JSON"), follow these steps:',
+        '1. Create the file in the current working directory.',
+        '2. After creating the file, output a reference on its own line using this exact format:',
+        '   <!-- FILE_DELIVERY:/absolute/path/to/file.ext -->',
+        '3. You may include multiple FILE_DELIVERY markers if the user asks for multiple files.',
+        '',
+        'Do NOT use FILE_DELIVERY for files you create as part of normal coding tasks (editing source code, config files, etc.). Only use it when the user explicitly wants a deliverable file to download.',
+      ].join('\n');
+      const parts = [globalPrompt, wsInstructions, memoryMcpAddendum, kbMcpAddendum, fileDeliveryAddendum].filter(Boolean);
       systemPrompt = parts.join('\n\n');
     }
 
@@ -1105,6 +1115,68 @@ export function createChatRouter({ chatService, backendRegistry, updateService }
       const result = await chatService.setWorkspaceInstructions(param(req, 'hash'), instructions);
       if (result === null) return res.status(404).json({ error: 'Workspace not found' });
       res.json({ instructions: result });
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // ── Workspace file delivery ─────────────────────────────────────────────────
+  // Serves files from the workspace's working directory for the file delivery
+  // feature. The CLI outputs <!-- FILE_DELIVERY:/path --> markers when the user
+  // asks for a deliverable file; the UI renders download/view buttons that hit
+  // this endpoint.
+  //
+  // ?mode=download → Content-Disposition: attachment (browser downloads the file)
+  // ?mode=view     → returns { content, filename, language } JSON for the viewer panel
+  router.get('/workspaces/:hash/files', async (req: Request, res: Response) => {
+    try {
+      const hash = param(req, 'hash');
+      const filePath = req.query.path as string | undefined;
+      const mode = (req.query.mode as string) || 'download';
+
+      if (!filePath) {
+        return res.status(400).json({ error: 'path query parameter is required' });
+      }
+
+      const workspacePath = await chatService.getWorkspacePath(hash);
+      if (!workspacePath) {
+        return res.status(404).json({ error: 'Workspace not found' });
+      }
+
+      // Path traversal protection: resolved path must be under the workspace root
+      const resolved = path.resolve(filePath);
+      const wsRoot = path.resolve(workspacePath);
+      if (!resolved.startsWith(wsRoot + path.sep) && resolved !== wsRoot) {
+        return res.status(403).json({ error: 'Access denied: path is outside workspace' });
+      }
+
+      // Check file exists and is a regular file
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(resolved);
+      } catch {
+        return res.status(404).json({ error: 'File not found' });
+      }
+      if (!stat.isFile()) {
+        return res.status(400).json({ error: 'Path is not a file' });
+      }
+
+      const filename = path.basename(resolved);
+
+      if (mode === 'view') {
+        // Cap viewable file size at 2 MB to avoid flooding the browser
+        if (stat.size > 2 * 1024 * 1024) {
+          return res.status(413).json({ error: 'File too large to view (max 2 MB). Use download instead.' });
+        }
+        const content = fs.readFileSync(resolved, 'utf8');
+        const ext = path.extname(filename).replace('.', '');
+        return res.json({ content, filename, language: ext });
+      }
+
+      // Download mode
+      res.setHeader('Content-Disposition', `attachment; filename="${filename.replace(/"/g, '\\"')}"`);
+      res.setHeader('Content-Type', 'application/octet-stream');
+      fs.createReadStream(resolved).pipe(res);
     } catch (err: unknown) {
       res.status(500).json({ error: (err as Error).message });
     }

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -824,6 +824,11 @@ export class ChatService {
     return this._convWorkspaceMap.get(convId) || null;
   }
 
+  async getWorkspacePath(hash: string): Promise<string | null> {
+    const index = await this._readWorkspaceIndex(hash);
+    return index?.workspacePath || null;
+  }
+
   // ── Workspace Memory ───────────────────────────────────────────────────────
   //
   // Memory is stored per-workspace under `memory/` with this layout:

--- a/test/chat.test.ts
+++ b/test/chat.test.ts
@@ -1077,10 +1077,11 @@ describe('System prompt passthrough', () => {
       backend: 'claude-code',
     });
 
-    expect(mockBackend._lastOptions!.systemPrompt).toBe('You are a pirate');
+    expect(mockBackend._lastOptions!.systemPrompt).toContain('You are a pirate');
+    expect(mockBackend._lastOptions!.systemPrompt).toContain('FILE_DELIVERY');
   });
 
-  test('passes empty systemPrompt when none configured', async () => {
+  test('passes file delivery addendum when no other prompt configured', async () => {
     const conv = await chatService.createConversation('Test');
     mockBackend.setMockEvents([
       { type: 'text', content: 'Hi', streaming: true },
@@ -1092,7 +1093,7 @@ describe('System prompt passthrough', () => {
       backend: 'claude-code',
     });
 
-    expect(mockBackend._lastOptions!.systemPrompt).toBe('');
+    expect(mockBackend._lastOptions!.systemPrompt).toContain('FILE_DELIVERY');
   });
 
   test('does not pass systemPrompt on subsequent messages', async () => {
@@ -1650,7 +1651,8 @@ describe('Workspace instructions in system prompt', () => {
       backend: 'claude-code',
     });
 
-    expect(mockBackend._lastOptions!.systemPrompt).toBe('Only workspace');
+    expect(mockBackend._lastOptions!.systemPrompt).toContain('Only workspace');
+    expect(mockBackend._lastOptions!.systemPrompt).toContain('FILE_DELIVERY');
   });
 
   test('does not include workspace instructions on subsequent messages', async () => {
@@ -3353,5 +3355,75 @@ describe('POST /conversations/:id/reset', () => {
     const getRes = await makeRequest('GET', `/api/chat/conversations/${conv.id}`);
     expect(getRes.status).toBe(200);
     expect(getRes.body.messages).toHaveLength(0);
+  });
+});
+
+// ── File delivery endpoint ──────────────────────────────────────────────────
+
+describe('GET /api/chat/workspaces/:hash/files', () => {
+  test('downloads a file from workspace directory', async () => {
+    const wsDir = path.join(tmpDir, 'ws-file-dl');
+    fs.mkdirSync(wsDir, { recursive: true });
+    fs.writeFileSync(path.join(wsDir, 'report.csv'), 'a,b,c\n1,2,3\n');
+
+    const conv = await chatService.createConversation('Test', wsDir);
+    const hash = conv.workspaceHash;
+
+    const res = await makeRequest('GET', `/api/chat/workspaces/${hash}/files?path=${encodeURIComponent(path.join(wsDir, 'report.csv'))}&mode=download`);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-disposition']).toContain('report.csv');
+  });
+
+  test('views a file as JSON', async () => {
+    const wsDir = path.join(tmpDir, 'ws-file-view');
+    fs.mkdirSync(wsDir, { recursive: true });
+    fs.writeFileSync(path.join(wsDir, 'data.json'), '{"hello":"world"}');
+
+    const conv = await chatService.createConversation('Test', wsDir);
+    const hash = conv.workspaceHash;
+
+    const res = await makeRequest('GET', `/api/chat/workspaces/${hash}/files?path=${encodeURIComponent(path.join(wsDir, 'data.json'))}&mode=view`);
+    expect(res.status).toBe(200);
+    expect(res.body.filename).toBe('data.json');
+    expect(res.body.content).toBe('{"hello":"world"}');
+    expect(res.body.language).toBe('json');
+  });
+
+  test('rejects path traversal', async () => {
+    const wsDir = path.join(tmpDir, 'ws-file-traversal');
+    fs.mkdirSync(wsDir, { recursive: true });
+
+    const conv = await chatService.createConversation('Test', wsDir);
+    const hash = conv.workspaceHash;
+
+    const res = await makeRequest('GET', `/api/chat/workspaces/${hash}/files?path=${encodeURIComponent('/etc/passwd')}`);
+    expect(res.status).toBe(403);
+  });
+
+  test('returns 400 when path is missing', async () => {
+    const wsDir = path.join(tmpDir, 'ws-file-noparam');
+    fs.mkdirSync(wsDir, { recursive: true });
+
+    const conv = await chatService.createConversation('Test', wsDir);
+    const hash = conv.workspaceHash;
+
+    const res = await makeRequest('GET', `/api/chat/workspaces/${hash}/files`);
+    expect(res.status).toBe(400);
+  });
+
+  test('returns 404 for nonexistent file', async () => {
+    const wsDir = path.join(tmpDir, 'ws-file-missing');
+    fs.mkdirSync(wsDir, { recursive: true });
+
+    const conv = await chatService.createConversation('Test', wsDir);
+    const hash = conv.workspaceHash;
+
+    const res = await makeRequest('GET', `/api/chat/workspaces/${hash}/files?path=${encodeURIComponent(path.join(wsDir, 'nope.txt'))}`);
+    expect(res.status).toBe(404);
+  });
+
+  test('returns 404 for unknown workspace', async () => {
+    const res = await makeRequest('GET', `/api/chat/workspaces/0000000000000000/files?path=/tmp/foo`);
+    expect(res.status).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a file delivery system: when the user asks the CLI for a deliverable file, the system prompt instructs the CLI to output `<!-- FILE_DELIVERY:/path -->` markers
- The frontend strips these markers and renders inline file cards with **View** and **Download** buttons
- **View** opens a right-side panel with syntax-highlighted text content (2 MB cap)
- **Download** streams the file via a new `GET /workspaces/:hash/files` endpoint with path traversal protection
- Works with all CLI backends (system prompt is backend-agnostic)

## Test plan
- [x] 6 new endpoint tests (download, view, path traversal, missing path, missing file, unknown workspace)
- [x] Updated 3 existing system prompt tests for the new addendum
- [x] Full test suite passes (985/985, pre-existing flaky failures excluded)
- [x] Manual: ask the CLI to create a deliverable file, verify card renders with View/Download
- [x] Manual: verify View panel opens on right side with syntax highlighting
- [x] Manual: verify Download triggers browser download
- [x] Manual: verify panel closes on conversation switch