### PR TITLE
Remove goal state CommonJS fallback

### DIFF
--- a/test/goalState.test.ts
+++ b/test/goalState.test.ts
@@ -1,4 +1,11 @@
-const { cleanGoalObjectiveText, goalElapsedSeconds, goalSnapshotTimeMs, goalStatusLabel, goalSupportsAction, isActiveGoal } = require('../web/AgentCockpitWeb/src/goalState.js');
+const {
+  cleanGoalObjectiveText,
+  goalElapsedSeconds,
+  goalSnapshotTimeMs,
+  goalStatusLabel,
+  goalSupportsAction,
+  isActiveGoal,
+} = require('../web/AgentCockpitWeb/src/goalState.js');
 
 describe('goalState helpers', () => {
   test('normalizes second and millisecond goal timestamps', () => {

--- a/web/AgentCockpitWeb/src/goalState.js
+++ b/web/AgentCockpitWeb/src/goalState.js
@@ -68,7 +68,3 @@ export function goalElapsedSeconds(goal, nowMs = Date.now()){
   if (!snapshotAt) return base;
   return base + Math.max(0, Math.floor((nowMs - snapshotAt) / 1000));
 }
-
-if (typeof module !== 'undefined') {
-  module.exports = { goalTimestampMs, goalSnapshotTimeMs, cleanGoalObjectiveText, isActiveGoal, goalSupportsAction, goalStatusLabel, goalElapsedSeconds };
-}


### PR DESCRIPTION
## Summary
- remove the CommonJS `module.exports` fallback from the browser-side goal state helper
- keep the goalState Jest coverage loading the helper through the existing Jest transform
- eliminate the Vite/Rolldown CommonJS-variable warning during `web:build`

## Mobile PWA impact
No mobile code changed. Mobile typecheck and build passed.

## Validation
- npm test -- --runTestsByPath test/goalState.test.ts --runInBand
- npm run typecheck
- npm run web:typecheck
- npm run web:build
- npm run web:budget
- npm run mobile:typecheck
- npm run mobile:build
- npm run maintainability:check
- npm run spec:drift
- npm run adr:lint
- git diff --check
