### PR TITLE
chore: restore engines >=22 field dropped in #165

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "agent-cockpit",
   "version": "0.1.100",
   "private": true,
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "start": "tsx server.ts",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

Follow-up to #165. The `engines: { node: ">=22" }` field was added in commit 9958845 but inadvertently removed in commit ed297af when `npm install multer@^2.0.0` rewrote `package.json` between my commits. The three commits merged as-is, so `main` is missing the field.

This restores it.

## Test plan

- [x] `git diff package.json` shows only the 3-line engines block added