### PR TITLE
refactor: tighten TypeScript any usage in src/

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,5 +1,5 @@
 import passport from 'passport';
-import { Strategy as GoogleStrategy, type Profile } from 'passport-google-oauth20';
+import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 import { Strategy as GitHubStrategy } from 'passport-github2';
 import rateLimit from 'express-rate-limit';
 import type { Request, Response, NextFunction, Express } from '../types';
@@ -24,7 +24,7 @@ function verifyEmail(config: AppConfig) {
   return (
     _accessToken: string,
     _refreshToken: string,
-    profile: Profile,
+    profile: passport.Profile,
     done: (err: Error | null, user?: AuthUser | false, info?: { message: string }) => void,
   ) => {
     const email = profile.emails?.[0]?.value;
@@ -55,8 +55,7 @@ export function setupAuth(app: Express, config: AppConfig): void {
         callbackURL: config.GITHUB_CALLBACK_URL || '',
         scope: ['user:email'],
       },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      verifyEmail(config) as any,
+      verifyEmail(config),
     ));
   }
 

--- a/src/services/backends/kiro.ts
+++ b/src/services/backends/kiro.ts
@@ -151,6 +151,9 @@ interface JsonRpcNotification {
   jsonrpc: '2.0';
   method: string;
   params?: Record<string, unknown>;
+  /** Present when the peer is actually sending a JSON-RPC request (e.g. `session/request_permission`),
+      not a pure notification — the queue holds both. */
+  id?: number;
 }
 
 type JsonRpcMessage = JsonRpcResponse | JsonRpcNotification;
@@ -761,7 +764,7 @@ export class KiroAdapter extends BaseBackendAdapter {
 
         // ── Permission requests (auto-approve) ─────────────────────────
         if (notification.method === 'session/request_permission') {
-          const reqId = (notification as any).id;
+          const reqId = notification.id;
           if (reqId != null) {
             client.respond(reqId, {
               outcome: { outcome: 'selected', optionId: 'allow_always' },
@@ -774,7 +777,7 @@ export class KiroAdapter extends BaseBackendAdapter {
         if (notification.method.startsWith('_kiro.dev/')) {
           // Extract subagent info from list_update
           if (notification.method === '_kiro.dev/subagent/list_update') {
-            const subagents = (notification.params as any)?.subagents as Array<{ sessionId: string; sessionName: string; agentName?: string; initialQuery?: string }> | undefined;
+            const subagents = notification.params?.subagents as Array<{ sessionId: string; sessionName: string; agentName?: string; initialQuery?: string }> | undefined;
             if (subagents) {
               for (const sa of subagents) {
                 if (sa.sessionId && sa.sessionName) {
@@ -797,8 +800,8 @@ export class KiroAdapter extends BaseBackendAdapter {
           }
           // Map toolCallId → sessionId from subagent session updates
           if (notification.method === '_kiro.dev/session/update') {
-            const intUpdate = (notification.params as any)?.update as Record<string, unknown> | undefined;
-            const intSessionId = (notification.params as any)?.sessionId as string | undefined;
+            const intUpdate = notification.params?.update as Record<string, unknown> | undefined;
+            const intSessionId = notification.params?.sessionId as string | undefined;
             if (intUpdate && intSessionId && intUpdate.toolCallId) {
               toolToSubagent.set(intUpdate.toolCallId as string, intSessionId);
             }

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -11,6 +11,7 @@ import type {
   ToolActivity,
   Usage,
   UsageLedger,
+  UsageLedgerDay,
   SessionEntry,
   SessionFile,
   SessionHistoryItem,
@@ -2196,12 +2197,13 @@ export class ChatService {
     }
 
     // Migrate old format: if day has 'backends' but no 'records', convert
-    if ((dayEntry as any).backends && !dayEntry.records) {
-      dayEntry.records = [];
-      for (const [bid, u] of Object.entries((dayEntry as any).backends)) {
-        dayEntry.records.push({ backend: bid, model: 'unknown', usage: u as Usage });
+    const legacy = dayEntry as UsageLedgerDay & { backends?: Record<string, Usage> };
+    if (legacy.backends && !legacy.records) {
+      legacy.records = [];
+      for (const [bid, u] of Object.entries(legacy.backends)) {
+        legacy.records.push({ backend: bid, model: 'unknown', usage: u });
       }
-      delete (dayEntry as any).backends;
+      delete legacy.backends;
     }
 
     let record = dayEntry.records.find(r => r.backend === backendId && r.model === model);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -919,6 +919,7 @@ export interface AppConfig {
 declare module 'express-session' {
   interface SessionData {
     csrfToken?: string;
+    passport?: { user?: unknown };
   }
 }
 

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -199,8 +199,7 @@ export function attachWebSocket(
         }
 
         // Check passport user exists in session
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const passportUser = (session as any)?.passport?.user;
+        const passportUser = session?.passport?.user;
         if (!passportUser && !isLocal) {
           socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
           socket.destroy();

--- a/test/chat.rest.test.ts
+++ b/test/chat.rest.test.ts
@@ -3,7 +3,7 @@
 import fs from 'fs';
 import path from 'path';
 import { createChatRouterEnv, destroyChatRouterEnv, type ChatRouterEnv } from './helpers/chatEnv';
-import type { StreamEvent } from '../src/types';
+import type { StreamEvent, ActiveStreamEntry } from '../src/types';
 
 let env: ChatRouterEnv;
 

--- a/test/chat.websocket.test.ts
+++ b/test/chat.websocket.test.ts
@@ -2,7 +2,7 @@
 
 import WebSocket from 'ws';
 import { createChatRouterEnv, destroyChatRouterEnv, CSRF_TOKEN, type ChatRouterEnv } from './helpers/chatEnv';
-import type { StreamEvent } from '../src/types';
+import type { StreamEvent, SendMessageOptions } from '../src/types';
 
 let env: ChatRouterEnv;
 


### PR DESCRIPTION
## Summary
Replace 8 `any` type assertions with real types across 4 files in `src/`. No runtime behavior changes.

- **`backends/kiro.ts`** — add optional `id` to the `JsonRpcNotification` interface (the queue holds both notifications and requests per JSON-RPC 2.0); drop three `(params as any)?.*` casts since `params` is already `Record<string, unknown>`.
- **`chatService.ts`** — model the legacy `dayEntry.backends` field with a local intersection type (`UsageLedgerDay & { backends?: ... }`) so the usage-ledger migration type-checks without `any`.
- **`ws.ts`** — add `passport?: { user?: unknown }` to the existing `express-session` `SessionData` augmentation so `session.passport.user` narrows naturally.
- **`middleware/auth.ts`** — widen `verifyEmail`'s `profile` parameter from `passport-google-oauth20`'s `Profile` to `passport.Profile` (both strategies' profile types extend it) so the GitHub strategy no longer needs `as any`.

Also fixes two missing type imports in the chat test splits that ts-jest tolerated but `tsc` flagged (`SendMessageOptions` in `chat.websocket.test.ts`, `ActiveStreamEntry` in `chat.rest.test.ts`).

## Test plan
- [x] `npx tsc --noEmit` → exit 0
- [x] `npx jest --testPathPatterns="chat\.|chatService\.|auth|kiro"` → 18 suites, 532 tests pass
- [x] Verified the staged commit alone type-checks clean (not relying on unrelated in-progress working-tree changes)