### PR TITLE
feat(v2): KB browser top bar counts + Dream Stepper grid

### DIFF
--- a/docs/spec-backend-services.md
+++ b/docs/spec-backend-services.md
@@ -199,6 +199,9 @@ Files missing on disk during migration are still inserted with `sha256 = rawId` 
     entryCount: number,
     pendingCount: number,       // ingested + pending-delete
     folderCount: number,
+    topicCount: number,
+    connectionCount: number,
+    reflectionCount: number,
   },
   folders: KbFolder[],          // full flat folder tree sorted by folderPath
   raw: KbRawEntry[],            // ONE PAGE of the focused folder (not workspace-wide)

--- a/docs/spec-data-models.md
+++ b/docs/spec-data-models.md
@@ -647,6 +647,9 @@ interface KbCounters {
   entryCount: number;
   pendingCount: number;   // ingested + pending-delete
   folderCount: number;
+  topicCount: number;
+  connectionCount: number;
+  reflectionCount: number;
 }
 
 /** Full KB state snapshot returned by GET /workspaces/:hash/kb */

--- a/public/v2/index.html
+++ b/public/v2/index.html
@@ -18,10 +18,11 @@
 <link id="hljs-theme" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" />
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 
-<link rel="stylesheet" href="src/tokens.css?v=113" />
-<link rel="stylesheet" href="src/app.css?v=113" />
-<link rel="stylesheet" href="src/dialog.css?v=113" />
-<link rel="stylesheet" href="src/tooltip.css?v=113" />
+<link rel="stylesheet" href="src/tokens.css?v=116" />
+<link rel="stylesheet" href="src/app.css?v=116" />
+<link rel="stylesheet" href="src/dialog.css?v=116" />
+<link rel="stylesheet" href="src/tooltip.css?v=116" />
+<link rel="stylesheet" href="src/stepper.css?v=116" />
 <style>
   html, body, #root { height: 100%; margin: 0; }
   body { background: var(--bg); }
@@ -66,24 +67,24 @@
   })();
 </script>
 
-<script src="src/api.js?v=113"></script>
-<script src="src/streamStore.js?v=113"></script>
-<script src="src/planUsageStore.js?v=113"></script>
-<script src="src/kiroPlanUsageStore.js?v=113"></script>
-<script src="src/tabIndicator.js?v=113"></script>
-<script type="text/babel" data-presets="react" src="src/icons.jsx?v=113"></script>
-<script type="text/babel" data-presets="react" src="src/dialog.jsx?v=113"></script>
-<script type="text/babel" data-presets="react" src="src/toast.jsx?v=113"></script>
-<script type="text/babel" data-presets="react" src="src/tooltip.jsx?v=113"></script>
-<script type="text/babel" data-presets="react" src="src/chip-renderers.jsx?v=113"></script>
-<script type="text/babel" data-presets="react" src="src/primitives.jsx?v=113"></script>
-<script type="text/babel" data-presets="react" src="src/screens/kbBrowser.jsx?v=113"></script>
-<script type="text/babel" data-presets="react" src="src/screens/filesBrowser.jsx?v=113"></script>
-<script type="text/babel" data-presets="react" src="src/screens/settingsScreen.jsx?v=113"></script>
-<script type="text/babel" data-presets="react" src="src/folderPicker.jsx?v=113"></script>
-<script type="text/babel" data-presets="react" src="src/workspaceSettings.jsx?v=113"></script>
-<script type="text/babel" data-presets="react" src="src/sessionsModal.jsx?v=113"></script>
-<script type="text/babel" data-presets="react" src="src/updateModal.jsx?v=113"></script>
-<script type="text/babel" data-presets="react" src="src/shell.jsx?v=113"></script>
+<script src="src/api.js?v=116"></script>
+<script src="src/streamStore.js?v=116"></script>
+<script src="src/planUsageStore.js?v=116"></script>
+<script src="src/kiroPlanUsageStore.js?v=116"></script>
+<script src="src/tabIndicator.js?v=116"></script>
+<script type="text/babel" data-presets="react" src="src/icons.jsx?v=116"></script>
+<script type="text/babel" data-presets="react" src="src/dialog.jsx?v=116"></script>
+<script type="text/babel" data-presets="react" src="src/toast.jsx?v=116"></script>
+<script type="text/babel" data-presets="react" src="src/tooltip.jsx?v=116"></script>
+<script type="text/babel" data-presets="react" src="src/chip-renderers.jsx?v=116"></script>
+<script type="text/babel" data-presets="react" src="src/primitives.jsx?v=116"></script>
+<script type="text/babel" data-presets="react" src="src/screens/kbBrowser.jsx?v=116"></script>
+<script type="text/babel" data-presets="react" src="src/screens/filesBrowser.jsx?v=116"></script>
+<script type="text/babel" data-presets="react" src="src/screens/settingsScreen.jsx?v=116"></script>
+<script type="text/babel" data-presets="react" src="src/folderPicker.jsx?v=116"></script>
+<script type="text/babel" data-presets="react" src="src/workspaceSettings.jsx?v=116"></script>
+<script type="text/babel" data-presets="react" src="src/sessionsModal.jsx?v=116"></script>
+<script type="text/babel" data-presets="react" src="src/updateModal.jsx?v=116"></script>
+<script type="text/babel" data-presets="react" src="src/shell.jsx?v=116"></script>
 </body>
 </html>

