### PR TITLE
refactor(v2): align KB status tooltip with stat-variant template

### DIFF
--- a/public/v2/src/app.css
+++ b/public/v2/src/app.css
@@ -1550,62 +1550,6 @@ body{
   0%,100% { transform: scale(1);   opacity: 1;   }
   50%     { transform: scale(1.35); opacity: .55; }
 }
-.kb-status-card{
-  display: flex; flex-direction: column; gap: 8px;
-  min-width: 260px;
-  padding: 2px 0;
-  font-size: 12.5px;
-  color: var(--text);
-  text-align: left;
-}
-.kb-status-head{
-  font-family: var(--mono-font);
-  font-size: 10.5px;
-  letter-spacing: .08em;
-  text-transform: uppercase;
-  color: var(--text-3);
-}
-.kb-status-row{
-  display: flex; align-items: center; gap: 8px;
-  flex-wrap: wrap;
-}
-.kb-status-row-label{ flex: 1; min-width: 0; }
-.kb-status-dot{
-  display: inline-block;
-  width: 8px; height: 8px; border-radius: 999px;
-  flex-shrink: 0;
-}
-.kb-status-dot.ok{ background: var(--status-ok, #22c55e); }
-.kb-status-dot.warn{ background: var(--accent, #6366f1); }
-.kb-status-hint{
-  font-family: var(--mono-font);
-  font-size: 10.5px;
-  color: var(--text-3);
-}
-.kb-status-action{
-  font-size: 11.5px;
-  padding: 3px 8px;
-  background: var(--accent, #6366f1);
-  color: #fff;
-  border-color: var(--accent, #6366f1);
-}
-.kb-status-action:hover{ filter: brightness(1.05); }
-.kb-status-running{
-  display: flex; flex-direction: column; gap: 6px;
-  margin-top: 2px;
-  padding-top: 8px;
-  border-top: 1px dashed var(--border);
-}
-.kb-status-running-head{
-  display: flex; align-items: center; gap: 6px;
-  font-weight: 500;
-}
-.kb-status-stop{
-  margin-left: auto;
-  display: inline-flex; align-items: center; gap: 3px;
-  padding: 2px 6px;
-  font-size: 11px;
-}
 .dream-stepper{
   display: flex; align-items: center; gap: 6px;
   font-family: var(--mono-font);

--- a/public/v2/src/shell.jsx
+++ b/public/v2/src/shell.jsx
@@ -2370,18 +2370,15 @@ function StreamErrorCard({ convId, error, queueLength, messages }){
 /* Composer KB status icon — car-dashboard-style indicator positioned
    just left of the Send button. Only renders when the conversation's
    workspace has KB enabled. On hover a rich tooltip shows pending-
-   digestion and pending-synthesis counts, plus an inline Dream/Stop
-   action when applicable. State is hydrated from `conv.kb` on conv
-   load and patched live via `kb_state_update` WS frames (handled in
-   streamStore). A 2s poll on GET /conversations/:id backstops dream
-   progress transitions while a run is in flight. */
+   digestion and pending-synthesis counts plus auto-digest state, using
+   the standard Tip stat-variant template (.tt-header / .tt-eye / .tt-h
+   / .tt-section / .tt-rows / .tt-kv). State is hydrated from `conv.kb`
+   on conv load and patched live via `kb_state_update` WS frames
+   (handled in streamStore). A 2s poll on GET /conversations/:id
+   backstops dream progress transitions while a run is in flight. */
 function KbStatusIcon({ conv, convId }){
-  const toast = useToasts();
   const kb = conv && conv.kb;
-  const hash = conv && conv.workspaceHash;
   const running = !!(kb && kb.dreamingStatus === 'running');
-  const [starting, setStarting] = React.useState(false);
-  const [stopping, setStopping] = React.useState(false);
 
   React.useEffect(() => {
     if (!running || !convId) return;
@@ -2404,84 +2401,51 @@ function KbStatusIcon({ conv, convId }){
   const pendingDream  = Math.max(0, kb.pendingEntries || 0);
   const autoDigest    = !!kb.autoDigest;
   const hasWork       = pendingDigest > 0 || pendingDream > 0;
-  const stopPending   = !!kb.dreamingStopping;
   const state = running ? 'running' : hasWork ? 'pending' : 'ok';
 
-  async function startDream(){
-    if (!hash || starting || running) return;
-    setStarting(true);
-    try {
-      await AgentApi.workspace.triggerDream(hash);
-      StreamStore.patchConv(convId, { kb: { ...kb, dreamingStatus: 'running', _dreamProgress: null } });
-    } catch (err) {
-      toast.error('Failed to start dreaming: ' + (err.message || String(err)));
-    } finally {
-      setStarting(false);
-    }
-  }
-  async function stopDream(){
-    if (!hash || stopping) return;
-    setStopping(true);
-    try {
-      await AgentApi.workspace.stopDream(hash);
-      StreamStore.patchConv(convId, { kb: { ...kb, dreamingStopping: true } });
-    } catch (err) {
-      toast.error('Stop failed: ' + (err.message || String(err)));
-    } finally {
-      setStopping(false);
-    }
-  }
-
   const card = (
-    <div className="kb-status-card">
-      <div className="kb-status-head">Knowledge Base</div>
-
-      <div className="kb-status-row">
-        <span className={"kb-status-dot " + (pendingDigest > 0 ? 'warn' : 'ok')}/>
-        <span className="kb-status-row-label">
-          {pendingDigest === 0
-            ? 'No files awaiting digestion'
-            : (pendingDigest + (pendingDigest === 1 ? ' file' : ' files') + ' awaiting digestion')}
-        </span>
-        {pendingDigest > 0 && !autoDigest ? (
-          <span className="kb-status-hint">auto-digest off</span>
-        ) : null}
+    <>
+      <div className="tt-header">
+        <span className="tt-eye">Knowledge Base</span>
       </div>
-
-      <div className="kb-status-row">
-        <span className={"kb-status-dot " + (pendingDream > 0 ? 'warn' : 'ok')}/>
-        <span className="kb-status-row-label">
-          {pendingDream === 0
-            ? 'No entries awaiting synthesis'
-            : (pendingDream + (pendingDream === 1 ? ' entry' : ' entries') + ' awaiting synthesis')}
-        </span>
-        {pendingDream > 0 && !running ? (
-          <button
-            className="btn kb-status-action"
-            onClick={startDream}
-            disabled={starting}
-          >
-            {starting ? 'Starting…' : 'Dream now'}
-          </button>
-        ) : null}
-      </div>
-
-      {running ? (
-        <div className="kb-status-running">
-          <div className="kb-status-running-head">
-            {Ico.moon(12)} Dreaming in progress
-            <button
-              className="btn danger kb-status-stop"
-              onClick={stopDream}
-              disabled={stopPending || stopping}
-            >
-              {stopPending ? 'Stopping…' : <>{Ico.stop(10)} Stop</>}
-            </button>
+      <h4 className="tt-h">
+        {running
+          ? 'Dreaming…'
+          : hasWork
+            ? (pendingDigest + pendingDream) + ' pending'
+            : 'Up to date'}
+      </h4>
+      <div className="tt-section">
+        <div className="tt-rows">
+          <div className="tt-kv">
+            <span>Digestion</span>
+            <b>
+              {pendingDigest === 0
+                ? '—'
+                : pendingDigest + (pendingDigest === 1 ? ' file' : ' files')}
+            </b>
           </div>
+          <div className="tt-kv">
+            <span>Synthesis</span>
+            <b>
+              {pendingDream === 0
+                ? '—'
+                : pendingDream + (pendingDream === 1 ? ' entry' : ' entries')}
+            </b>
+          </div>
+          <div className="tt-kv">
+            <span>Auto-digest</span>
+            <b>{autoDigest ? 'on' : 'off'}</b>
+          </div>
+        </div>
+      </div>
+      {running ? (
+        <div className="tt-section">
+          <div className="tt-section-label">Dreaming in progress</div>
           <DreamStepper progress={kb._dreamProgress}/>
         </div>
       ) : null}
-    </div>
+    </>
   );
 
   const label = running


### PR DESCRIPTION
## Summary
- Rewrites the composer KB status tooltip (`KbStatusIcon` in `shell.jsx`) to use the standard Tip stat-variant template classes (`.tt-header` / `.tt-eye` / `.tt-h` / `.tt-section` / `.tt-rows` / `.tt-kv`) instead of the bespoke `.kb-status-*` layout that duplicated that template.
- Removes the in-tooltip **Dream now** and **Stop** buttons — `.tt` is `pointer-events: none` unless pinned, so those actions were unreachable by users. The `startDream` / `stopDream` handlers and their orphaned state (`starting`, `stopping`, `hash`, `useToasts` call) go with them.
- Deletes the now-unused `.kb-status-card/-head/-row/-row-label/-dot/-hint/-action/-running/-running-head/-stop` rules from `app.css` (~56 lines). Trigger-button styling (`.kb-status-icon`, `.kb-status-pulse`) stays.
- `DreamStepper` still renders inside a labeled `.tt-section` when a dream is in flight, so the running-state progress indicator survives.

## Test plan
- [ ] Hover the KB status icon next to the Send button with an empty KB — tooltip shows `Up to date`, three `—` rows.
- [ ] Hover with pending work — tooltip shows `N pending` heading, actual counts in Digestion / Synthesis rows, Auto-digest `on`/`off` row.
- [ ] Trigger a dream run from the KB browser — tooltip heading flips to `Dreaming…` and a `Dreaming in progress` section with the stepper appears.
- [ ] Verify no console errors from removed React state or handlers.

## Notes
- `test/graceful-shutdown.test.ts` is flaky on this machine (10s `tsx server.ts` startup window) and fails on clean `main` too — not caused by this change.
- If a reachable Stop affordance is still wanted during a dream run, it will need a separate surface outside the tooltip.