### PR TITLE
feat(v2): composer KB status icon with live pending counts

### DIFF
--- a/public/v2/src/app.css
+++ b/public/v2/src/app.css
@@ -1517,30 +1517,94 @@ body{
   box-shadow: var(--shadow-2);
   overflow: hidden;
 }
-.dream-banner{
-  display: flex; align-items: center; gap: 10px;
-  padding: 8px 12px;
-  margin-bottom: 10px;
-  border-radius: var(--r-md, 8px);
-  border: 1px solid var(--accent-border, rgba(99,102,241,.35));
-  background: var(--accent-bg, rgba(99,102,241,.08));
+/* Composer KB status icon — dashboard-style indicator rendered to the
+   left of the Send button when the conversation's workspace has KB
+   enabled. Replaces the former `.dream-banner` in-flow panel. Hover
+   surfaces a rich tooltip with pending counts, auto-digest state, and
+   Dream/Stop actions. */
+.kb-status-icon{
+  position: relative;
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 26px; height: 26px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: var(--r-sm);
+  color: var(--text-2);
+  cursor: pointer;
+  padding: 0;
+  transition: border-color .15s, color .15s, background .15s;
+}
+.kb-status-icon:hover{ border-color: var(--border-strong); color: var(--text); }
+.kb-status-icon.state-pending{ color: var(--accent, #6366f1); border-color: var(--accent-border, rgba(99,102,241,.45)); }
+.kb-status-icon.state-running{ color: var(--accent, #6366f1); border-color: var(--accent-border, rgba(99,102,241,.55)); background: var(--accent-bg, rgba(99,102,241,.08)); }
+.kb-status-pulse{
+  position: absolute;
+  top: 2px; right: 2px;
+  width: 7px; height: 7px;
+  border-radius: 999px;
+  background: var(--accent, #6366f1);
+  box-shadow: 0 0 0 2px var(--surface);
+}
+.kb-status-pulse.state-running{ animation: kb-status-pulse 1.6s ease-in-out infinite; }
+@keyframes kb-status-pulse{
+  0%,100% { transform: scale(1);   opacity: 1;   }
+  50%     { transform: scale(1.35); opacity: .55; }
+}
+.kb-status-card{
+  display: flex; flex-direction: column; gap: 8px;
+  min-width: 260px;
+  padding: 2px 0;
   font-size: 12.5px;
   color: var(--text);
+  text-align: left;
 }
-.dream-banner-label{
-  display: inline-flex; align-items: center; gap: 6px;
-  font-weight: 500;
+.kb-status-head{
+  font-family: var(--mono-font);
+  font-size: 10.5px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--text-3);
 }
-.dream-go-btn{
-  margin-left: auto;
+.kb-status-row{
+  display: flex; align-items: center; gap: 8px;
+  flex-wrap: wrap;
+}
+.kb-status-row-label{ flex: 1; min-width: 0; }
+.kb-status-dot{
+  display: inline-block;
+  width: 8px; height: 8px; border-radius: 999px;
+  flex-shrink: 0;
+}
+.kb-status-dot.ok{ background: var(--status-ok, #22c55e); }
+.kb-status-dot.warn{ background: var(--accent, #6366f1); }
+.kb-status-hint{
+  font-family: var(--mono-font);
+  font-size: 10.5px;
+  color: var(--text-3);
+}
+.kb-status-action{
+  font-size: 11.5px;
+  padding: 3px 8px;
   background: var(--accent, #6366f1);
   color: #fff;
   border-color: var(--accent, #6366f1);
 }
-.dream-go-btn:hover{ filter: brightness(1.05); }
-.dream-stop-btn{
+.kb-status-action:hover{ filter: brightness(1.05); }
+.kb-status-running{
+  display: flex; flex-direction: column; gap: 6px;
+  margin-top: 2px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--border);
+}
+.kb-status-running-head{
+  display: flex; align-items: center; gap: 6px;
+  font-weight: 500;
+}
+.kb-status-stop{
   margin-left: auto;
-  display: inline-flex; align-items: center; gap: 4px;
+  display: inline-flex; align-items: center; gap: 3px;
+  padding: 2px 6px;
+  font-size: 11px;
 }
 .dream-stepper{
   display: flex; align-items: center; gap: 6px;
@@ -2186,13 +2250,15 @@ body{
   background: var(--bg-sunk);
 }
 .kb-synth-controls{
-  display: flex; align-items: center; flex-wrap: wrap; gap: 8px;
+  display: flex; flex-direction: column; gap: 6px;
   padding: 10px 16px;
   border-bottom: 1px solid var(--border);
   background: var(--bg-sunk);
   font-size: 12px;
   color: var(--text-2);
 }
+.kb-synth-btn-row{ display: flex; align-items: center; gap: 8px; }
+.kb-synth-info-row{ display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .kb-synth-dream-btn{
   background: var(--accent, #6366f1);
   color: #fff;

--- a/public/v2/src/screens/kbBrowser.jsx
+++ b/public/v2/src/screens/kbBrowser.jsx
@@ -635,40 +635,44 @@ function KbSynthesisTab({ hash }){
     <div className="kb-pane kb-split">
       <div className="kb-split-left">
         <div className="kb-synth-controls">
-          <button
-            type="button"
-            className="btn kb-synth-dream-btn"
-            onClick={startDream}
-            disabled={starting || isRunning}
-            title="Run incremental dream on pending entries"
-          >
-            {starting || isRunning ? 'Dreaming…' : <>{Ico.moon(12)} Dream</>}
-          </button>
-          {isRunning ? (
+          <div className="kb-synth-btn-row">
             <button
               type="button"
-              className="btn danger kb-synth-stop-btn"
-              onClick={stopDream}
-              disabled={stopping || isStopping}
+              className="btn kb-synth-dream-btn"
+              onClick={startDream}
+              disabled={starting || isRunning}
+              title="Run incremental dream on pending entries"
             >
-              {stopping || isStopping ? 'Stopping…' : <>{Ico.stop(12)} Stop</>}
+              {starting || isRunning ? 'Dreaming…' : <>{Ico.moon(12)} Dream</>}
             </button>
-          ) : null}
-          <button
-            type="button"
-            className="btn kb-synth-redream-btn"
-            onClick={(e) => redream(e.currentTarget)}
-            disabled={isRunning}
-            title="Wipe all topics & connections, then rebuild from scratch"
-          >
-            Re-Dream
-          </button>
-          <span className="kb-synth-status">
-            Last run: {lastRunLabel}
-            {pending > 0 ? <> · <span>{pending} pending</span></> : null}
-            {lastErr ? <> · <span className="u-err">{lastErr}</span></> : null}
-          </span>
-          {isRunning ? <DreamStepper progress={data.dreamProgress} stepStart={stepStart}/> : null}
+            {isRunning ? (
+              <button
+                type="button"
+                className="btn danger kb-synth-stop-btn"
+                onClick={stopDream}
+                disabled={stopping || isStopping}
+              >
+                {stopping || isStopping ? 'Stopping…' : <>{Ico.stop(12)} Stop</>}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="btn kb-synth-redream-btn"
+              onClick={(e) => redream(e.currentTarget)}
+              disabled={isRunning}
+              title="Wipe all topics & connections, then rebuild from scratch"
+            >
+              Re-Dream
+            </button>
+          </div>
+          <div className="kb-synth-info-row">
+            <span className="kb-synth-status">
+              Last run: {lastRunLabel}
+              {pending > 0 ? <> · <span>{pending} pending</span></> : null}
+              {lastErr ? <> · <span className="u-err">{lastErr}</span></> : null}
+            </span>
+            {isRunning ? <DreamStepper progress={data.dreamProgress} stepStart={stepStart}/> : null}
+          </div>
         </div>
         <div className="kb-status">
           <span className={`kb-pill ${statusLabel === 'idle' ? 'ok' : 'run'}`}>

--- a/public/v2/src/shell.jsx
+++ b/public/v2/src/shell.jsx
@@ -855,7 +855,6 @@ function ChatLive({ convId, onArchived, onDeleted, onRenamed, onOpenWorkspaceSet
 
       <div className="composer">
         <div className="composer-inner">
-          <DreamBanner conv={conv} convId={convId}/>
           <div className="composer-box">
             <textarea
               rows={3}
@@ -937,6 +936,7 @@ function ChatLive({ convId, onArchived, onDeleted, onRenamed, onOpenWorkspaceSet
                   <span style={{fontSize:11.5}}>Attach…</span>
                 </button>
               </span>
+              <KbStatusIcon conv={conv} convId={convId}/>
               {streaming ? (
                 <button
                   className="send stop"
@@ -2360,13 +2360,15 @@ function StreamErrorCard({ convId, error, queueLength, messages }){
   );
 }
 
-/* Dream banner — shown above the composer when the active conversation's
-   workspace KB has pending entries awaiting synthesis, OR while a dream run
-   is in progress. Reads from conv.kb (hydrated by GET /conversations/:id).
-   Live progress arrives via kb_state_update WS frames; a 2s poll on
-   GET /conversations/:id backstops status transitions when no WS frames
-   cover them. */
-function DreamBanner({ conv, convId }){
+/* Composer KB status icon — car-dashboard-style indicator positioned
+   just left of the Send button. Only renders when the conversation's
+   workspace has KB enabled. On hover a rich tooltip shows pending-
+   digestion and pending-synthesis counts, plus an inline Dream/Stop
+   action when applicable. State is hydrated from `conv.kb` on conv
+   load and patched live via `kb_state_update` WS frames (handled in
+   streamStore). A 2s poll on GET /conversations/:id backstops dream
+   progress transitions while a run is in flight. */
+function KbStatusIcon({ conv, convId }){
   const toast = useToasts();
   const kb = conv && conv.kb;
   const hash = conv && conv.workspaceHash;
@@ -2390,11 +2392,16 @@ function DreamBanner({ conv, convId }){
   }, [running, convId]);
 
   if (!kb || !kb.enabled) return null;
-  const idle = !running && kb.dreamingNeeded && kb.pendingEntries > 0;
-  if (!running && !idle) return null;
+
+  const pendingDigest = Math.max(0, kb.pendingDigestions || 0);
+  const pendingDream  = Math.max(0, kb.pendingEntries || 0);
+  const autoDigest    = !!kb.autoDigest;
+  const hasWork       = pendingDigest > 0 || pendingDream > 0;
+  const stopPending   = !!kb.dreamingStopping;
+  const state = running ? 'running' : hasWork ? 'pending' : 'ok';
 
   async function startDream(){
-    if (!hash || starting) return;
+    if (!hash || starting || running) return;
     setStarting(true);
     try {
       await AgentApi.workspace.triggerDream(hash);
@@ -2418,33 +2425,75 @@ function DreamBanner({ conv, convId }){
     }
   }
 
-  if (running) {
-    const stopPending = !!kb.dreamingStopping;
-    return (
-      <div className="dream-banner">
-        <span className="dream-banner-label">Dreaming in progress</span>
-        <DreamStepper progress={kb._dreamProgress}/>
-        <button
-          className="btn danger dream-stop-btn"
-          onClick={stopDream}
-          disabled={stopPending || stopping}
-        >
-          {stopPending ? 'Stopping…' : <>{Ico.stop(12)} Stop</>}
-        </button>
-      </div>
-    );
-  }
+  const card = (
+    <div className="kb-status-card">
+      <div className="kb-status-head">Knowledge Base</div>
 
-  const n = kb.pendingEntries;
-  return (
-    <div className="dream-banner">
-      <span className="dream-banner-label">
-        {Ico.moon(13)} {n} entr{n === 1 ? 'y' : 'ies'} awaiting synthesis
-      </span>
-      <button className="btn dream-go-btn" onClick={startDream} disabled={starting}>
-        {starting ? 'Starting…' : 'Dream now'}
-      </button>
+      <div className="kb-status-row">
+        <span className={"kb-status-dot " + (pendingDigest > 0 ? 'warn' : 'ok')}/>
+        <span className="kb-status-row-label">
+          {pendingDigest === 0
+            ? 'No files awaiting digestion'
+            : (pendingDigest + (pendingDigest === 1 ? ' file' : ' files') + ' awaiting digestion')}
+        </span>
+        {pendingDigest > 0 && !autoDigest ? (
+          <span className="kb-status-hint">auto-digest off</span>
+        ) : null}
+      </div>
+
+      <div className="kb-status-row">
+        <span className={"kb-status-dot " + (pendingDream > 0 ? 'warn' : 'ok')}/>
+        <span className="kb-status-row-label">
+          {pendingDream === 0
+            ? 'No entries awaiting synthesis'
+            : (pendingDream + (pendingDream === 1 ? ' entry' : ' entries') + ' awaiting synthesis')}
+        </span>
+        {pendingDream > 0 && !running ? (
+          <button
+            className="btn kb-status-action"
+            onClick={startDream}
+            disabled={starting}
+          >
+            {starting ? 'Starting…' : 'Dream now'}
+          </button>
+        ) : null}
+      </div>
+
+      {running ? (
+        <div className="kb-status-running">
+          <div className="kb-status-running-head">
+            {Ico.moon(12)} Dreaming in progress
+            <button
+              className="btn danger kb-status-stop"
+              onClick={stopDream}
+              disabled={stopPending || stopping}
+            >
+              {stopPending ? 'Stopping…' : <>{Ico.stop(10)} Stop</>}
+            </button>
+          </div>
+          <DreamStepper progress={kb._dreamProgress}/>
+        </div>
+      ) : null}
     </div>
+  );
+
+  const label = running
+    ? 'KB: dreaming in progress'
+    : hasWork
+      ? ('KB: ' + (pendingDigest + pendingDream) + ' pending')
+      : 'KB up to date';
+
+  return (
+    <Tip variant="stat" rich={card}>
+      <button
+        type="button"
+        className={"kb-status-icon state-" + state}
+        aria-label={label}
+      >
+        {Ico.book(14)}
+        {state !== 'ok' ? <span className={"kb-status-pulse state-" + state}/> : null}
+      </button>
+    </Tip>
   );
 }
 

--- a/public/v2/src/streamStore.js
+++ b/public/v2/src/streamStore.js
@@ -624,10 +624,19 @@
         kb._dreamProgress = changed.dreamProgress;
       }
       update(convId, curState => ({ ...curState, conv: { ...curState.conv, kb } }));
-      /* Synthesis changed without progress → dream finished or status
-         reset. Refetch the conv to pull fresh kb block (pendingEntries,
-         dreamingStatus, etc.). */
-      if (changed.synthesis && !changed.stopping) {
+      /* Any event that changes the count of pending-digestion or
+         pending-synthesis items requires a refetch so the composer's KB
+         status icon sees accurate `pendingDigestions` / `pendingEntries`.
+         `synthesis` covers dream completion, `raw` covers ingestion
+         add/delete, `entries` covers digest completion, and `digestion`
+         covers digestion-session transitions (active true↔false). */
+      const needsRefresh = (
+        (changed.synthesis && !changed.stopping) ||
+        (Array.isArray(changed.raw) && changed.raw.length > 0) ||
+        (Array.isArray(changed.entries) && changed.entries.length > 0) ||
+        (changed.digestion && typeof changed.digestion.active === 'boolean')
+      );
+      if (needsRefresh) {
         AgentApi.fetch('conversations/' + encodeURIComponent(convId))
           .then(r => r.json())
           .then(data => {

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -345,22 +345,24 @@ export function createChatRouter({ chatService, backendRegistry, updateService, 
   // used by the watcher to compute `changedFiles` for the `memory_update` WS frame.
   // Cleared when the watcher is unwatched so a re-watched conversation starts fresh.
   const memoryFingerprints = new Map<string, Map<string, string>>();
-  let wsFns: Pick<WsFunctions, 'send' | 'isConnected' | 'isStreamAlive' | 'clearBuffer'> | null = null;
+  let wsFns: Pick<WsFunctions, 'send' | 'isConnected' | 'isStreamAlive' | 'clearBuffer' | 'forEachConnected'> | null = null;
 
   /**
-   * Fan out a `kb_state_update` frame to every active stream whose
-   * conversation belongs to the target workspace. Mirrors the pattern
-   * used for `memory_update` — only conversations with a live WS get
-   * the frame; the KB Browser polls GET /kb when it's opened standalone
-   * (no active stream) so it still sees changes.
+   * Fan out a `kb_state_update` frame to every conversation with an OPEN
+   * WebSocket whose workspace matches the event — regardless of whether
+   * that conv has an active agent stream. This is what lets the composer
+   * KB status icon update in real time while the user is idle in the
+   * conversation (e.g. after uploading files via the KB Browser).
    */
   function broadcastKbStateUpdate(hash: string, frame: import('../types').KbStateUpdateEvent): void {
     if (!wsFns) return;
-    for (const [convId] of activeStreams) {
-      if (chatService.getWorkspaceHashForConv(convId) === hash && wsFns.isConnected(convId)) {
-        wsFns.send(convId, frame);
-      }
-    }
+    const sent = new Set<string>();
+    wsFns.forEachConnected((convId) => {
+      if (chatService.getWorkspaceHashForConv(convId) !== hash) return;
+      if (sent.has(convId)) return;
+      sent.add(convId);
+      wsFns!.send(convId, frame);
+    });
   }
 
   // Knowledge Base ingestion orchestrator. Owns the per-workspace queue
@@ -636,18 +638,21 @@ export function createChatRouter({ chatService, backendRegistry, updateService, 
       const conv = await chatService.getConversation(param(req, 'id'));
       if (!conv) return res.status(404).json({ error: 'Conversation not found' });
 
-      // Augment with KB status so the frontend can render the dreaming
-      // banner without a separate round-trip to GET /kb.
+      // Augment with KB status so the frontend's composer KB status icon
+      // can render without a separate round-trip to GET /kb.
       const kbEnabled = await chatService.getWorkspaceKbEnabled(conv.workspaceHash);
       if (kbEnabled) {
         const db = chatService.getKbDb(conv.workspaceHash);
         if (db) {
           const snapshot = db.getSynthesisSnapshot();
           const counters = db.getCounters();
+          const autoDigest = await chatService.getWorkspaceKbAutoDigest(conv.workspaceHash);
           (conv as unknown as Record<string, unknown>).kb = {
             enabled: true,
             dreamingNeeded: snapshot.needsSynthesisCount > 0,
             pendingEntries: snapshot.needsSynthesisCount,
+            pendingDigestions: counters.pendingCount,
+            autoDigest,
             dreamingStatus: kbDreaming.isRunning(conv.workspaceHash) ? 'running' : snapshot.status,
             dreamingStopping: kbDreaming.isStopRequested(conv.workspaceHash),
             failedItems: counters.rawByStatus.failed,
@@ -2759,7 +2764,7 @@ export function createChatRouter({ chatService, backendRegistry, updateService, 
     if (updateService) updateService.stop();
   }
 
-  function setWsFunctions(fns: Pick<WsFunctions, 'send' | 'isConnected' | 'isStreamAlive' | 'clearBuffer'>) {
+  function setWsFunctions(fns: Pick<WsFunctions, 'send' | 'isConnected' | 'isStreamAlive' | 'clearBuffer' | 'forEachConnected'>) {
     wsFns = fns;
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -264,11 +264,15 @@ export interface Conversation {
   kb?: ConversationKbStatus;
 }
 
-/** KB status block on conversation responses (avoids extra round-trip for the dreaming banner). */
+/** KB status block on conversation responses (avoids extra round-trip for the KB status icon). */
 export interface ConversationKbStatus {
   enabled: boolean;
   dreamingNeeded: boolean;
   pendingEntries: number;
+  /** Raw files awaiting digestion (status = 'ingested' | 'pending-delete'). */
+  pendingDigestions: number;
+  /** Per-workspace auto-digest toggle — when true, pendingDigestions drains on its own. */
+  autoDigest: boolean;
   dreamingStatus: 'idle' | 'running' | 'failed';
   failedItems: number;
 }

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -16,6 +16,8 @@ export interface WsFunctions {
   isConnected: (convId: string) => boolean;
   isStreamAlive: (convId: string) => boolean;
   clearBuffer: (convId: string) => void;
+  /** Invoke `cb` for each conversation with an OPEN WebSocket. */
+  forEachConnected: (cb: (convId: string) => void) => void;
 }
 
 // ── Event buffer for reconnection ──────────────────────────────────────────
@@ -337,6 +339,13 @@ export function attachWebSocket(
     return !!ws && ws.readyState === WebSocket.OPEN;
   }
 
+  /** Enumerate every conversation with an OPEN WebSocket. */
+  function forEachConnected(cb: (convId: string) => void): void {
+    for (const [convId, ws] of activeWebSockets) {
+      if (ws.readyState === WebSocket.OPEN) cb(convId);
+    }
+  }
+
   /**
    * True if the stream should keep running: WS is open OR we're in a grace
    * period (buffer exists with an active grace timer). Used by processStream's
@@ -368,5 +377,5 @@ export function attachWebSocket(
     wss.close();
   }
 
-  return { shutdown, send, isConnected, isStreamAlive, clearBuffer };
+  return { shutdown, send, isConnected, isStreamAlive, clearBuffer, forEachConnected };
 }


### PR DESCRIPTION
## Summary
- Replaces the above-composer dreaming panel with a dashboard-style KB icon placed immediately to the left of the Send button. Hover shows pending-digestion and pending-synthesis counts (with an "auto-digest off" hint when applicable) and preserves the `Dream now` / `Stop` actions inside the tooltip.
- Fixes the bug where returning to a conversation after KB ingestion required a full page refresh to see the "N entries awaiting synthesis" warning: `kb_state_update` frames now fan out to every WebSocket-connected conversation (not just those with an active agent stream), and the streamStore refetches `conv.kb` whenever `raw`, `entries`, `digestion`, or `synthesis` changes.
- Adds `pendingDigestions` and `autoDigest` to the `conv.kb` payload so the new icon can render both axes of KB status without an extra round-trip.

## Test plan
- [ ] Open a KB-enabled workspace conversation, upload a file from KB Browser, switch focus away, return — icon badge appears live without a page refresh.
- [ ] Hover the icon: tooltip shows both counts; "auto-digest off" hint appears only when pending digestions exist and auto-digest is disabled.
- [ ] Click `Dream now` from the tooltip with pending entries > 0; dream starts, icon pulses, `Stop` button appears inside the tooltip.
- [ ] Verify icon is hidden for workspaces without KB enabled.
- [ ] `npm run typecheck` clean; `npx jest test/chat.test.ts test/knowledgeBase.ingestion.test.ts test/knowledgeBase.digest.test.ts` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)