--- a/public/v2/src/app.css
+++ b/public/v2/src/app.css
@@ -2113,15 +2113,6 @@ body{
   background: var(--surface);
   box-shadow: inset 0 -2px 0 var(--accent);
 }
-.kb-status{
-  display: flex; align-items: center; flex-wrap: wrap; gap: 6px;
-  padding: 8px 16px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-sunk);
-  font-family: var(--mono-font);
-  font-size: 10.5px;
-  color: var(--text-2);
-}
 .kb-pill{
   display: inline-flex; align-items: center; gap: 6px;
   padding: 3px 8px;
@@ -2193,30 +2184,15 @@ body{
   border-bottom: 1px solid var(--border);
   background: var(--bg-sunk);
 }
+/* KB Synthesis tab wrapper styling: the host band that holds the handoff
+   .kb-actions grid + .stepper. Visual details (buttons, stepper) live in
+   src/stepper.css which is imported verbatim from the handoff bundle. */
 .kb-synth-controls{
-  display: flex; flex-direction: column; gap: 6px;
   padding: 10px 16px;
   border-bottom: 1px solid var(--border);
   background: var(--bg-sunk);
   font-size: 12px;
   color: var(--text-2);
-}
-.kb-synth-btn-row{ display: flex; align-items: center; gap: 8px; }
-.kb-synth-info-row{ display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.kb-synth-dream-btn{
-  background: var(--accent, #6366f1);
-  color: #fff;
-  border-color: var(--accent, #6366f1);
-}
-.kb-synth-dream-btn:hover:not(:disabled){ filter: brightness(1.05); }
-.kb-synth-dream-btn:disabled{ opacity: .6; cursor: not-allowed; }
-.kb-synth-stop-btn{ display: inline-flex; align-items: center; gap: 4px; }
-.kb-synth-redream-btn{ opacity: .85; }
-.kb-synth-redream-btn:disabled{ opacity: .5; cursor: not-allowed; }
-.kb-synth-status{
-  font-family: var(--mono-font);
-  font-size: 11px;
-  color: var(--text-3);
 }
 .kb-search-input{
   width: 100%;
@@ -2686,7 +2662,12 @@ body{
 .kb-settings-health.ok{ color: var(--status-done); border-color: var(--status-done); }
 .kb-settings-health.err{ color: var(--status-error); border-color: var(--status-error); }
 
-.kb-split{ flex-direction: row; }
+.kb-split{
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: row;
+}
 .kb-split-left{
   flex: 0 0 380px;
   min-height: 0;

--- a/public/v2/src/screens/kbBrowser.jsx
+++ b/public/v2/src/screens/kbBrowser.jsx
@@ -81,7 +81,9 @@ function KbBrowser({ hash, label, onClose }){
   const totals = counters ? {
     raw: counters.rawTotal || 0,
     entries: counters.entryCount || 0,
-    folders: counters.folderCount || 0,
+    topics: counters.topicCount || 0,
+    connections: counters.connectionCount || 0,
+    reflections: counters.reflectionCount || 0,
   } : null;
 
   return (
@@ -94,7 +96,7 @@ function KbBrowser({ hash, label, onClose }){
         <span className="ws">{label}</span>
         {totals ? (
           <span className="u-mono u-dim" style={{fontSize:10.5}}>
-            {totals.raw} files · {totals.entries} entries{totals.folders ? ` · ${totals.folders} folders` : ''}
+            {totals.raw} files · {totals.entries} entries · {totals.topics} topics · {totals.connections} connections · {totals.reflections} reflections
           </span>
         ) : kbErr ? (
           <span className="u-err" style={{fontSize:11}}>{kbErr}</span>
@@ -462,33 +464,81 @@ function formatDreamRelative(iso){
   return `${day}d ago`;
 }
 
-/* Horizontal stepper rendered inside the Synthesis controls bar while a
-   dream is running. Five phases (routing → verification → synthesis →
-   discovery → reflection) render as done / active / pending. The active
-   step shows `done/total` plus elapsed-in-step. Duplicates shell.jsx's
-   DreamStepper because this file loads before shell.jsx and can't import
-   from it; the shape stays aligned deliberately. */
-function DreamStepper({ progress, stepStart }){
-  const phases = ['routing', 'verification', 'synthesis', 'discovery', 'reflection'];
-  const currentIdx = progress && progress.phase ? phases.indexOf(progress.phase) : -1;
-  const elapsed = stepStart ? formatDreamElapsed(Date.now() - stepStart) : '';
+/* Dream pipeline stepper. Markup and class names mirror the handoff
+   `src/stepper.jsx` verbatim so that `public/v2/src/stepper.css` (also
+   copied verbatim from the handoff) applies without any adaptation.
+   Five phases (routing → verification → synthesis → discovery →
+   reflection) render as upcoming / active / done. Active reserves a wider
+   slot (6-col grid, active spans 2) and shows done/total. The component
+   renders a shimmering "Starting…" rail when triggered before the first
+   progress frame arrives. Spec: docs/spec-frontend.md#dream-pipeline-stepper. */
+const DREAM_PHASES = ['routing', 'verification', 'synthesis', 'discovery', 'reflection'];
+const DREAM_PHASE_LABELS = {
+  routing: 'Routing',
+  verification: 'Verification',
+  synthesis: 'Synthesis',
+  discovery: 'Discovery',
+  reflection: 'Reflection',
+};
+function StepCheck(){
   return (
-    <div className="dream-stepper">
-      {phases.map((p, i) => {
-        const active = i === currentIdx;
-        const done = currentIdx > i;
-        const label = p.charAt(0).toUpperCase() + p.slice(1);
-        const counts = active && progress && progress.total ? ` ${progress.done || 0}/${progress.total}` : '';
-        const elapsedLabel = active && elapsed ? ` — ${elapsed}` : '';
-        return (
-          <React.Fragment key={p}>
-            {i > 0 ? <span className="dream-stepper-sep">→</span> : null}
-            <span className={"dream-stepper-step" + (active ? ' active' : done ? ' done' : '')}>
-              {done ? '✓ ' : ''}{label}{counts}{elapsedLabel}
-            </span>
-          </React.Fragment>
-        );
-      })}
+    <svg className="step-check" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+      <path d="M2.5 6.5 L5 9 L9.5 3.5" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  );
+}
+function DreamStepperGrid({ progress, stepStart, starting }){
+  if (starting || !progress || !progress.phase) {
+    return (
+      <div className="stepper-host">
+        <div className="stepper starting" role="status" aria-live="polite">
+          <div className="stepper-stages">
+            <span className="starting-chip"><span className="spin" aria-hidden="true"/> Starting…</span>
+            <span className="starting-rail"/>
+          </div>
+          <div className="stepper-timer"><span className="lbl">Elapsed</span><b>0:00</b></div>
+        </div>
+      </div>
+    );
+  }
+  const currentIdx = DREAM_PHASES.indexOf(progress.phase);
+  const stages = DREAM_PHASES.map((key, i) => {
+    const label = DREAM_PHASE_LABELS[key];
+    if (i < currentIdx) return { key, label, state: 'done' };
+    if (i === currentIdx) return {
+      key, label, state: 'active',
+      count: progress.done || 0,
+      total: progress.total || 0,
+    };
+    return { key, label, state: 'upcoming' };
+  });
+  const elapsed = stepStart ? formatDreamElapsed(Date.now() - stepStart) : '0:00';
+  return (
+    <div className="stepper-host">
+      <div className="stepper" role="group" aria-label="Dream pipeline progress">
+        <div className="stepper-stages">
+          {stages.map((s, i) => (
+            <div key={s.key} className="step" data-state={s.state}
+                 aria-label={`Stage ${i+1} of 5, ${s.label}, ${s.state}`}>
+              <span className="step-icon">
+                {s.state === 'active' ? <span className="spin" aria-hidden="true"/>
+                  : s.state === 'done' ? <StepCheck/>
+                  : <span className="step-num">{i+1}</span>}
+              </span>
+              <span className="step-body">
+                <span className="step-label">{s.label}</span>
+                <span className="step-counter" aria-hidden={s.state !== 'active'}>
+                  {s.state === 'active' && s.total ? `${s.count}/${s.total}` : ''}
+                </span>
+              </span>
+            </div>
+          ))}
+        </div>
+        <div className="stepper-timer"><span className="lbl">Elapsed</span><b>{elapsed}</b></div>
+        <span className="sr-only" aria-live="polite">
+          {stages.filter(s => s.state === 'active').map(s => `${s.label} ${s.count} of ${s.total}`).join(', ')}
+        </span>
+      </div>
     </div>
   );
 }
@@ -629,35 +679,36 @@ function KbSynthesisTab({ hash }){
   const lastRunLabel = formatDreamRelative(data.lastRunAt);
   const pending = data.needsSynthesisCount || 0;
   const lastErr = data.lastRunError || '';
-  const statusLabel = isRunning ? 'running' : (data.status || 'idle');
 
   return (
-    <div className="kb-pane kb-split">
-      <div className="kb-split-left">
-        <div className="kb-synth-controls">
-          <div className="kb-synth-btn-row">
+    <div className="kb-pane">
+      <div className="kb-synth-controls">
+        <div className="kb-actions">
+          <div className="btns">
             <button
               type="button"
-              className="btn kb-synth-dream-btn"
+              className={"btn-dream" + (isRunning ? " running" : "")}
               onClick={startDream}
               disabled={starting || isRunning}
               title="Run incremental dream on pending entries"
             >
-              {starting || isRunning ? 'Dreaming…' : <>{Ico.moon(12)} Dream</>}
+              {starting || isRunning
+                ? <>{Ico.bolt(12)} Dreaming…</>
+                : <>{Ico.moon(12)} Dream</>}
             </button>
             {isRunning ? (
               <button
                 type="button"
-                className="btn danger kb-synth-stop-btn"
+                className="btn-dream stop"
                 onClick={stopDream}
                 disabled={stopping || isStopping}
               >
-                {stopping || isStopping ? 'Stopping…' : <>{Ico.stop(12)} Stop</>}
+                {Ico.stop(11)} {stopping || isStopping ? 'Stopping…' : 'Stop'}
               </button>
             ) : null}
             <button
               type="button"
-              className="btn kb-synth-redream-btn"
+              className="btn-dream ghost"
               onClick={(e) => redream(e.currentTarget)}
               disabled={isRunning}
               title="Wipe all topics & connections, then rebuild from scratch"
@@ -665,71 +716,70 @@ function KbSynthesisTab({ hash }){
               Re-Dream
             </button>
           </div>
-          <div className="kb-synth-info-row">
-            <span className="kb-synth-status">
-              Last run: {lastRunLabel}
-              {pending > 0 ? <> · <span>{pending} pending</span></> : null}
-              {lastErr ? <> · <span className="u-err">{lastErr}</span></> : null}
-            </span>
-            {isRunning ? <DreamStepper progress={data.dreamProgress} stepStart={stepStart}/> : null}
+          <div className="status">
+            Last run: {lastRunLabel}
+            {pending > 0 ? <> · <span>{pending} pending</span></> : null}
+            {lastErr ? <> · <span className="u-err">{lastErr}</span></> : null}
           </div>
         </div>
-        <div className="kb-status">
-          <span className={`kb-pill ${statusLabel === 'idle' ? 'ok' : 'run'}`}>
-            <span className="dot"/>{statusLabel}
-          </span>
-          <span className="kb-pill"><span className="dot"/>{topics.length} topics</span>
-          <span className="kb-pill"><span className="dot"/>{data.connectionCount || 0} connections</span>
-          {data.needsSynthesisCount ? <span className="kb-pill warn"><span className="dot"/>{data.needsSynthesisCount} pending</span> : null}
-          {data.reflectionCount ? <span className="kb-pill"><span className="dot"/>{data.reflectionCount} reflections</span> : null}
-        </div>
-        {topics.length > 0 ? (
-          <div className="kb-filters">
-            <input
-              type="text"
-              placeholder="Search topics…"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              className="kb-search-input"
-            />
-          </div>
-        ) : null}
-        <div className="kb-list">
-          {topics.length === 0 ? (
-            <div className="u-dim" style={{padding:"16px"}}>No topics yet. Click Dream to synthesize pending entries into topics.</div>
-          ) : filteredTopics.length === 0 ? (
-            <div className="u-dim" style={{padding:"16px"}}>No matches for “{query.trim()}”.</div>
-          ) : filteredTopics.map(t => (
-            <button
-              key={t.topicId}
-              type="button"
-              className={`kb-entry-row ${selectedId === t.topicId ? 'active' : ''}`}
-              onClick={() => setSelectedId(t.topicId)}
-            >
-              <div className="kb-entry-title">
-                {t.isGodNode ? <span className="u-accent" style={{marginRight:6}}>★</span> : null}
-                {t.title}
-              </div>
-              {t.summary ? <div className="kb-entry-summary">{t.summary}</div> : null}
-              <div className="kb-entry-meta">
-                <span className="kb-meta-chip">{t.entryCount || 0} entries</span>
-                <span className="kb-meta-chip">{t.connectionCount || 0} links</span>
-              </div>
-            </button>
-          ))}
-        </div>
-      </div>
-      <div className="kb-split-right">
-        {selectedId ? (
-          <KbTopicDetail
-            hash={hash}
-            topicId={selectedId}
-            topicsById={topicsById}
-            onSelectTopic={setSelectedId}
+        {isRunning ? (
+          <DreamStepperGrid
+            progress={data && data.dreamProgress}
+            stepStart={stepStart}
+            starting={!(data && data.dreamProgress && data.dreamProgress.phase)}
           />
-        ) : (
-          <div className="u-dim" style={{padding:"16px"}}>Select a topic to view its entries and connections.</div>
-        )}
+        ) : null}
+      </div>
+      <div className="kb-split">
+        <div className="kb-split-left">
+          {topics.length > 0 ? (
+            <div className="kb-filters">
+              <input
+                type="text"
+                placeholder="Search topics…"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                className="kb-search-input"
+              />
+            </div>
+          ) : null}
+          <div className="kb-list">
+            {topics.length === 0 ? (
+              <div className="u-dim" style={{padding:"16px"}}>No topics yet. Click Dream to synthesize pending entries into topics.</div>
+            ) : filteredTopics.length === 0 ? (
+              <div className="u-dim" style={{padding:"16px"}}>No matches for “{query.trim()}”.</div>
+            ) : filteredTopics.map(t => (
+              <button
+                key={t.topicId}
+                type="button"
+                className={`kb-entry-row ${selectedId === t.topicId ? 'active' : ''}`}
+                onClick={() => setSelectedId(t.topicId)}
+              >
+                <div className="kb-entry-title">
+                  {t.isGodNode ? <span className="u-accent" style={{marginRight:6}}>★</span> : null}
+                  {t.title}
+                </div>
+                {t.summary ? <div className="kb-entry-summary">{t.summary}</div> : null}
+                <div className="kb-entry-meta">
+                  <span className="kb-meta-chip">{t.entryCount || 0} entries</span>
+                  <span className="kb-meta-chip">{t.connectionCount || 0} links</span>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="kb-split-right">
+          {selectedId ? (
+            <KbTopicDetail
+              hash={hash}
+              topicId={selectedId}
+              topicsById={topicsById}
+              onSelectTopic={setSelectedId}
+            />
+          ) : (
+            <div className="u-dim" style={{padding:"16px"}}>Select a topic to view its entries and connections.</div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/public/v2/src/stepper.css
+++ b/public/v2/src/stepper.css
@@ -1,0 +1,437 @@
+/* ============================================================
+   Dream Pipeline Stepper
+   5 stages · 4 states · fixed widths to avoid jitter
+   Works in KB tab (primary) + chat dream banner (thinner)
+   ============================================================ */
+
+/* ---------- Demo page chrome ---------- */
+.st-page{
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--ui-font);
+  padding: 40px 48px 80px;
+  max-width: 1280px; margin: 0 auto;
+}
+.st-eyebrow{
+  font-family: var(--mono-font);
+  font-size: 11px; letter-spacing: .18em; text-transform: uppercase;
+  color: var(--text-3);
+}
+.st-title{
+  font-family: var(--prose-font);
+  font-size: 44px; line-height: 1.05; letter-spacing: -.018em;
+  font-weight: 500; color: var(--text);
+  margin: 8px 0 10px;
+}
+.st-sub{
+  max-width: 760px; font-size: 14px; line-height: 1.6;
+  color: var(--text-2); margin: 0 0 32px;
+}
+.st-section{
+  margin: 36px 0 0;
+  padding-top: 24px;
+  border-top: 1px solid var(--border);
+}
+.st-section h3{
+  font-family: var(--prose-font);
+  font-size: 22px; line-height: 1.2; font-weight: 500;
+  margin: 0 0 4px; color: var(--text); letter-spacing: -.01em;
+}
+.st-section p{
+  font-size: 13px; color: var(--text-2); margin: 0 0 14px; max-width: 640px;
+}
+.st-frame-wrap{ margin-bottom: 18px; }
+.st-frame-wrap[data-w="620"]{ width: 620px; max-width: 100%; }
+.st-frame-wrap[data-w="480"]{ width: 480px; max-width: 100%; }
+.st-frame-wrap[data-w="820"]{ width: 820px; max-width: 100%; }
+.st-frame-tag{
+  display: block;
+  font-family: var(--mono-font); font-size: 10px;
+  color: var(--text-3); letter-spacing: .12em;
+  text-transform: uppercase;
+  margin: 0 0 6px 2px;
+}
+.st-frame{
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-md);
+  background: var(--surface);
+  padding: 14px 16px;
+  position: relative;
+  overflow: hidden;
+}
+
+/* ---------- KB action bar layout (host context) ---------- */
+.kb-actions{
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 8px 10px; align-items: center;
+  margin-bottom: 10px;
+}
+.kb-actions + .stepper{ margin-top: 2px; }
+.kb-actions .btns{ display: inline-flex; gap: 6px; }
+.kb-actions .status{
+  font-family: var(--mono-font); font-size: 11px;
+  color: var(--text-3);
+}
+.kb-actions .search{
+  max-width: 240px; justify-self: end;
+}
+.btn-dream{
+  padding: 5px 12px; border: 1px solid var(--accent);
+  background: var(--accent-soft); color: var(--accent);
+  border-radius: var(--r-sm); font: inherit; font-size: 12.5px; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 6px;
+  cursor: pointer;
+}
+.btn-dream.running{ opacity: .7; }
+.btn-dream.stop{ background: color-mix(in oklch, var(--status-error), transparent 88%); color: var(--status-error); border-color: color-mix(in oklch, var(--status-error), transparent 55%); }
+.btn-dream.ghost{ background: transparent; color: var(--text-2); border-color: var(--border-strong); }
+
+/* ---------- Chat dream banner (host context) ---------- */
+.chat-banner{
+  display: flex; align-items: center; gap: 12px;
+  padding: 8px 12px;
+  background: linear-gradient(180deg, color-mix(in oklch, var(--accent-soft), transparent 50%), var(--surface));
+  border: 1px solid var(--border);
+  border-bottom: 0;
+  border-radius: var(--r-md) var(--r-md) 0 0;
+}
+.chat-banner .lbl{
+  font-family: var(--mono-font); font-size: 10.5px; letter-spacing: .14em; text-transform: uppercase;
+  color: var(--accent);
+  display: inline-flex; align-items: center; gap: 6px;
+  flex-shrink: 0;
+}
+.chat-banner .lbl .dot{
+  width: 7px; height: 7px; border-radius: 999px; background: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent), transparent 75%);
+  animation: st-pulse 1.4s var(--easing) infinite;
+}
+.chat-banner .stop-btn{
+  appearance: none; font: inherit; font-size: 11px;
+  padding: 3px 10px;
+  border: 1px solid color-mix(in oklch, var(--status-error), transparent 50%);
+  background: color-mix(in oklch, var(--status-error), transparent 88%);
+  color: var(--status-error);
+  border-radius: var(--r-sm);
+  font-weight: 500; cursor: pointer;
+  flex-shrink: 0;
+}
+
+/* ============================================================
+   THE STEPPER
+   Each slot is fixed-proportional so nothing jumps.
+   ============================================================ */
+.stepper{
+  --slot-gap: 6px;
+  display: grid;
+  grid-template-columns: 1fr auto;  /* stages | timer */
+  gap: 10px;
+  align-items: center;
+  font-family: var(--ui-font);
+  min-width: 0;
+}
+.stepper-stages{
+  display: grid;
+  /* 6 columns-worth: active step spans 2 via grid-column. The remaining
+     4 stages get 1 column each. Without an active step, fall back to 5
+     equal tracks so the starting/pre-run layout is balanced. */
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: var(--slot-gap);
+  min-width: 0;
+}
+.step[data-state="active"]{ grid-column: span 2; }
+.stepper-stages:not(:has(.step[data-state="active"])){
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.step{
+  display: grid;
+  grid-template-columns: 12px minmax(0, 1fr);
+  align-items: center;
+  gap: 5px;
+  padding: 4px 7px 4px 6px;
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  font-size: 11.5px;
+  color: var(--text-3);
+  min-width: 0;
+  position: relative;
+  transition: background .25s var(--easing), color .25s var(--easing), border-color .25s var(--easing);
+}
+/* Done steps tighten padding since there's no counter and the check is compact */
+.step[data-state="done"]{ padding: 4px 6px 4px 5px; gap: 4px; }
+
+/* Container-query responsive tightening: when host is narrow, done labels
+   shrink in size before they truncate. The icon (check / dash / num) still
+   identifies the stage by its pipeline position. */
+.stepper-host{ container-type: inline-size; container-name: stepper; min-width: 0; flex: 1 1 0; }
+@container stepper (max-width: 680px){
+  .stepper:not(.compact) .step[data-state="done"] .step-label,
+  .stepper:not(.compact) .step[data-state="skipped"] .step-label,
+  .stepper:not(.compact) .step[data-state="upcoming"] .step-label{
+    font-size: 10.5px;
+    letter-spacing: -.012em;
+  }
+}
+.step-icon{
+  width: 12px; height: 12px;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--text-4);
+  flex-shrink: 0;
+}
+.step-num{
+  font-family: var(--mono-font); font-size: 10px; font-weight: 600;
+  color: var(--text-4);
+}
+.step-body{
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: baseline; gap: 4px;
+  min-width: 0;
+}
+.step-label{
+  font-weight: 500;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  font-size: 11.5px;
+  letter-spacing: -.005em;
+  min-width: 0;
+}
+
+/* Only the ACTIVE step reserves counter space. Done/upcoming/skipped steps
+   let the label claim the whole slot. */
+.step-counter{
+  font-family: var(--mono-font);
+  font-size: 10px;
+  color: var(--text-3);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  display: none;
+}
+.step[data-state="active"] .step-counter{ display: inline; }
+
+/* Upcoming — default */
+.step[data-state="upcoming"]{
+  background: transparent;
+  border-color: var(--border);
+  color: var(--text-3);
+}
+
+/* Done */
+.step[data-state="done"]{
+  background: color-mix(in oklch, var(--status-done), transparent 90%);
+  border-color: color-mix(in oklch, var(--status-done), transparent 70%);
+  color: color-mix(in oklch, var(--status-done), var(--text) 30%);
+}
+.step[data-state="done"] .step-icon{ color: var(--status-done); }
+.step[data-state="done"] .step-num{ color: color-mix(in oklch, var(--status-done), transparent 40%); }
+
+/* Skipped — clearly distinct: strikethrough label, muted, dashed border */
+.step[data-state="skipped"]{
+  background: transparent;
+  border: 1px dashed var(--border-strong);
+  color: var(--text-4);
+}
+.step[data-state="skipped"] .step-label{ text-decoration: line-through; text-decoration-color: var(--text-4); text-decoration-thickness: 1px; }
+.step[data-state="skipped"] .step-icon{ color: var(--text-4); }
+
+/* Active — bold, filled, glowing */
+.step[data-state="active"]{
+  background: color-mix(in oklch, var(--accent-soft), var(--surface) 10%);
+  border-color: var(--accent);
+  color: var(--text);
+  box-shadow:
+    0 0 0 1px var(--accent) inset,
+    0 2px 10px -4px color-mix(in oklch, var(--accent), transparent 60%);
+  animation: st-active-breathe 2.4s var(--easing) infinite;
+}
+.step[data-state="active"] .step-icon{ color: var(--accent); }
+.step[data-state="active"] .step-num{ color: var(--accent); font-weight: 700; }
+.step[data-state="active"] .step-label{ font-weight: 600; color: var(--text); }
+
+/* Spinner */
+.spin{
+  width: 12px; height: 12px;
+  border-radius: 999px;
+  border: 1.5px solid color-mix(in oklch, var(--accent), transparent 70%);
+  border-top-color: var(--accent);
+  animation: st-spin 0.9s linear infinite;
+}
+
+/* Checkmark (for done) */
+.step-check{
+  width: 12px; height: 12px;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--status-done);
+}
+
+/* ---------- Elapsed timer — stable slot on the right ---------- */
+.stepper-timer{
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono-font); font-size: 11px;
+  color: var(--text-2);
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  border-radius: var(--r-sm);
+  font-variant-numeric: tabular-nums;
+  min-width: 72px; justify-content: flex-end;
+}
+.stepper-timer .lbl{ color: var(--text-4); font-size: 9.5px; letter-spacing: .14em; text-transform: uppercase; }
+.stepper-timer b{ color: var(--text); font-weight: 600; }
+
+/* ---------- Starting state ---------- */
+.stepper.starting .stepper-stages{ display: flex; align-items: center; gap: 10px; }
+.stepper.starting .starting-chip{
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 5px 12px;
+  background: var(--accent-soft); color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: var(--r-sm);
+  font-size: 11.5px; font-weight: 500;
+}
+.stepper.starting .starting-rail{
+  flex: 1; height: 2px; border-radius: 999px;
+  background: var(--surface-2);
+  overflow: hidden;
+  position: relative;
+}
+.stepper.starting .starting-rail::after{
+  content: ""; position: absolute; inset: 0;
+  background: linear-gradient(90deg, transparent, var(--accent), transparent);
+  animation: st-slide 1.4s linear infinite;
+  width: 40%;
+}
+
+/* ============================================================
+   COMPACT mode — raise threshold so narrow widths default to it.
+   ============================================================ */
+@container (max-width: 560px){
+  .stepper-autoscope{ --compact: 1; }
+}
+.stepper.compact{
+  grid-template-columns: 1fr auto;
+}
+.stepper.compact .stepper-stages{
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  align-items: center;
+}
+.stepper.compact .step{
+  display: none;
+}
+.stepper.compact .step[data-state="active"]{
+  display: grid;
+  padding: 5px 10px 5px 8px;
+  grid-template-columns: 14px auto auto;
+  gap: 8px;
+  min-width: 0;
+}
+.stepper.compact .step[data-state="active"] .step-body{
+  grid-template-columns: auto auto;
+  gap: 8px;
+}
+.stepper.compact .step[data-state="active"] .step-counter{
+  width: auto; min-width: 58px;
+}
+
+/* Dot rail */
+.dot-rail{
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 0 2px;
+}
+.dot-rail .d{
+  width: 8px; height: 8px; border-radius: 999px;
+  background: var(--surface-2);
+  border: 1px solid var(--border-strong);
+  position: relative;
+  font-size: 0;
+  flex-shrink: 0;
+}
+.dot-rail .d[data-state="done"]{
+  background: var(--status-done);
+  border-color: var(--status-done);
+}
+.dot-rail .d[data-state="skipped"]{
+  background: transparent;
+  border-style: dashed;
+}
+.dot-rail .d[data-state="active"]{
+  background: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent), transparent 75%);
+  width: 10px; height: 10px;
+}
+.dot-rail .d[data-state="upcoming"]{
+  background: transparent;
+}
+
+/* ============================================================
+   STATE MATRIX (design system view)
+   ============================================================ */
+.st-matrix{
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px 24px;
+  align-items: center;
+  padding: 18px 20px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+.st-matrix-row-label{
+  font-family: var(--mono-font);
+  font-size: 10.5px; letter-spacing: .14em; text-transform: uppercase;
+  color: var(--text-3);
+}
+
+/* ============================================================
+   Screen-reader-only live region
+   ============================================================ */
+.sr-only{
+  position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+}
+
+/* ---------- annotation card ---------- */
+.st-note{
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 14px;
+  padding: 10px 14px;
+  border-left: 3px solid var(--accent);
+  background: color-mix(in oklch, var(--accent-soft), transparent 40%);
+  border-radius: 0 var(--r-sm) var(--r-sm) 0;
+  font-size: 12.5px; line-height: 1.55; color: var(--text-2);
+  margin-top: 10px;
+}
+.st-note b{ color: var(--text); }
+.st-note .st-note-title{
+  font-family: var(--mono-font); font-size: 10.5px; letter-spacing: .14em; text-transform: uppercase;
+  color: var(--text-3);
+}
+
+/* ---------- motion ---------- */
+@keyframes st-spin { to { transform: rotate(360deg); } }
+@keyframes st-pulse{
+  0%, 100% { box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent), transparent 75%); }
+  50%      { box-shadow: 0 0 0 5px color-mix(in oklch, var(--accent), transparent 85%); }
+}
+@keyframes st-active-breathe{
+  0%, 100% { box-shadow: 0 0 0 1px var(--accent) inset, 0 2px 10px -4px color-mix(in oklch, var(--accent), transparent 60%); }
+  50%      { box-shadow: 0 0 0 1px var(--accent) inset, 0 2px 16px -4px color-mix(in oklch, var(--accent), transparent 35%); }
+}
+@keyframes st-slide{
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(350%);  }
+}
+@media (prefers-reduced-motion: reduce){
+  .step[data-state="active"]{ animation: none; }
+  .chat-banner .lbl .dot{ animation: none; }
+  .stepper.starting .starting-rail::after{ animation: none; }
+  .spin{ animation-duration: 2s; }
+}

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -1829,6 +1829,9 @@ export class ChatService {
       entryCount: 0,
       pendingCount: 0,
       folderCount: 0,
+      topicCount: 0,
+      connectionCount: 0,
+      reflectionCount: 0,
     };
     return {
       version: KB_STATE_VERSION,

--- a/src/services/knowledgeBase/db.ts
+++ b/src/services/knowledgeBase/db.ts
@@ -813,12 +813,24 @@ export class KbDatabase {
     const folderCountRow = this.db
       .prepare<unknown[], { n: number }>('SELECT COUNT(*) AS n FROM folders')
       .get();
+    const topicCountRow = this.db
+      .prepare<unknown[], { n: number }>('SELECT COUNT(*) AS n FROM synthesis_topics')
+      .get();
+    const connectionCountRow = this.db
+      .prepare<unknown[], { n: number }>('SELECT COUNT(*) AS n FROM synthesis_connections')
+      .get();
+    const reflectionCountRow = this.db
+      .prepare<unknown[], { n: number }>('SELECT COUNT(*) AS n FROM synthesis_reflections')
+      .get();
     return {
       rawTotal,
       rawByStatus,
       entryCount: entryCountRow?.n ?? 0,
       pendingCount: rawByStatus.ingested + rawByStatus['pending-delete'],
       folderCount: folderCountRow?.n ?? 0,
+      topicCount: topicCountRow?.n ?? 0,
+      connectionCount: connectionCountRow?.n ?? 0,
+      reflectionCount: reflectionCountRow?.n ?? 0,
     };
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -659,6 +659,9 @@ export interface KbCounters {
   entryCount: number;
   pendingCount: number; // ingested + pending-delete
   folderCount: number;
+  topicCount: number;
+  connectionCount: number;
+  reflectionCount: number;
 }
 
 /**

--- a/test/knowledgeBase.db.test.ts
+++ b/test/knowledgeBase.db.test.ts
@@ -77,6 +77,9 @@ describe('schema + root folder', () => {
     expect(c.rawByStatus.ingested).toBe(0);
     expect(c.rawByStatus.digested).toBe(0);
     expect(c.rawByStatus.failed).toBe(0);
+    expect(c.topicCount).toBe(0);
+    expect(c.connectionCount).toBe(0);
+    expect(c.reflectionCount).toBe(0);
   });
 });
 
@@ -461,6 +464,24 @@ describe('getCounters', () => {
     expect(c.rawByStatus.failed).toBe(1);
     expect(c.rawByStatus['pending-delete']).toBe(1);
     expect(c.pendingCount).toBe(3); // 2 ingested + 1 pending-delete
+  });
+
+  test('topic, connection, and reflection counts reflect synthesis tables', () => {
+    const now = '2026-01-01T00:00:00Z';
+    db.upsertTopic({ topicId: 't1', title: 'T1', summary: null, content: null, updatedAt: now });
+    db.upsertTopic({ topicId: 't2', title: 'T2', summary: null, content: null, updatedAt: now });
+    db.upsertTopic({ topicId: 't3', title: 'T3', summary: null, content: null, updatedAt: now });
+    db.upsertConnection({ sourceTopic: 't1', targetTopic: 't2', relationship: 'r', confidence: 'inferred', evidence: null });
+    db.upsertConnection({ sourceTopic: 't2', targetTopic: 't3', relationship: 'r', confidence: 'inferred', evidence: null });
+    db.insertReflection({
+      reflectionId: 'ref-1', title: 'R', type: 'pattern',
+      summary: null, content: 'c', createdAt: now, citedEntryIds: [],
+    });
+
+    const c = db.getCounters();
+    expect(c.topicCount).toBe(3);
+    expect(c.connectionCount).toBe(2);
+    expect(c.reflectionCount).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary

- KB Browser top bar now shows workspace-wide synthesis counts: `N files · N entries · N topics · N connections · N reflections`. Folder count removed.
- Inner `kb-status` pill row on the Synthesis tab is gone — the same numbers (and more) now live in the top bar.
- Dream pipeline progress renders via a new `DreamStepperGrid` component (full-width CSS Grid stepper from the design mock) inside the synthesis controls.

## Backend

- `KbCounters` gains `topicCount`, `connectionCount`, `reflectionCount`. Populated by three `COUNT(*)` queries in `KbDatabase.getCounters()` against `synthesis_topics`, `synthesis_connections`, `synthesis_reflections`. Zero defaults added to `_emptyKbSnapshot` so KB-disabled / empty workspaces still return a well-formed shape. Spec docs updated in `docs/spec-data-models.md` and `docs/spec-backend-services.md`.

## Frontend

- `kbBrowser.jsx` top bar updated; `.kb-status` div + its CSS rule deleted. Orphaned `statusLabel` local removed.
- `DreamStepperGrid` added alongside the old `DreamStepper` in `shell.jsx` — the grid variant is named distinctly to avoid the babel-standalone global-scope collision (identically-named top-level functions across `public/v2` files collide; later load wins, and `shell.jsx` loads after `kbBrowser.jsx`).
- New `public/v2/src/stepper.css` carries the stepper styles verbatim from the handoff mock.
- Cache-bust bumped to `?v=116`.

## Tests

- New assertions in `test/knowledgeBase.db.test.ts` for the new counter fields (empty DB + populated synthesis tables). All 82 KB DB tests pass.

## Test plan

- [ ] Hard-refresh `/v2`, open the KB Browser on a workspace with synthesized topics → top bar shows five counts
- [ ] Start a Dream on the Synthesis tab → grid stepper renders full-width above the topic list (not the old arrow-style one)
- [ ] Stop/Re-Dream buttons still work
- [ ] KB Browser on an empty/KB-disabled workspace shows zero counts without errors