### PR TITLE
diag: add [diag] logs around WS lifecycle and message ordering

### DIFF
--- a/public/v2/src/streamStore.js
+++ b/public/v2/src/streamStore.js
@@ -437,6 +437,9 @@
       const draft = (!s.input && s.pendingAttachments.length === 0)
         ? readDraft(convId)
         : null;
+      console.log('[diag]', new Date().toISOString(), 'load-result',
+        'conv=' + convId.slice(0,8),
+        'msgCount=' + (Array.isArray(data.messages) ? data.messages.length : 0));
       update(convId, cur => ({
         ...cur,
         conv: data,
@@ -470,10 +473,11 @@
     if (s.ws && (s.ws.readyState === WebSocket.OPEN || s.ws.readyState === WebSocket.CONNECTING)) {
       return s.wsOpening || Promise.resolve();
     }
+    console.log('[diag]', new Date().toISOString(), 'ensureWsOpen-new', 'conv=' + convId.slice(0,8));
     const ws = new WebSocket(AgentApi.chatWsUrl(convId));
     const opening = new Promise((resolve, reject) => {
       const timer = setTimeout(() => reject(new Error('WebSocket connect timed out')), 5000);
-      ws.addEventListener('open', () => { clearTimeout(timer); resolve(); }, { once: true });
+      ws.addEventListener('open', () => { clearTimeout(timer); console.log('[diag]', new Date().toISOString(), 'ws-open', 'conv=' + convId.slice(0,8)); resolve(); }, { once: true });
       ws.addEventListener('error', () => { clearTimeout(timer); reject(new Error('WebSocket failed')); }, { once: true });
     });
     ws.onmessage = (evt) => {
@@ -481,8 +485,9 @@
       try { frame = JSON.parse(evt.data); } catch { return; }
       handleFrame(convId, frame);
     };
-    ws.onerror = () => { update(convId, { streamError: 'WebSocket error', uiState: 'error' }); };
-    ws.onclose = () => {
+    ws.onerror = () => { console.log('[diag]', new Date().toISOString(), 'ws-error', 'conv=' + convId.slice(0,8)); update(convId, { streamError: 'WebSocket error', uiState: 'error' }); };
+    ws.onclose = (ev) => {
+      console.log('[diag]', new Date().toISOString(), 'ws-close', 'conv=' + convId.slice(0,8), 'code=' + (ev?.code ?? '?'), 'reason=' + (ev?.reason || ''));
       const cur = states.get(convId);
       if (cur && cur.ws === ws) update(convId, { ws: null, wsOpening: null });
     };
@@ -588,6 +593,10 @@
     if (!frame || typeof frame !== 'object') return;
     const s = states.get(convId);
     if (!s) return;
+    if (frame.type !== 'text' && frame.type !== 'thinking') {
+      console.log('[diag]', new Date().toISOString(), 'frame', 'conv=' + convId.slice(0,8), 'type=' + frame.type,
+        frame.message ? ('msgId=' + String(frame.message.id || '').slice(0,16)) : '');
+    }
 
     if (frame.type === 'text') {
       appendTextOrThinking(convId, 'text', typeof frame.content === 'string' ? frame.content : '');
@@ -643,11 +652,20 @@
     if (frame.type === 'assistant_message' && frame.message) {
       update(convId, cur => {
         const phId = cur.streamingMsgId;
+        const matched = phId && cur.messages.some(m => m.id === phId);
+        console.log('[diag]', new Date().toISOString(), 'assistant_message-apply',
+          'conv=' + convId.slice(0,8),
+          'phId=' + (phId ? String(phId).slice(0,16) : 'null'),
+          'matched=' + matched,
+          'incomingId=' + String(frame.message.id || '').slice(0,16),
+          'incomingTs=' + (frame.message.timestamp || 'null'),
+          'mode=' + (phId ? 'replace-placeholder' : 'append'));
         const messages = phId
           ? cur.messages.map(m => m.id === phId ? frame.message : m)
           : [...cur.messages, frame.message];
         return { ...cur, messages, streamingMsgId: null };
       });
+      diagSnap(convId, 'assistant_message-after');
       bumpConvListActivity(convId, frame.message.timestamp);
       return;
     }
@@ -659,6 +677,10 @@
       return;
     }
     if (frame.type === 'replay_start') {
+      console.log('[diag]', new Date().toISOString(), 'replay_start',
+        'conv=' + convId.slice(0,8),
+        'bufferedEvents=' + (frame.bufferedEvents ?? '?'));
+      diagSnap(convId, 'replay_start-before');
       /* Server is about to replay the full per-conv WS buffer (ws.ts
          replayBuffer). Wipe the streaming placeholder's contentBlocks and
          any partial accumulated interaction state so the replayed frames
@@ -680,6 +702,7 @@
       return;
     }
     if (frame.type === 'replay_end') {
+      diagSnap(convId, 'replay_end-after');
       /* No-op — state was rebuilt during replay by the normal frame
          handlers; React subscribers re-render on each update. */
       return;
@@ -815,6 +838,23 @@
       : '[Uploaded files: ' + paths + ']';
   }
 
+  function diagSnap(convId, label){
+    const s = states.get(convId);
+    if (!s) { console.log('[diag]', new Date().toISOString(), label, 'conv=' + convId.slice(0,8), 'NO_STATE'); return; }
+    const last3 = (s.messages || []).slice(-3).map(m => ({
+      id: m.id ? String(m.id).slice(0,16) : null,
+      role: m.role,
+      ts: m.timestamp || null,
+      snippet: typeof m.content === 'string' ? m.content.slice(0, 50) : '[blocks]',
+    }));
+    console.log('[diag]', new Date().toISOString(), label,
+      'conv=' + convId.slice(0,8),
+      'len=' + (s.messages?.length ?? 0),
+      'streamingMsgId=' + (s.streamingMsgId ? String(s.streamingMsgId).slice(0,16) : 'null'),
+      'wsReady=' + (s.ws ? s.ws.readyState : 'no-ws'),
+      'last3=', last3);
+  }
+
   async function send(convId, text){
     const s = states.get(convId);
     if (!s || s.sending || s.streaming) return;
@@ -822,6 +862,7 @@
     const hasUploading = s.pendingAttachments.some(f => f.status === 'uploading');
     if (hasUploading) return;
     if (!text && doneAtts.length === 0) return;
+    diagSnap(convId, 'send-entry');
 
     /* Snapshot pendingAttachments and input so we can restore on POST
        failure — the files are still on the server so we don't need to
@@ -865,6 +906,7 @@
       uiState: 'streaming',
       input: '',
     }));
+    diagSnap(convId, 'send-post-optimistic');
 
     try {
       const body = { content };
@@ -1468,29 +1510,37 @@
   let lastHiddenAt = null;
 
   function revalidateAllSockets(){
+    let count = 0;
     for (const [convId, s] of states) {
       if (!s.ws) continue;
+      count++;
+      console.log('[diag]', new Date().toISOString(), 'revalidate-close', 'conv=' + convId.slice(0,8), 'wsReady=' + s.ws.readyState);
       try { s.ws.close(4000, 'revalidating'); } catch {}
       update(convId, { ws: null, wsOpening: null });
       ensureWsOpen(convId).catch(() => {});
     }
+    console.log('[diag]', new Date().toISOString(), 'revalidateAllSockets-done', 'count=' + count);
   }
 
   function handleVisibilityChange(){
     if (typeof document === 'undefined') return;
     if (document.hidden) {
       lastHiddenAt = Date.now();
+      console.log('[diag]', new Date().toISOString(), 'visibility-hidden');
       return;
     }
+    const hiddenMs = lastHiddenAt != null ? (Date.now() - lastHiddenAt) : 0;
+    console.log('[diag]', new Date().toISOString(), 'visibility-visible', 'hiddenMs=' + hiddenMs);
     /* Brief tab switches must NOT revalidate — replay_start wipes
        contentBlocks and a sub-30s away triggers needless replay churn. */
-    if (lastHiddenAt != null && (Date.now() - lastHiddenAt) >= VISIBILITY_REVALIDATE_THRESHOLD_MS) {
+    if (lastHiddenAt != null && hiddenMs >= VISIBILITY_REVALIDATE_THRESHOLD_MS) {
       revalidateAllSockets();
     }
     lastHiddenAt = null;
   }
 
   function handleOnline(){
+    console.log('[diag]', new Date().toISOString(), 'online-event');
     revalidateAllSockets();
   }
 

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -993,6 +993,7 @@ export function createChatRouter({ chatService, backendRegistry, updateService, 
     if (!content || typeof content !== 'string' || !content.trim()) {
       return res.status(400).json({ error: 'Message content required' });
     }
+    console.log(`[diag][chat] POST /message conv=${convId.slice(0,8)} contentLen=${content.length} activeStreamHas=${activeStreams.has(convId)} wsConnected=${wsFns?.isConnected(convId) ?? '?'}`);
 
     const conv = await chatService.getConversation(convId);
     if (!conv) return res.status(404).json({ error: 'Conversation not found' });
@@ -1150,6 +1151,7 @@ export function createChatRouter({ chatService, backendRegistry, updateService, 
     });
     const needsTitleUpdate = isNewSession && conv.sessionNumber > 1;
     activeStreams.set(convId, { stream, abort, sendInput, backend: backendId, needsTitleUpdate, titleUpdateMessage: needsTitleUpdate ? content.trim() : null });
+    console.log(`[diag][chat] activeStreams.set conv=${convId.slice(0,8)} backend=${backendId} userMsgId=${userMsg?.id ?? 'null'} userMsgTs=${userMsg?.timestamp ?? 'null'}`);
 
     // Always pipe the stream — if no WS is connected yet (e.g. the user
     // arrived via a stale page after a long sleep / network change), the

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -229,6 +229,7 @@ export function attachWebSocket(
   function handleConnection(ws: WebSocket, convId: string) {
     // Close any existing WS for this conversation
     const existing = activeWebSockets.get(convId);
+    const hadExisting = !!(existing && existing.readyState === WebSocket.OPEN);
     if (existing && existing.readyState === WebSocket.OPEN) {
       existing.close(1000, 'Replaced by new connection');
     }
@@ -237,10 +238,15 @@ export function attachWebSocket(
 
     // Cancel grace timer — client reconnected
     const buf = convBuffers.get(convId);
+    const hadGrace = !!buf?.graceTimer;
+    const hadCleanup = !!buf?.cleanupTimer;
     if (buf) {
       if (buf.graceTimer) { clearTimeout(buf.graceTimer); buf.graceTimer = null; }
       if (buf.cleanupTimer) { clearTimeout(buf.cleanupTimer); buf.cleanupTimer = null; }
     }
+
+    const eventTypes = buf ? buf.events.map(e => 'type' in e ? e.type : '?').join(',') : '';
+    console.log(`[diag][ws] handleConnection conv=${convId.slice(0,8)} replacedExisting=${hadExisting} bufEvents=${buf?.events.length ?? 0} hadGrace=${hadGrace} hadCleanup=${hadCleanup} activeStreamHas=${activeStreams.has(convId)} types=[${eventTypes}]`);
 
     // If there's a buffer with events, this is a reconnection — replay immediately
     if (buf && buf.events.length > 0) {
@@ -282,7 +288,9 @@ export function attachWebSocket(
       }
     });
 
-    ws.on('close', () => {
+    ws.on('close', (code, reason) => {
+      const wasActive = activeWebSockets.get(convId) === ws;
+      console.log(`[diag][ws] ws-close conv=${convId.slice(0,8)} code=${code} reason="${reason?.toString() || ''}" wasActive=${wasActive} activeStreamHas=${activeStreams.has(convId)}`);
       if (!shuttingDown) {
         console.log(`[ws] Disconnected for conv=${convId}`);
       }
@@ -318,8 +326,12 @@ export function attachWebSocket(
 
     // Send to WS if open
     const ws = activeWebSockets.get(convId);
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify(frame));
+    const wsOpen = !!(ws && ws.readyState === WebSocket.OPEN);
+    if (frame.type !== 'text' && frame.type !== 'thinking') {
+      console.log(`[diag][ws] send conv=${convId.slice(0,8)} type=${frame.type} wsOpen=${wsOpen} bufLen=${buf.events.length}`);
+    }
+    if (wsOpen) {
+      ws!.send(JSON.stringify(frame));
       return true;
     }
 
@@ -353,6 +365,11 @@ export function attachWebSocket(
 
   /** Clear the event buffer for a conversation (called before starting a new stream). */
   function clearBuffer(convId: string) {
+    const buf = convBuffers.get(convId);
+    if (buf) {
+      const types = buf.events.map(e => 'type' in e ? e.type : '?').join(',');
+      console.log(`[diag][ws] clearBuffer conv=${convId.slice(0,8)} bufLen=${buf.events.length} types=[${types}]`);
+    }
     deleteBuffer(convId);
   }
 
@@ -362,6 +379,8 @@ export function attachWebSocket(
    *  when no WS is connected at submission time (network-change recovery). */
   function startStreamGracePeriod(convId: string): void {
     const entry = activeStreams.get(convId);
+    const wsOpen = isConnected(convId);
+    console.log(`[diag][ws] startGrace conv=${convId.slice(0,8)} hasEntry=${!!entry} wsOpen=${wsOpen}`);
     if (!entry) return;
     const buf = getOrCreateBuffer(convId);
     if (buf.graceTimer) return;


### PR DESCRIPTION
## Summary
Temporary diagnostic logs to capture the exact sequence behind a bug where, after laptop sleep + network change + return, a typed message lands **before** the prior assistant reply in the chat (and any new send produces no reply until the user retypes). The earlier fix (`fix/ws-revalidate-on-network-change`) didn't address it; static analysis can't pin down the cause without seeing the live sequence.

All logs are prefixed with `[diag]`. Filter with:
- Server: `npx pm2 logs <site> | grep diag`
- Browser: Cmd-F `[diag]` in the console

## What's logged

**Client (`public/v2/src/streamStore.js`)**
- `diagSnap` helper: last-3 messages snapshot + `streamingMsgId` + WS readyState
- `send-entry` / `send-post-optimistic` around the optimistic insert
- `frame` for every WS frame received (skips `text`/`thinking` to keep noise down)
- `assistant_message-apply`: whether placeholder matched, replace vs append mode, incoming msg id + timestamp
- `assistant_message-after` snapshot
- `replay_start` / `replay_end` with buffered event count
- `ws-open` / `ws-close` / `ws-error` with code + reason
- `ensureWsOpen-new` per fresh socket
- `revalidate-close` per conv + `revalidateAllSockets-done`
- `visibility-hidden` / `visibility-visible` with hidden duration
- `online-event`
- `load-result` with persisted message count

**Server (`src/ws.ts`, `src/routes/chat.ts`)**
- `handleConnection`: `replacedExisting`, `bufEvents` count + types, `hadGrace`, `hadCleanup`, `activeStreamHas`
- `ws-close`: `code`, `reason`, `wasActive`
- `send`: `frame.type`, `wsOpen`, `bufLen` (skips text/thinking)
- `clearBuffer`: prior length + types
- `startStreamGracePeriod`: `hasEntry` + `wsOpen`
- `POST /message`: `activeStreamHas` + `wsConnected` at entry
- `activeStreams.set`: userMsg id + timestamp

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest test/chat.websocket.test.ts test/streamStore.test.ts` — 62/62 pass (Jest just complains about post-test logging on shutdown, no failures)
- [ ] Reproduce the original bug (sleep + network change) and capture both server `[diag]` logs and browser console
- [ ] Use captured logs to identify root cause; revert this branch once fix is shipped

## Notes
- These logs are **temporary**. Plan is to remove them once the root cause is identified and a real fix lands.
- No behavior changes — pure observation.