### PR TITLE
docs(kb): mark hybrid ingestion design as Implemented (closes #211)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -21,7 +21,7 @@ In-flight or pending design proposals that complement (but have not yet been fol
 
 | Document | Status | Description |
 |----------|--------|-------------|
-| [design-kb-ingestion-hybrid.md](design-kb-ingestion-hybrid.md) | Draft | Hybrid AI-assisted KB ingestion (PDF/DOCX/PPTX/image conversion at ingest time) |
+| [design-kb-ingestion-hybrid.md](design-kb-ingestion-hybrid.md) | Implemented | Hybrid AI-assisted KB ingestion (PDF/DOCX/PPTX/image conversion at ingest time) — shipped across PRs #213–#228 |
 
 ---
 

--- a/docs/design-kb-ingestion-hybrid.md
+++ b/docs/design-kb-ingestion-hybrid.md
@@ -4,10 +4,10 @@
 
 | | |
 |--|--|
-| **Status** | Draft — under design review |
+| **Status** | Implemented |
 | **Author** | Daron Yondem |
-| **Last updated** | 2026-04-26 |
-| **Implementation** | Not yet started |
+| **Last updated** | 2026-04-27 |
+| **Implementation** | Shipped across PRs #213–#228 (issue #211). All 8 design PRs landed plus follow-ups for image downscaling (#222), PPTX paragraph structure (#219), and adaptive CLI timeouts (#228). |
 
 ---
 
@@ -541,7 +541,7 @@ flowchart LR
 2. **DOCX width threshold edge cases.** 100px is the chosen cutoff for "decorative." Are there real-world charts narrower than 100px? Probably rare but worth verifying with a few sample docs.
 3. **PPTX without `convertSlidesToImages`.** Should we offer to enable it automatically when an Ingestion CLI is configured, or keep it as a separate user choice? Currently kept separate for clarity, but the dependency is awkward.
 4. **AI converter timeout per call.** ~~Current digestion uses 15 min. For per-page conversion, 2-3 min per call seems more appropriate. Make it a setting?~~ **Resolved.** Per-image timeout bumped to 10 min (`pageConversion.ts:DEFAULT_TIMEOUT_MS`); per-document digestion is now adaptive — `digestTimeoutMs = max(30 min, unitCount × 10 min)` where `unitCount` is `pageCount` (PDFs) or `slideCount` (PPTX), defaulting to the 30 min floor for handlers that don't report a unit count. Not a user-facing setting; the heuristic covers all observed inputs.
-5. **Re-digestion of existing entries.** When this design ships, should existing `pdf/rasterized` raws be auto-reingested under `pdf/rasterized-hybrid` to benefit from the new flow? Or wait for a manual user action?
+5. **Re-digestion of existing entries.** ~~When this design ships, should existing `pdf/rasterized` raws be auto-reingested under `pdf/rasterized-hybrid` to benefit from the new flow? Or wait for a manual user action?~~ **Resolved.** No auto-migration. Users re-upload manually if they want to benefit from the new hybrid flow. Existing `pdf/rasterized` raws keep their old `text.md` (image-only references) and continue to digest under the source-aware rule as `image-only`.
 
 ## 17. Future Work (Out of Scope for This Design)
 

--- a/docs/spec-data-models.md
+++ b/docs/spec-data-models.md
@@ -831,6 +831,8 @@ interface ExternalSessionEvent {
 | `EMBED_BATCH_SIZE` | 50 | dream.ts | Texts per Ollama embedding call |
 | `DREAM_TIMEOUT_MS` | 1,200,000 (20 min) | dream.ts | Per-CLI-call timeout |
 | `digestTimeoutMs` | adaptive: `max(30 min, pageCount × 10 min)` | digest.ts | Per-CLI-call timeout, scales with handler `pageCount`/`slideCount` |
+| `DEFAULT_TIMEOUT_MS` | 600,000 (10 min) | ingestion/pageConversion.ts | Per-image AI conversion timeout (one CLI call per page/slide/embedded image) |
+| `MAX_LONG_EDGE_PX` | 2576 | ingestion/pageConversion.ts | Long-edge cap (px) for images sent to vision models. Sources above this get a `.ai.png` downscaled sibling that handlers link to in `text.md` so digestion-time CLI reads also stay under the cap. |
 | `DISCOVERY_CANDIDATE_CAP` | 50 | dream.ts | Max connection candidates per run |
 | `DISCOVERY_BATCH_SIZE` | 5 | dream.ts | Candidates per discovery CLI batch |
 | `DISCOVERY_EMBEDDING_TOP_K` | 10 | dream.ts | Embedding similarity search limit |


### PR DESCRIPTION
## Summary
Doc-only closeout for issue #211 — Hybrid AI-Assisted KB Ingestion. The design shipped across 11 PRs (#213–#228); this PR updates the docs to match and closes the tracking issue.

## Changes
- **`docs/design-kb-ingestion-hybrid.md`**
  - Status header: `Draft — under design review` → `Implemented`.
  - Last updated bumped to 2026-04-27.
  - "Implementation: Not yet started" replaced with the shipped-PR list (#213–#228).
  - §16 Open question #5 (re-digesting legacy `pdf/rasterized` raws): resolved — no auto-migration; users re-upload manually if they want the new hybrid flow.
- **`docs/SPEC.md`** — Design Documents row status `Draft` → `Implemented` with the PR range.
- **`docs/spec-data-models.md`** — KB Constants table: adds `MAX_LONG_EDGE_PX` (2576) and `DEFAULT_TIMEOUT_MS` (10 min, per-image AI conversion timeout).

## Verified (no change needed)
- The §11 concurrency mermaid diagram was already updated in PR 8 (#227) to show the bounded pool + drain-barrier arrow + per-pipeline slots.
- Pipeline / PDF / PPTX / DOCX flowcharts in §3–§7 match shipped behavior.
- `WorkspaceTaskQueueRegistry` + drain-barrier + shared cliConcurrency budget already documented in `spec-backend-services.md`.
- All hybrid test files (`knowledgeBase.handlers.test.ts`, `pageConversion.test.ts`, `pdfSignals.test.ts`, `concurrency.test.ts`) already listed in `spec-testing.md`.

Closes #211