### PR TITLE
docs: add public positioning guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 </p>
 
 <p align="center">
-  Run AI assistants from your browser. Keep your data. Switch vendors anytime.
+  Run CLI AI agents from your browser. Keep your context on your machine. Switch vendors without starting over.
 </p>
 
 <p align="center">
-  <em>Built for command-line AI agents like Claude Code, OpenAI Codex, and Kiro.</em>
+  <em>A local browser cockpit for Claude Code, OpenAI Codex, Kiro, and future command-line AI agents.</em>
 </p>
 
 <p align="center">
@@ -28,151 +28,169 @@
   </a>
 </p>
 
+<p align="center">
+  <a href="#quickstart"><strong>Quickstart</strong></a> &middot;
+  <a href="docs/README.md"><strong>Docs</strong></a> &middot;
+  <a href="BACKENDS.md"><strong>Backends</strong></a> &middot;
+  <a href="ONBOARDING.md"><strong>Self-hosting</strong></a> &middot;
+  <a href="docs/SPEC.md"><strong>Spec</strong></a>
+</p>
+
 ---
 
-## Why Agent Cockpit?
+## What is Agent Cockpit?
 
-When you use vendor-hosted AI interfaces — Anthropic's Claude, Amazon's Kiro, OpenAI's ChatGPT — each one builds up memory and context about you. Your conversation history, accumulated knowledge, working preferences, and the documents you've uploaded all sit inside their platform. The moment a better model ships from another provider, you can't take any of it with you. You start over.
+Agent Cockpit is an open source, local-first web UI for command-line AI agents.
+It runs on your machine, talks to local CLIs such as Claude Code, OpenAI Codex,
+and Kiro, streams their work into a browser interface, and stores your
+conversations, memory, and knowledge base on disk.
 
-Agent Cockpit decouples **your data** from **the AI vendor**. It runs on your own machine, talks to command-line AI agents, and stores every conversation, session, and knowledge-base entry locally on disk as open JSON and Markdown files. When you switch vendors, the new agent inherits everything the previous one built up — for code, for writing, for research, for whatever you use AI for.
+The core idea is simple: models and vendors will keep changing, but your working
+context should not reset every time. Agent Cockpit decouples your AI interaction
+data from the vendor interface you happen to use today.
 
-The bet is simple: vendors will keep changing, but your context shouldn't reset every time. The model is rented; the context is yours.
+## Agent Cockpit is right for you if
 
-## Who is this for?
+- You use more than one AI vendor and want a single browser interface across
+  them.
+- You want conversations, memory, knowledge-base entries, and workspace context
+  on a machine you control.
+- You want to switch from Claude Code to Codex or Kiro without losing the
+  workspace understanding built up over time.
+- You use AI for coding, writing, research, planning, operations, or other
+  knowledge work.
+- You are comfortable running a local server, or using the macOS/Windows
+  installers to manage that server for you.
 
-Agent Cockpit is for you if any of these apply:
+## Agent Cockpit is not for you if
 
-- You pay for more than one AI vendor and want a single interface across them.
-- You want your conversations, knowledge base, and accumulated context on **your own machine**, not in a vendor's cloud.
-- You want to switch vendors without losing history — because models keep getting better and lock-in keeps getting worse.
-- You use AI for more than coding: research, writing, knowledge work, decision-making, running your day.
-- You're comfortable self-hosting (Node.js, a server you control, optional tunnel for remote access).
+- You want a hosted SaaS with no local setup.
+- You only use one vendor and do not care about context portability.
+- You want Agent Cockpit to replace vendor CLIs. It wraps those CLIs; it does
+  not reimplement them.
+- You want a multi-agent company or task-orchestration system. Agent Cockpit is
+  a personal/local cockpit for interacting with AI agents you invoke.
 
-It is **not** a hosted SaaS. If you want zero-setup, this isn't it. If you only ever use one vendor and never plan to switch, you don't need it.
+## Without and With Agent Cockpit
 
-## What it does
+| Without Agent Cockpit | With Agent Cockpit |
+| --- | --- |
+| AI work is scattered across terminal tabs and vendor apps. | Claude Code, Codex, and Kiro run from one browser UI. |
+| Each vendor owns its own memory and history. | Conversations, memory, KB, and Context Map live locally. |
+| Switching vendors means starting over. | Provider-neutral workspace context follows the next backend. |
+| Remote access requires SSHing into a terminal. | Use the desktop web UI or mobile PWA through your own secure access path. |
+| Tool output and generated files are buried in stream logs. | Tool activity, artifacts, file delivery, and session state are shown in the UI. |
 
-Three things, at the core:
+## Core Capabilities
 
-### 1. Unified interface across AI vendors
-Use Claude Code, OpenAI Codex, and Kiro from a single browser-based UI. Switch backends per conversation. Pick the model, set the reasoning effort, and keep your workflow consistent regardless of which vendor you're using.
+**Unified CLI interface**
+Run Claude Code, OpenAI Codex, and Kiro from a browser-based chat surface. Switch
+backends per conversation while keeping the same workspace and interaction
+model.
 
-### 2. Your data stays on your disk
-Every conversation, session, memory snapshot, and knowledge-base entry is stored locally as open JSON or Markdown. No vendor cloud, no proprietary database, no lock-in. If you stop using Agent Cockpit tomorrow, your data is still right there in plain files.
+**Local open storage**
+Conversation files, session metadata, settings, memory snapshots, and
+knowledge-base artifacts are stored under your local data directory as
+JSON/Markdown plus local indexes where search requires them.
 
-### 3. Context is portable across vendors
-The integrated memory system snapshots every change to a CLI's memory file. Cross-CLI instruction compatibility keeps `CLAUDE.md`, `AGENTS.md`, and Kiro steering files in sync. The knowledge base and the workspace Context Map feed structured context to whichever vendor you ask next. Switching backends doesn't reset your context — your accumulated knowledge follows you.
+**Portable workspace context**
+Workspace Memory, Knowledge Base, instruction compatibility checks, and Context
+Map help each backend see the same durable context instead of rebuilding it from
+scratch.
 
-## The Knowledge Base
+**Knowledge Base**
+Upload PDFs, Word documents, PowerPoints, images, CSV/TSV files, Markdown, and
+text-like files into a per-workspace knowledge base. Agent Cockpit converts,
+extracts, organizes, and retrieves that material for later conversations.
 
-The KB is the longest-lived part of Agent Cockpit. While conversations come and go, the KB accumulates everything you want your AI to know about — in your files, on your disk, queryable by any vendor you point at it.
+**Context Map**
+Context Map builds a governed workspace graph of important people, projects,
+services, decisions, documents, and relationships. The active CLI can read a
+compact context pack through MCP tools instead of receiving a prompt dump.
 
-Upload PDFs, Word documents, PowerPoints, images, CSV/TSV files, Markdown, and text-like files into a per-workspace knowledge base. Agent Cockpit converts and analyzes each file, extracts structured entries, organizes them into synthesized topics, discovers connections between ideas, and surfaces topic/reflection readers that your AI agents can search and reason over during conversations.
+**Real-time agent view**
+Responses stream live with tool calls, sub-agents, thinking, outcomes, progress
+state, draft persistence, plan-mode approvals, interactive questions, and
+reconnection recovery.
 
-Use it for code documentation. Use it for board prep. Use it for personal reading notes. Use it for whatever you want to be able to ask an AI about later — and have the answer grounded in *your* sources.
+**Mobile PWA**
+The supported mobile client is served from the same backend at `/mobile/`, so
+you can monitor and steer work from a phone without a native app.
 
-## The Context Map
-
-The Context Map is the workspace-level graph that tracks the important entities in a workspace — people, projects, services, documents, decisions — the relationships between them, and the evidence that supports each conclusion. It runs asynchronously in the background, scans high-signal workspace files and conversation history, and surfaces a governed graph you can review and curate from workspace settings.
-
-When the active CLI needs to ground a turn, it can read the graph through read-only MCP tools: matching entities, related entities, and a compact context pack of pointers, summaries, and evidence — instead of dumping every memory or KB document into the prompt.
-
-Context Map is separate from Memory and the Knowledge Base, enabled per workspace, and disabled by default. See [docs/spec-context-map.md](docs/spec-context-map.md) for the full feature specification.
+**Self-update and first-party auth**
+Production installs update from GitHub Releases. Dev installs update from
+`main`. A first-party local owner account protects access, with password login,
+passkeys, recovery codes, and optional legacy OAuth compatibility.
 
 ## Supported Backends
 
 | Backend | CLI | Status |
-|---------|-----|--------|
+| --- | --- | --- |
 | **Claude Code** | `claude` | Fully supported |
-| **Kiro** | `kiro-cli` | Fully supported |
 | **OpenAI Codex** | `codex` | Fully supported |
+| **Kiro** | `kiro-cli` | Fully supported |
 
-Switch between backends per-conversation using the dropdown in the chat input area. Your selected backend is remembered for new conversations.
-
-See [BACKENDS.md](BACKENDS.md) for a comparison of feature support across backends.
-
-## How it gets used
-
-Agent Cockpit is the substrate. The real value comes from the patterns you build on top of it. A few examples:
-
-- **Personal knowledge work.** Ingest your reading list, meeting notes, and research into the KB. Ask any AI agent to reason over them. Switch agents based on which model handles your question best.
-- **Multi-vendor coding.** Run Claude Code on the hard problem, switch to Codex for fast iteration, use Kiro for spec work. Same workspace, same files, same accumulated memory.
-- **Persona profiles for the people you work with.** One conversation per person. Add context about them over time. Use it to prep for the next interaction — without ever sending those notes to a vendor's cloud.
-- **Workflow execution from a tablet.** Give the CLI full filesystem access on a server you control, then describe a workflow in plain language. Let the agent run it on the host machine while you watch the stream from your phone.
-
-These aren't features the tool conceptualizes — they're patterns the substrate enables. The tool is the runway; what you take off with is up to you.
+See [BACKENDS.md](BACKENDS.md) and [docs/user/backends.md](docs/user/backends.md)
+for feature differences, auth notes, and setup guidance.
 
 ## How It Works
 
-Agent Cockpit runs on the same machine as your CLI tools. When you send a message through the browser, the server spawns a CLI process locally, streams the response back over WebSocket, and stores the conversation as a JSON file on disk. The CLI runs with full access to your local filesystem and tools, just as it would in your terminal.
+Agent Cockpit runs on the same machine as your CLI tools. When you send a
+message through the browser, the server starts or connects to the selected local
+backend, streams events over WebSocket, records the conversation under the
+current workspace, and exposes generated files through the authenticated UI.
 
-This means:
-- **The CLI and the web interface must run on the same machine.** Agent Cockpit spawns local processes, not remote API calls.
-- **Expose the server for remote access.** Use a tunnel like [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) to chat with your coding agents from any browser, anywhere, while they operate on your local files and environment.
-- **First-party owner auth protects access.** Create one local owner account per Agent Cockpit server; exposed first-run setup can be guarded with `AUTH_SETUP_TOKEN`.
+This has three important consequences:
 
-## Also included
-
-Beyond the core, Agent Cockpit also ships with:
-
-- **Real-time streaming** — responses stream live via WebSocket with automatic reconnection and state recovery
-- **Agent & tool visualization** — sub-agents, tool calls, thinking, and outcomes shown in real time with grouped activity panels and a compact progress timeline that collapses intermediate turns
-- **Multi-workspace support** — conversations are organized by workspace directory, each with its own system prompt and per-workspace memory and knowledge-base toggles
-- **Instruction compatibility checks** — composer notification warns when `AGENTS.md`, `CLAUDE.md`, or Kiro steering files are out of sync across supported CLI vendors, with one-click pointer creation
-- **Conversation management** — create, rename, search, archive, mark unread, and delete conversations grouped by workspace
-- **Session management** — reset CLI sessions and view session history with LLM-generated summaries
-- **Auto-generated titles** — conversation titles are generated automatically from the first message
-- **Draft persistence** — unsent messages and attached files are preserved across conversation switches and survive session expiry mid-send
-- **Plan mode and interactive questions** — approve plans and answer questions from the CLI directly in the browser, with the approval UI preserved across reconnects
-- **CLI file delivery** — files emitted by the CLI appear inline as cards with a download button and an in-browser viewer
-- **Browser tab status indicator** — favicon dot shows when a task is still running so you can flip away and check back
-- **Per-CLI context tooltip** — hover the context chip to see what the active backend reports (tokens vs. credits/percentage), including a projected end-of-cycle usage status when the backend exposes a renewing quota window
-- **Dark and light themes** — system-aware theme with manual override
-- **First-party authentication** — local owner setup, password login, passkeys, recovery codes, and optional legacy OAuth compatibility
-- **Mobile PWA** — installable mobile web client served from `/mobile/` by the same authenticated backend
-- **Self-update** — check for updates and apply them from the UI with one click; production installs update from GitHub Releases, dev installs update from `main`
-- **Pluggable backend system** — extensible adapter architecture for adding new CLI backends
-- **Graceful shutdown** — clean process cleanup on SIGTERM/SIGINT
-- **Local open storage** — conversations, sessions, settings, memory, and knowledge-base artifacts stay on disk as JSON/Markdown plus embedded SQLite/PGLite indexes where structured search requires them (no hosted database)
+- The CLI and the web interface must run on the same machine.
+- Remote access is your responsibility. Use a private network, tunnel, or
+  reverse proxy you control.
+- The CLIs keep their normal vendor authentication. Agent Cockpit does not host
+  or proxy model inference.
 
 ## Prerequisites
 
-- Node.js 22+ (declared in `engines`) for manual development installs. The
-  macOS and Windows release installers can install a private Node.js runtime
-  automatically when Node/npm are missing.
+- Node.js 22+ for manual development installs. The macOS and Windows release
+  installers can install a private Node.js runtime automatically when Node/npm
+  are missing.
 - At least one CLI backend installed and authenticated on the same machine:
-  - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (`claude`)
+  - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code)
+    (`claude`)
+  - [OpenAI Codex CLI](https://github.com/openai/codex) (`codex`, install with
+    `npm install -g @openai/codex`)
   - [Kiro CLI](https://kiro.dev) (`kiro-cli`)
-  - [OpenAI Codex CLI](https://github.com/openai/codex) (`codex`, install with `npm install -g @openai/codex`)
-- (Optional) [LibreOffice](https://www.libreoffice.org/) and/or [Pandoc](https://pandoc.org/) on `PATH` to expand Knowledge Base ingestion to Office and other document formats
-- (Optional) [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) or a similar tunnel for remote access — see [ONBOARDING.md](ONBOARDING.md) for a step-by-step self-hosting guide with PM2 and Cloudflare Tunnel
+- Optional: [LibreOffice](https://www.libreoffice.org/) and/or
+  [Pandoc](https://pandoc.org/) on `PATH` for broader Knowledge Base document
+  conversion.
+- Optional: [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/),
+  Tailscale, or a similar access path for remote browser/mobile use.
 
-## Mac Install
+## Quickstart
+
+### macOS Production Install
 
 The recommended production path on macOS is the release installer. It downloads
 the latest GitHub Release, verifies checksums, installs dependencies, writes
-local runtime config, starts Agent Cockpit through local PM2, and opens first-run
-owner setup in the browser.
+local runtime config, starts Agent Cockpit through local PM2, and opens
+first-run owner setup in the browser.
 
 ```bash
 curl -fsSL https://github.com/daronyondem/agent-cockpit/releases/latest/download/install-macos.sh -o /tmp/install-agent-cockpit.sh
 bash /tmp/install-agent-cockpit.sh --channel production
 ```
 
-Production installs update from GitHub Releases. Dev installs track `main`:
+Dev installs track `main`:
 
 ```bash
 bash /tmp/install-agent-cockpit.sh --channel dev
 ```
 
-## Windows Install
+### Windows Production Install
 
 The supported Windows production path is a per-user PowerShell installer. It
-installs under `%LOCALAPPDATA%\Agent Cockpit`, verifies GitHub Release
-checksums, installs a private Node.js runtime when needed, uses install-local
-PM2 state, registers a current-user logon scheduled task, starts Agent Cockpit,
-runs the managed Node process in the background without a visible console window,
-and opens first-run owner setup in the browser.
+installs under `%LOCALAPPDATA%\Agent Cockpit`, uses install-local PM2 state,
+registers a current-user logon scheduled task, starts Agent Cockpit in the
+background, and opens first-run owner setup in the browser.
 
 ```powershell
 powershell -ExecutionPolicy Bypass -NoProfile -Command "iwr https://github.com/daronyondem/agent-cockpit/releases/latest/download/install-windows.ps1 -OutFile $env:TEMP\install-agent-cockpit.ps1; & $env:TEMP\install-agent-cockpit.ps1 -Channel production"
@@ -184,81 +202,32 @@ Dev installs track `main`:
 & $env:TEMP\install-agent-cockpit.ps1 -Channel dev
 ```
 
-The Windows installer is intentionally user-logon based. It does not install a
-Windows Service and does not run before any Windows user has logged in.
-When the welcome screen installs Claude Code or Codex on Windows, it installs
-the CLI into Agent Cockpit's per-user `cli-tools` prefix and Agent Cockpit runs
-the installed package entrypoint directly before falling back to npm command
-shims. Agent Cockpit also adds that `cli-tools` prefix to the current user's
-Windows `Path`, so new PowerShell or terminal windows can run `claude` and
-`codex`. Welcome-screen Claude/Codex login uses the same vendor CLI auth home as
-those terminal commands, so Agent Cockpit and the terminal share login state. No
-global Node/npm/PM2 install is required. If Claude Code or Codex was
-already installed outside Agent Cockpit, the Windows resolver still detects the
-user's existing PATH command.
-
-## Developer Quick Start
-
-1. Clone the repository and install dependencies:
+### Developer Quick Start
 
 ```bash
 git clone https://github.com/daronyondem/agent-cockpit.git
 cd agent-cockpit
 npm install
-```
-
-2. Copy `.env.example` to `.env` and fill in your values:
-
-```bash
 cp .env.example .env
-```
-
-3. Start the server:
-
-```bash
 npm start
 ```
 
-4. Open `http://localhost:3334` in your browser and create the first local owner account.
+Open `http://localhost:3334` in your browser and create the first local owner
+account. For persistent local server management, use PM2 as documented in
+[ONBOARDING.md](ONBOARDING.md).
 
-## Environment Variables
+## Authentication and Security
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `PORT` | No | `3334` | Server listen port |
-| `SESSION_SECRET` | Yes | — | Secret for signing session cookies |
-| `AGENT_COCKPIT_DATA_DIR` | No | `data` | Mutable data root for chat data, sessions, auth state, plan usage, install manifest, and update restart artifacts. The macOS production installer sets this outside the replaceable app release directory. |
-| `AUTH_DATA_DIR` | No | `data/auth` | First-party owner auth state directory |
-| `AUTH_SETUP_TOKEN` | Recommended for remote setup | — | Token required to create the first owner account from a non-localhost request |
-| `AUTH_ENABLE_LEGACY_OAUTH` | No | `false` | Set to `true` to register legacy Google/GitHub OAuth routes |
-| `GOOGLE_CLIENT_ID` | No | — | Legacy Google OAuth client ID, used only when legacy OAuth is enabled |
-| `GOOGLE_CLIENT_SECRET` | No | — | Legacy Google OAuth client secret, used only when legacy OAuth is enabled |
-| `GOOGLE_CALLBACK_URL` | No | — | Legacy Google OAuth callback URL, used only when legacy OAuth is enabled |
-| `GITHUB_CLIENT_ID` | No | — | Legacy GitHub OAuth client ID, used only when legacy OAuth is enabled |
-| `GITHUB_CLIENT_SECRET` | No | — | Legacy GitHub OAuth client secret, used only when legacy OAuth is enabled |
-| `GITHUB_CALLBACK_URL` | No | — | Legacy GitHub OAuth callback URL, used only when legacy OAuth is enabled |
-| `ALLOWED_EMAIL` | No | — | Legacy OAuth allowed-email list |
-| `DEFAULT_WORKSPACE` | No | `~/.openclaw/workspace` | Default working directory for CLI processes |
-| `BASE_PATH` | No | `''` | URL base path for reverse proxy deployments |
-| `KIRO_ACP_IDLE_TIMEOUT_MS` | No | `3600000` | Idle timeout (ms) before killing the Kiro ACP process |
-| `CODEX_IDLE_TIMEOUT_MS` | No | `600000` | Idle timeout (ms) before killing the Codex `app-server` process |
-| `CODEX_APPROVAL_POLICY` | No | `never` | Codex approval policy for interactive threads (`untrusted`, `on-failure`, `on-request`, `never`). The default treats Agent Cockpit as a trusted local agent and does not ask before Codex runs tools. |
-| `CODEX_SANDBOX_MODE` | No | `danger-full-access` | Codex sandbox mode for interactive threads (`read-only`, `workspace-write`, `danger-full-access`). The default gives Codex full local filesystem/tool access through Agent Cockpit; set this and `CODEX_APPROVAL_POLICY` to stricter values for restricted deployments. |
-| `LOG_LEVEL` | No | `info` | Server log threshold: `error`, `warn`, `info`, or `debug`. Structured logger metadata redacts secret-like keys before writing to stdout/stderr. |
+Agent Cockpit uses one first-party local owner account by default. No GitHub,
+Google, Apple ID, or Cloudflare Access login is required for the normal
+self-hosted flow.
 
-## Authentication Setup
+On first run, open `/auth/setup` and create the owner account. If the backend is
+exposed through a tunnel before setup, set `AUTH_SETUP_TOKEN` and enter that
+token on the setup page so a remote visitor cannot claim the empty backend.
 
-Agent Cockpit uses one first-party local owner account by default. No GitHub, Google, Apple ID, or Cloudflare Access login is required for the normal self-hosted flow.
-
-On first run, open `/auth/setup` and create the owner account with an email, display name, and password of at least 12 characters. If the backend is exposed through a tunnel before setup, set `AUTH_SETUP_TOKEN` and enter that token on the setup page so a remote visitor cannot claim the empty backend.
-
-After setup, open **Settings > Security** to:
-
-- Register one or more passkeys.
-- Generate recovery codes and store them somewhere safe.
-- Enable **Require passkey for login** after at least one passkey and one unused recovery code exist.
-
-Passkeys are tied to the backend domain. If you move from one host to another, for example from `chat-dev.example.com` to `chat.example.com`, register a passkey while signed in on the new domain.
+After setup, open **Settings > Security** to register passkeys, generate
+recovery codes, and optionally require passkey login.
 
 For local lockout recovery, run this on the backend machine:
 
@@ -266,152 +235,38 @@ For local lockout recovery, run this on the backend machine:
 npm run auth:reset -- --password "new long password" --disable-passkey-required --revoke-sessions --regenerate-recovery-codes
 ```
 
-The reset command requires local filesystem access. It can reset the owner password, disable passkey-required mode, revoke sessions, and print replacement recovery codes.
+## Documentation
 
-### Legacy OAuth
+Start with [docs/README.md](docs/README.md).
 
-Google/GitHub OAuth is legacy-only and disabled by default. Set `AUTH_ENABLE_LEGACY_OAUTH=true` only if you need the old provider routes temporarily, then configure the provider client id, client secret, callback URL, and `ALLOWED_EMAIL`.
+- [User Guide](docs/user/README.md) covers daily use, backends, Memory,
+  Knowledge Base, Context Map, and mobile PWA.
+- [Deploy Guide](docs/deploy/README.md) covers macOS, Windows, remote access,
+  auth, updates, and troubleshooting.
+- [Reference](docs/reference/README.md) covers data layout, environment
+  variables, backend capabilities, development, and tests.
+- [Specification](docs/SPEC.md) is the full implementation source of truth.
 
-## Remote Access with Cloudflare Tunnel
+## Contributing
 
-To access Agent Cockpit from outside your local network, use [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/):
+For implementation work, read [AGENTS.md](AGENTS.md) and
+[docs/SPEC.md](docs/SPEC.md). This repo keeps user docs, technical specs, and
+ADRs in source control.
 
-```bash
-cloudflared tunnel --url http://localhost:3334
-```
-
-Use the tunnel-provided URL to reach your local Agent Cockpit from any device. For a fresh exposed backend, set `AUTH_SETUP_TOKEN` before creating the owner account.
-
-## Mobile PWA
-
-The supported mobile client is served by the same backend at `/mobile/`. Open `https://<your-host>/mobile/` on the phone, sign in with the normal owner account, then use the browser's Add to Home Screen flow. The server rebuilds stale mobile assets into ignored `public/mobile-built/` during startup and self-update; `npm run mobile:build` remains the explicit local check.
-
-The PWA uses the same authenticated web session as the desktop UI. Xcode, Expo Go, TestFlight, App Store distribution, and native app pairing are not part of the supported mobile path.
-
-## Project Structure
-
-```
-agent-cockpit/
-├── server.ts                 # Express server entry point (TypeScript, run via tsx)
-├── src/
-│   ├── ws.ts                 # WebSocket server (streaming, reconnection, state recovery)
-│   ├── contracts/            # Shared API request/response contracts and validators
-│   ├── types/index.ts        # Shared type definitions
-│   ├── config/index.ts       # Environment configuration
-│   ├── middleware/
-│   │   ├── auth.ts           # First-party owner auth, legacy OAuth, login routes
-│   │   ├── csrf.ts           # CSRF token generation and validation
-│   │   └── security.ts       # Helmet CSP configuration
-│   ├── routes/chat.ts        # Chat API composition root
-│   ├── routes/chat/          # Focused chat route modules and shared route utilities
-│   ├── utils/logger.ts       # Structured logger with level filtering and metadata redaction
-│   └── services/
-│       ├── localAuthStore.ts # First-party auth state, passkeys, recovery codes
-│       ├── backends/
-│       │   ├── base.ts           # Base adapter interface for CLI backends
-│       │   ├── claudeCode.ts     # Claude Code CLI adapter
-│       │   ├── kiro.ts           # Kiro CLI adapter (ACP protocol)
-│       │   ├── codex.ts          # Codex CLI adapter (Codex App Server protocol)
-│       │   ├── toolUtils.ts      # Shared tool helpers across backends
-│       │   └── registry.ts       # Backend registry (pluggable adapter system)
-│       ├── knowledgeBase/    # KB ingestion, digestion, dreaming, embeddings, vector store
-│       ├── memoryMcp/        # Memory MCP server (notes from CLI tools)
-│       ├── kbSearchMcp/      # Knowledge-base search MCP server
-│       ├── chatService.ts    # Conversation CRUD, messages, sessions, workspaces, KB/memory state
-│       ├── chat/             # Focused ChatService helper modules
-│       ├── memoryWatcher.ts  # Watches CLI memory files for snapshot capture
-│       ├── settingsService.ts # User settings persistence
-│       ├── updateService.ts  # Self-update: dev git/main path and production GitHub Release path
-│       ├── webBuildService.ts # V2 web asset build preflight
-│       └── mobileBuildService.ts # Mobile PWA asset build preflight
-├── public/
-│   ├── v2/                   # Retired Browser-Babel placeholders for ADR path stability
-│   ├── v2-built/             # Ignored Vite output served at /v2/
-│   └── mobile-built/         # Ignored mobile PWA output served at /mobile/
-├── web/
-│   └── AgentCockpitWeb/      # Source for the Vite React V2 web UI
-├── mobile/
-│   └── AgentCockpitPWA/      # Source for the Vite React mobile PWA
-├── docs/                     # Wiki-style specification (see SPEC.md)
-├── scripts/                  # Repository maintenance helpers
-│   └── auth-reset.ts         # Local owner-account recovery command
-├── test/                     # Jest test suites
-└── data/                     # Runtime data (gitignored)
-    ├── chat/
-    │   ├── workspaces/{hash}/  # Workspace-scoped storage
-    │   │   ├── index.json      # Conversations + session metadata
-    │   │   ├── {convId}/       # Session files per conversation
-    │   │   ├── memory/         # Per-workspace memory snapshots + notes
-    │   │   ├── knowledge/      # Per-workspace KB raw/converted/entries/synthesis
-    │   │   ├── context-map/    # Per-workspace graph state and candidates
-    │   │   └── session-finalizers.json # Durable reset/archive background jobs
-    │   ├── stream-jobs.json    # Durable active-stream supervision registry
-    │   ├── usage-ledger.json   # Daily backend/model usage totals
-    │   ├── artifacts/          # Per-conversation uploaded files
-    │   └── settings.json       # User settings
-    └── sessions/               # Express session files
-```
-
-## Testing
-
-Tests use Jest and run with:
+Useful verification commands:
 
 ```bash
+npm run typecheck
 npm test
+npm run maintainability:check
+npm run spec:drift
 ```
 
-Tests cover ChatService CRUD/messaging/sessions, backend adapter system (registry, ClaudeCodeAdapter, KiroAdapter, CodexAdapter, tool utilities), chat route integration (streaming, reconnection, options passthrough), graceful shutdown (SIGINT/SIGTERM), session file-store persistence, draft state persistence, message queuing, self-update service, first-party auth and legacy OAuth flows, settings service, browser tab indicator, V2 bundle budget checks, mobile PWA static serving, memory MCP and watcher, and the full Knowledge Base pipeline (ingestion, digestion, dreaming, embeddings, vector store, folders, multi-location, handlers).
-
-CI runs tests automatically on every pull request against `main` via GitHub Actions. Version bumps are automated on merge to `main`.
-
-## Backend-Specific Notes
-
-### Kiro CLI
-
-Kiro connects via ACP (Agent Client Protocol) — JSON-RPC 2.0 over stdin/stdout. The adapter handles:
-- Lazy process spawning with idle timeout (configurable via `KIRO_ACP_IDLE_TIMEOUT_MS`)
-- Automatic session creation, loading, and resume across server restarts
-- Sub-agent tracking with grouped tool activity visualization
-- Permission auto-approval for all tool calls
-
-Ensure `kiro-cli` is installed and authenticated before selecting Kiro as a backend.
-
-### OpenAI Codex CLI
-
-Codex connects via the Codex App Server protocol — JSON-RPC 2.0 over stdin/stdout (a separate transport from ACP, but conceptually similar). The adapter handles:
-- Lazy `codex app-server` process spawning per conversation with idle timeout (configurable via `CODEX_IDLE_TIMEOUT_MS`, default 10 min)
-- Automatic thread creation, resume across server restarts, and `turn/interrupt` for aborts
-- Mid-turn user input via `turn/steer`
-- Interactive user questions via `item/tool/requestUserInput` (gated behind Codex's `default_mode_request_user_input` experimental flag — wired but dormant until enabled)
-- Full subagent thread demultiplexing — child threads spawned via `spawn_agent` render nested under their parent Agent card with their own live tool activity, matching Claude Code's behavior
-- MCP server injection via `-c mcp_servers.<name>.{command,args,env}=…` overrides at spawn time, so your real `~/.codex/` is used unchanged for auth, sessions, and config
-- Per-turn token usage tracking via `thread/tokenUsage/updated`
-- Permission auto-approval for all tool calls and patches
-- Full local filesystem/tool access by default through `CODEX_APPROVAL_POLICY=never` and `CODEX_SANDBOX_MODE=danger-full-access`
-
-Ensure `codex` is installed (`npm install -g @openai/codex`) and authenticated (`codex login` or `OPENAI_API_KEY`) before selecting Codex as a backend.
-
-## Adding a New Backend
-
-Agent Cockpit's pluggable adapter system makes it straightforward to add new CLI backends:
-
-1. Create `src/services/backends/myBackend.ts` extending `BaseBackendAdapter`
-2. Implement `metadata`, `sendMessage()`, `generateSummary()`, and optionally `generateTitle()`, `shutdown()`, `onSessionReset()`
-3. Import shared helpers from `toolUtils.ts` (never import from another adapter)
-4. Register in `server.ts` — no other file changes needed
-
-See [docs/SPEC.md](docs/SPEC.md) for the full adapter contract and stream event protocol.
-
-## Roadmap
-
-Agent Cockpit supports Claude Code, Kiro, and OpenAI Codex as its first three backends. As vendors release more CLI-based coding agents, Agent Cockpit will add adapters so you can use them all from a single interface while keeping your data portable.
-
-## Specification
-
-See [docs/SPEC.md](docs/SPEC.md) for a complete technical specification covering every API endpoint, data model, frontend behavior, security mechanism, and implementation detail. The root `SPEC.md` is a thin redirect — all content lives under `docs/`.
+Before production releases, follow [docs/release-workflow.md](docs/release-workflow.md).
 
 ## License
 
 Copyright 2026 Daron Yondem.
 
-Agent Cockpit is licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE).
+Agent Cockpit is licensed under the Apache License, Version 2.0. See
+[LICENSE](LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,55 @@
+# Agent Cockpit Documentation
+
+Agent Cockpit is a local browser cockpit for CLI-based AI agents. It gives you a
+browser interface for Claude Code, OpenAI Codex, and Kiro while keeping
+conversations, memory, knowledge-base material, and workspace context on your
+machine.
+
+Use this page as the public documentation entry point. The implementation
+specification remains in [SPEC.md](SPEC.md).
+
+## User Guide
+
+Start here if you are installing or using Agent Cockpit.
+
+- [User Guide](user/README.md)
+- [Quickstart](user/quickstart.md)
+- [Supported backends](user/backends.md)
+- [Memory](user/memory.md)
+- [Knowledge Base](user/knowledge-base.md)
+- [Context Map](user/context-map.md)
+- [Mobile PWA](user/mobile-pwa.md)
+
+## Deploy Guide
+
+Use these docs when setting up, exposing, updating, or troubleshooting the local
+server.
+
+- [Deploy Guide](deploy/README.md)
+- [macOS install](deploy/macos.md)
+- [Windows install](deploy/windows.md)
+- [Remote access](deploy/remote-access.md)
+- [Security and owner auth](deploy/security.md)
+- [Install Doctor](deploy/install-doctor.md)
+- [Updates](deploy/updates.md)
+
+## Reference
+
+Technical reference for advanced users and contributors.
+
+- [Reference](reference/README.md)
+- [Environment variables](reference/environment-variables.md)
+- [Data layout](reference/data-layout.md)
+- [Backend capabilities](reference/backend-capabilities.md)
+- [Development](reference/development.md)
+- [Testing](reference/testing.md)
+
+## Project Sources Of Truth
+
+- [Specification](SPEC.md) describes implemented behavior.
+- [Architecture Decision Records](adr/README.md) describe major decisions and
+  rejected alternatives.
+- [Product positioning](product-positioning.md) defines public message
+  architecture.
+- [Release workflow](release-workflow.md) describes production release
+  preparation.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -30,6 +30,19 @@ Design and planning documents that preserve product intent, implementation plans
 | [design-kb-ingestion-hybrid.md](design-kb-ingestion-hybrid.md) | Implemented | Hybrid AI-assisted KB ingestion (PDF/DOCX/PPTX/image conversion at ingest time) — shipped across PRs #213–#228 |
 | [design-kb-vnext-implementation-plan.md](design-kb-vnext-implementation-plan.md) | Proposed | Phased Knowledge Base vNext plan: document structure, chunked digestion, gleaning, glossary expansion, graph retrieval, synthesis history, and pipeline visualization |
 
+### Public Documentation
+
+User-facing documentation explains how to install, configure, and operate Agent
+Cockpit without reading the implementation specification:
+
+| Document | Description |
+|----------|-------------|
+| [README.md](README.md) | Public docs entry point that routes to user, deploy, and reference guides. |
+| [user/README.md](user/README.md) | User guide for quickstart, backends, Memory, Knowledge Base, Context Map, and mobile PWA. |
+| [deploy/README.md](deploy/README.md) | Deploy guide for platform installers, remote access, security, Install Doctor, and updates. |
+| [reference/README.md](reference/README.md) | Technical reference for environment variables, data layout, backend capabilities, development, and testing. |
+| [product-positioning.md](product-positioning.md) | Public-copy message architecture for keeping positioning provider-neutral and user-owned-context focused. |
+
 ### Notes & Findings
 
 Engineering notes that capture empirical findings — not proposals or specs, but durable knowledge worth preserving:

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -1,0 +1,30 @@
+# Agent Cockpit Deploy Guide
+
+Agent Cockpit is a local server application. The production installers set up
+that server, write runtime config, start PM2, and open first-run owner setup.
+
+## Install
+
+- [macOS install](macos.md)
+- [Windows install](windows.md)
+- [Development setup](../reference/development.md)
+
+## Configure Access
+
+- [Security and owner auth](security.md)
+- [Remote access](remote-access.md)
+
+## Maintain
+
+- [Install Doctor](install-doctor.md)
+- [Updates](updates.md)
+- [Environment variables](../reference/environment-variables.md)
+- [Data layout](../reference/data-layout.md)
+
+## Important Deployment Boundaries
+
+- Agent Cockpit runs on the same machine as the vendor CLIs.
+- The normal production path is a local server, not hosted SaaS.
+- The first owner account should be created before exposing the server. If it
+  must be exposed first, configure `AUTH_SETUP_TOKEN`.
+- PM2 is the supported process manager for persistent local server operation.

--- a/docs/deploy/install-doctor.md
+++ b/docs/deploy/install-doctor.md
@@ -1,0 +1,64 @@
+# Install Doctor
+
+Install Doctor is the setup diagnostic surface used by the welcome flow and
+install-state APIs. It checks whether the local Agent Cockpit install has the
+runtime, process manager, build assets, optional backend CLIs, and optional
+document tools needed for the selected workflows.
+
+## Where It Appears
+
+The desktop welcome screen reads Install Doctor status after owner setup. It
+groups checks into required install readiness, backend CLIs, optional document
+tools, mobile build status, update-channel metadata, and platform-specific
+startup checks.
+
+The API endpoint is:
+
+```text
+GET /api/chat/install/doctor
+```
+
+## Required Checks
+
+Required checks include:
+
+- Node.js 22+ or an installer-managed private runtime;
+- npm;
+- local PM2;
+- writable data directory;
+- desktop web build presence.
+
+Required failures make the install status an error.
+
+## Optional Checks
+
+Optional checks include:
+
+- Claude Code CLI;
+- OpenAI Codex CLI;
+- Kiro CLI;
+- Pandoc;
+- LibreOffice;
+- mobile PWA build;
+- update-channel metadata;
+- Windows logon startup registration.
+
+Missing optional tools produce warnings, not hard install failures. Users only
+need to install the backend CLIs and document tools they plan to use.
+
+## Assisted Actions
+
+Some checks expose allowlisted install actions. The browser never sends shell
+command text to the server. It sends an action id, and the server runs the
+predefined command when no active conversation is running.
+
+On Windows, Claude Code and Codex install actions use Agent Cockpit's per-user
+`cli-tools` prefix and the installer-recorded private Node runtime when present.
+That keeps the welcome flow independent of global Node/npm/PM2 installs.
+
+## Related Specs
+
+- [API endpoints](../spec-api-endpoints.md)
+- [Frontend behavior](../spec-frontend.md)
+- [Backend services](../spec-backend-services.md)
+- [Testing](../spec-testing.md)

--- a/docs/deploy/macos.md
+++ b/docs/deploy/macos.md
@@ -1,0 +1,45 @@
+# macOS Install
+
+The recommended production path on macOS is the release installer. It downloads
+the latest GitHub Release, verifies checksums, installs dependencies, writes
+local runtime config, starts Agent Cockpit through local PM2, and opens
+first-run owner setup in the browser.
+
+```bash
+curl -fsSL https://github.com/daronyondem/agent-cockpit/releases/latest/download/install-macos.sh -o /tmp/install-agent-cockpit.sh
+bash /tmp/install-agent-cockpit.sh --channel production
+```
+
+## Dev Channel
+
+Dev installs track `main`:
+
+```bash
+bash /tmp/install-agent-cockpit.sh --channel dev
+```
+
+## Runtime Requirements
+
+Manual development installs require Node.js 22+. The macOS release installer
+can install a private Node.js runtime automatically when Node/npm are missing or
+too old.
+
+The installer does not assume Homebrew exists. If it needs a private runtime, it
+downloads the official Node.js macOS tarball, verifies checksums, and records
+runtime ownership in the install manifest.
+
+## After Install
+
+After the browser opens:
+
+1. Create the first owner account.
+2. Configure or confirm at least one backend CLI.
+3. Open Settings to review security, passkeys, recovery codes, and update
+   status.
+
+## More Detail
+
+- [Self-hosting guide](../../ONBOARDING.md)
+- [Deployment spec](../spec-deployment.md)
+- [ADR-0054: Mac installer and release channels](../adr/0054-adopt-mac-installer-and-release-channels.md)
+- [ADR-0059: Private Node runtime on macOS](../adr/0059-install-private-node-runtime-on-macos.md)

--- a/docs/deploy/remote-access.md
+++ b/docs/deploy/remote-access.md
@@ -1,0 +1,46 @@
+# Remote Access
+
+Agent Cockpit is local-first, but you can access it from other devices through a
+private network, tunnel, or reverse proxy you control.
+
+## Recommended Pattern
+
+1. Install and start Agent Cockpit locally.
+2. Create the first owner account from localhost when possible.
+3. Configure passkeys and recovery codes.
+4. Expose the server through a private access path.
+5. Open the desktop UI or mobile PWA from the remote device.
+
+## Cloudflare Tunnel
+
+For a simple tunnel during setup:
+
+```bash
+cloudflared tunnel --url http://localhost:3334
+```
+
+Use the tunnel-provided URL to reach your local Agent Cockpit from another
+browser. For persistent Cloudflare Tunnel setup with PM2, see
+[ONBOARDING.md](../../ONBOARDING.md).
+
+## Tailscale Or LAN
+
+Agent Cockpit can also be reached over a private network when the host and
+client device can route to the server. Use your own firewall, DNS, and TLS
+configuration appropriate to that network.
+
+## First-Run Exposure Warning
+
+If the backend is reachable from a non-localhost address before the owner
+account exists, set `AUTH_SETUP_TOKEN`. The setup page requires that token for
+remote first-owner creation.
+
+## Mobile
+
+After remote access works, open:
+
+```text
+https://<your-host>/mobile/
+```
+
+Then use the browser's Add to Home Screen flow. See [Mobile PWA](../user/mobile-pwa.md).

--- a/docs/deploy/security.md
+++ b/docs/deploy/security.md
@@ -1,0 +1,44 @@
+# Security And Owner Auth
+
+Agent Cockpit uses first-party local owner authentication by default. The normal
+self-hosted flow does not require GitHub, Google, Apple ID, or Cloudflare Access.
+
+## First Owner Setup
+
+On first run, open `/auth/setup` and create the owner account with an email,
+display name, and password.
+
+Localhost setup does not require `AUTH_SETUP_TOKEN`. Remote setup does. If the
+server is exposed before the owner account exists, set `AUTH_SETUP_TOKEN` and
+enter it on the setup page.
+
+## Passkeys And Recovery Codes
+
+After setup, open **Settings > Security** to:
+
+- register one or more passkeys;
+- generate recovery codes;
+- enable passkey-required login after at least one passkey and one unused
+  recovery code exist.
+
+Passkeys are tied to the backend domain. If you move from one host to another,
+register a passkey while signed in on the new domain.
+
+## Local Lockout Recovery
+
+Run this on the backend machine:
+
+```bash
+npm run auth:reset -- --password "new long password" --disable-passkey-required --revoke-sessions --regenerate-recovery-codes
+```
+
+The reset command requires local filesystem access. It can reset the owner
+password, disable passkey-required mode, revoke sessions, and print replacement
+recovery codes.
+
+## Legacy OAuth
+
+Google/GitHub OAuth is legacy-only and disabled by default. Set
+`AUTH_ENABLE_LEGACY_OAUTH=true` only if you need the old provider routes
+temporarily, then configure the provider client id, client secret, callback URL,
+and allowed-email settings.

--- a/docs/deploy/updates.md
+++ b/docs/deploy/updates.md
@@ -1,0 +1,38 @@
+# Updates
+
+Agent Cockpit has two update paths:
+
+- Production installs update from GitHub Releases.
+- Dev installs update from `main`.
+
+## Production Installs
+
+Production installers write install metadata that lets Agent Cockpit check the
+latest GitHub Release, verify release checksums, stage the next release, and
+restart through PM2.
+
+Release artifacts include:
+
+- macOS tarball;
+- Windows ZIP;
+- release manifest;
+- SHA256 sums;
+- macOS installer;
+- Windows installer.
+
+## Dev Installs
+
+Dev installs keep the git checkout model: pull from `main`, install
+dependencies, rebuild assets when required, and restart the PM2-managed server.
+
+## User-Facing Updates
+
+The UI exposes self-update status and controls when the install state supports
+it. Production installs should prefer the release path instead of pulling
+directly from `main`.
+
+## More Detail
+
+- [Deployment spec](../spec-deployment.md)
+- [Release workflow](../release-workflow.md)
+- [Release notes prompt](../release-notes-prompt.md)

--- a/docs/deploy/windows.md
+++ b/docs/deploy/windows.md
@@ -1,0 +1,41 @@
+# Windows Install
+
+The supported Windows production path is a per-user PowerShell installer. It
+installs under `%LOCALAPPDATA%\Agent Cockpit`, verifies GitHub Release
+checksums, installs a private Node.js runtime when needed, uses install-local
+PM2 state, registers a current-user logon scheduled task, starts Agent Cockpit
+in the background without a visible Node console window, and opens first-run
+owner setup in the browser.
+
+```powershell
+powershell -ExecutionPolicy Bypass -NoProfile -Command "iwr https://github.com/daronyondem/agent-cockpit/releases/latest/download/install-windows.ps1 -OutFile $env:TEMP\install-agent-cockpit.ps1; & $env:TEMP\install-agent-cockpit.ps1 -Channel production"
+```
+
+## Dev Channel
+
+Dev installs track `main`:
+
+```powershell
+& $env:TEMP\install-agent-cockpit.ps1 -Channel dev
+```
+
+## Runtime Model
+
+The Windows installer is intentionally user-logon based. It does not install a
+Windows Service and does not run before any Windows user has logged in.
+
+When the welcome screen installs Claude Code or Codex on Windows, it installs
+the CLI into Agent Cockpit's per-user `cli-tools` prefix and Agent Cockpit runs
+the installed package entrypoint directly before falling back to npm command
+shims. No global Node/npm/PM2 install is required.
+
+## After Install
+
+1. Create the first owner account.
+2. Confirm backend CLI detection in the welcome/setup flow.
+3. Use the same owner account from desktop and mobile browsers.
+
+## More Detail
+
+- [Deployment spec](../spec-deployment.md)
+- [ADR-0063: Per-user Windows installer](../adr/0063-adopt-per-user-windows-installer.md)

--- a/docs/product-positioning.md
+++ b/docs/product-positioning.md
@@ -1,0 +1,109 @@
+# Agent Cockpit Product Positioning
+
+This document is the message architecture for public Agent Cockpit copy. Use it
+when writing the README, user docs, release notes, landing pages, or product
+descriptions.
+
+It is not a technical spec. Implementation truth remains in [SPEC.md](SPEC.md)
+and the focused `docs/spec-*.md` files.
+
+## Core Identity
+
+**Category:** local browser cockpit for CLI-based AI agents.
+
+**One-line promise:** run CLI AI agents from your browser, keep your context on
+your machine, and switch vendors without starting over.
+
+**Short description:** Agent Cockpit is an open source, local-first web UI for
+Claude Code, OpenAI Codex, Kiro, and future command-line AI agents. It wraps the
+CLIs users already install, streams their work into a browser interface, and
+stores conversations, memory, knowledge-base material, and workspace context
+locally.
+
+## Primary Audience
+
+Agent Cockpit is for technical users, builders, researchers, operators, and
+knowledge workers who:
+
+- use more than one AI vendor or expect to switch vendors over time;
+- prefer self-hosted/local tooling over hosted SaaS for AI interaction data;
+- want browser and mobile access to agents that run on their own machine;
+- use AI across coding, research, planning, writing, and daily knowledge work;
+- want long-lived project/workspace context outside any single vendor product.
+
+## Positioning Pillars
+
+### One Browser Interface For Local CLIs
+
+Agent Cockpit should be understood as a cockpit, not a replacement runtime. It
+starts or connects to local CLI backends and gives them a consistent browser UI
+for conversation, tools, files, sessions, and approvals.
+
+### Your AI Interaction Data Stays Local
+
+Lead with user ownership of interaction data: conversations, sessions, memory,
+knowledge-base entries, Context Map state, settings, and generated artifacts.
+Avoid implying that Agent Cockpit operates a cloud service.
+
+### Context Is Portable Across Vendors
+
+Memory, Knowledge Base, workspace instructions, and Context Map should be
+framed as provider-neutral context layers. A user can choose the best backend
+for the next task without losing the workspace understanding that has built up
+locally.
+
+### Self-Hosted, But Not From Scratch
+
+Be honest that Agent Cockpit is not a hosted SaaS. At the same time, production
+installers on macOS and Windows own much of the server setup: private runtime
+fallbacks, PM2 startup, release verification, self-update, and first-run owner
+setup.
+
+## What Agent Cockpit Is Not
+
+- **Not hosted SaaS.** There is no Agent Cockpit cloud account or central
+  dashboard.
+- **Not a model provider.** It does not host, proxy, or resell inference.
+- **Not a CLI replacement.** It wraps vendor CLIs and relies on their installed
+  auth/runtime behavior.
+- **Not an autonomous company orchestration layer.** It is a personal/local
+  cockpit for interacting with AI agents, not a business-control-plane system.
+- **Not zero setup.** The release installers reduce setup, but users still run
+  and secure a local server and authenticate the vendor CLIs they choose.
+
+## Message Hierarchy
+
+Use this order when public copy needs to be brief:
+
+1. Local browser UI for CLI AI agents.
+2. Conversations and context stay on your machine.
+3. Switch providers without losing accumulated workspace understanding.
+4. Works today with Claude Code, Codex, and Kiro.
+5. Production installers manage the local server on macOS and Windows.
+
+## Proof Points
+
+- Supports Claude Code, OpenAI Codex, and Kiro as local backends.
+- Stores workspace-scoped conversations, sessions, memory, and knowledge-base
+  artifacts locally.
+- Context Map builds governed workspace context that backends can query through
+  read-only MCP tools.
+- Mobile PWA is served by the same authenticated backend.
+- Production installs update from GitHub Releases; development installs track
+  `main`.
+- First-party local owner auth protects the web UI, with passkeys and recovery
+  codes available after setup.
+
+## Language Guidelines
+
+- Prefer direct user-facing phrases: "your machine", "your workspace",
+  "browser UI", "local CLI", "vendor CLIs", "owned context".
+- Avoid provider-specific framing unless a section is backend-specific.
+- Avoid overclaiming setup simplicity. Say "installer-managed local server"
+  rather than "zero setup".
+- Avoid enterprise jargon and inflated claims.
+- Keep copy distinct from organization-scale orchestration language. Do not
+  describe Agent Cockpit as an AI company, workforce, or autonomous business
+  platform.
+- Do not ask users to edit personal Claude Code settings for permissions or
+  attribution in public setup copy.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,23 @@
+# Agent Cockpit Reference
+
+This section is for advanced users and contributors who need exact commands,
+paths, contracts, or implementation details.
+
+## Operational Reference
+
+- [Environment variables](environment-variables.md)
+- [Data layout](data-layout.md)
+- [Backend capabilities](backend-capabilities.md)
+
+## Development Reference
+
+- [Development](development.md)
+- [Testing](testing.md)
+- [Specification](../SPEC.md)
+- [Architecture Decision Records](../adr/README.md)
+
+## Source Of Truth
+
+The public user/deploy docs explain how to use Agent Cockpit. The spec files
+under `docs/spec-*.md` define implemented behavior in enough detail to recreate
+the system.

--- a/docs/reference/backend-capabilities.md
+++ b/docs/reference/backend-capabilities.md
@@ -1,0 +1,37 @@
+# Backend Capabilities
+
+Agent Cockpit supports Claude Code, OpenAI Codex, and Kiro. The exact feature
+surface differs because each vendor CLI exposes different protocols and
+metadata.
+
+The detailed comparison table lives in [BACKENDS.md](../../BACKENDS.md). This
+page summarizes the user-facing shape.
+
+## Claude Code
+
+- direct CLI spawn per message;
+- plan mode support;
+- token and cost reporting when exposed by the CLI;
+- subagent and tool visualization;
+- mid-turn user input;
+- workspace instruction compatibility checks.
+
+## OpenAI Codex
+
+- Codex App Server JSON-RPC transport;
+- per-conversation persistent process with idle timeout;
+- thread creation and resume;
+- goal mode controls;
+- subagent demultiplexing;
+- token usage tracking;
+- MCP injection through spawn-time config overrides;
+- full local execution defaults through Codex approval/sandbox environment
+  values.
+
+## Kiro
+
+- ACP JSON-RPC transport;
+- lazy process spawn with idle timeout;
+- session creation, loading, and resume across restarts;
+- subagent tracking with grouped tool visualization;
+- credits/context reporting rather than token/cost reporting.

--- a/docs/reference/data-layout.md
+++ b/docs/reference/data-layout.md
@@ -1,0 +1,37 @@
+# Data Layout
+
+Agent Cockpit stores mutable runtime data under `AGENT_COCKPIT_DATA_DIR`, which
+defaults to `data` for manual development installs. Production installers place
+the data directory outside the replaceable app release directory.
+
+## Main Layout
+
+```text
+data/
+├── auth/                  # First-party owner auth state
+├── chat/
+│   ├── workspaces/{hash}/ # Workspace-scoped storage
+│   │   ├── index.json
+│   │   ├── {conversationId}/
+│   │   ├── memory/
+│   │   ├── knowledge/
+│   │   ├── context-map/
+│   │   └── session-finalizers.json
+│   ├── stream-jobs.json
+│   ├── usage-ledger.json
+│   ├── artifacts/
+│   └── settings.json
+└── sessions/              # Express session files
+```
+
+## Workspace Scope
+
+Conversations, session files, memory, Knowledge Base artifacts, and Context Map
+state are scoped by workspace directory. The workspace path is hashed before it
+becomes an on-disk directory name.
+
+## Production Install Metadata
+
+Production installers also write install-state metadata used by self-update and
+Install Doctor. See [spec-deployment.md](../spec-deployment.md) for the full
+manifest contract.

--- a/docs/reference/development.md
+++ b/docs/reference/development.md
@@ -1,0 +1,50 @@
+# Development
+
+Use this path when working on Agent Cockpit itself rather than installing a
+production release.
+
+## Setup
+
+```bash
+git clone https://github.com/daronyondem/agent-cockpit.git
+cd agent-cockpit
+npm install
+cp .env.example .env
+```
+
+Edit `.env` for your local machine. At minimum, set `SESSION_SECRET` or use an
+installer-generated environment when testing an installed copy.
+
+## Run
+
+For a foreground development process:
+
+```bash
+npm start
+```
+
+For persistent local server management, use PM2:
+
+```bash
+npx pm2 start ecosystem.config.js
+npx pm2 logs agent-cockpit
+npx pm2 restart agent-cockpit
+npx pm2 stop agent-cockpit
+```
+
+Do not use `node server.js` directly.
+
+## Frontend Builds
+
+```bash
+npm run web:typecheck
+npm run web:build
+npm run mobile:typecheck
+npm run mobile:build
+```
+
+## More Detail
+
+- [AGENTS.md](../../AGENTS.md)
+- [Specification](../SPEC.md)
+- [Testing](testing.md)

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,0 +1,32 @@
+# Environment Variables
+
+This page summarizes the most common Agent Cockpit environment variables. The
+complete implementation contract lives in [spec-deployment.md](../spec-deployment.md)
+and [spec-server-security.md](../spec-server-security.md).
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `PORT` | No | `3334` | Server listen port. |
+| `SESSION_SECRET` | Yes | none | Secret for signing session cookies. Installers generate this. |
+| `AGENT_COCKPIT_DATA_DIR` | No | `data` | Mutable data root for chat data, sessions, auth state, install manifest, and update artifacts. |
+| `AUTH_DATA_DIR` | No | `data/auth` | First-party owner auth state directory. |
+| `AUTH_SETUP_TOKEN` | Recommended for remote setup | none | Token required to create the first owner account from a non-localhost request. |
+| `AUTH_ENABLE_LEGACY_OAUTH` | No | `false` | Enables legacy Google/GitHub OAuth routes. |
+| `DEFAULT_WORKSPACE` | No | `~/.openclaw/workspace` | Default working directory for CLI processes. |
+| `BASE_PATH` | No | empty | URL base path for reverse proxy deployments. |
+| `KIRO_ACP_IDLE_TIMEOUT_MS` | No | `3600000` | Idle timeout before killing the Kiro ACP process. |
+| `CODEX_IDLE_TIMEOUT_MS` | No | `600000` | Idle timeout before killing the Codex app-server process. |
+| `CODEX_APPROVAL_POLICY` | No | `never` | Codex approval policy for interactive threads. |
+| `CODEX_SANDBOX_MODE` | No | `danger-full-access` | Codex sandbox mode for interactive threads. |
+| `LOG_LEVEL` | No | `info` | Server log threshold. |
+
+## Codex Defaults
+
+Agent Cockpit treats Codex as a trusted local backend by default:
+
+```env
+CODEX_APPROVAL_POLICY=never
+CODEX_SANDBOX_MODE=danger-full-access
+```
+
+Set stricter values only when you intentionally want a restricted deployment.

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -1,0 +1,36 @@
+# Testing
+
+Tests use Jest for the main suite and separate commands for web, mobile, and
+real-CLI compatibility checks.
+
+## Common Checks
+
+```bash
+npm run typecheck
+npm test
+npm run maintainability:check
+npm run spec:drift
+```
+
+## Web And Mobile
+
+```bash
+npm run web:typecheck
+npm run web:build
+npm run web:budget
+npm run mobile:typecheck
+npm run mobile:build
+```
+
+## Claude Code Interactive Compatibility
+
+These suites require an authenticated real `claude` CLI and are intentionally
+not part of normal CI:
+
+```bash
+npm run e2e:claude-interactive:report
+npm run e2e:claude-interactive-ui:report
+```
+
+Review the Claude Code Interactive compatibility guidance in [AGENTS.md](../../AGENTS.md)
+before changing that backend path.

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,0 +1,25 @@
+# Agent Cockpit User Guide
+
+This guide covers day-to-day use of Agent Cockpit after the local server is
+installed and the first owner account exists.
+
+## Start Here
+
+- [Quickstart](quickstart.md) explains the first run from install to first
+  conversation.
+- [Supported backends](backends.md) explains Claude Code, OpenAI Codex, and Kiro
+  setup differences.
+
+## Core Workflows
+
+- [Memory](memory.md) explains workspace-scoped persistent memory.
+- [Knowledge Base](knowledge-base.md) explains document ingestion and retrieval.
+- [Context Map](context-map.md) explains the governed workspace graph.
+- [Mobile PWA](mobile-pwa.md) explains browser-based mobile access.
+
+## Related Deployment Topics
+
+- [macOS install](../deploy/macos.md)
+- [Windows install](../deploy/windows.md)
+- [Remote access](../deploy/remote-access.md)
+- [Security and owner auth](../deploy/security.md)

--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -1,0 +1,62 @@
+# Supported Backends
+
+Agent Cockpit wraps local command-line AI tools. The CLI must be installed and
+authenticated on the same machine that runs the Agent Cockpit server.
+
+| Backend | CLI | Best For | Notes |
+| --- | --- | --- | --- |
+| Claude Code | `claude` | Planning, tool-heavy coding, plan mode | Supports token and cost reporting, plan mode, subagents, and mid-turn input. |
+| OpenAI Codex | `codex` | Fast coding iteration and goal-mode workflows | Uses Codex App Server, supports subagents, goal controls, token usage, and full local execution defaults. |
+| Kiro | `kiro-cli` | ACP-based workflows and Kiro-specific projects | Uses ACP over stdin/stdout and reports credits/context percentage rather than token cost. |
+
+For the full feature matrix, see [BACKENDS.md](../../BACKENDS.md).
+
+## Claude Code
+
+Install and authenticate Claude Code using Anthropic's documented CLI flow.
+Agent Cockpit runs Claude through its own backend adapter and does not require
+users to edit personal Claude settings for permissions or attribution.
+
+Claude-specific features include:
+
+- plan mode;
+- token and USD cost reporting when exposed by the CLI;
+- subagent and tool visualization;
+- mid-turn user input;
+- workspace instruction compatibility checks.
+
+## OpenAI Codex
+
+Install Codex with npm when needed:
+
+```bash
+npm install -g @openai/codex
+```
+
+Then authenticate with `codex login` or configure the environment expected by
+the Codex CLI.
+
+Agent Cockpit defaults Codex interactive threads to full local execution:
+
+- `CODEX_APPROVAL_POLICY=never`
+- `CODEX_SANDBOX_MODE=danger-full-access`
+
+Use stricter environment settings only when you intentionally want a restricted
+deployment.
+
+## Kiro
+
+Install and authenticate `kiro-cli` on the server machine before selecting Kiro
+as a backend. Agent Cockpit talks to Kiro through ACP, keeps the process alive
+with an idle timeout, and resumes sessions across server restarts when the
+backend supports it.
+
+## Backend Switching
+
+Backend selection is per conversation. New conversations remember the currently
+selected default, and existing conversation context remains in Agent Cockpit's
+workspace storage regardless of which backend produced it.
+
+Provider-neutral context features such as Memory, Knowledge Base, and Context
+Map are designed to make switching backends useful instead of starting from an
+empty prompt every time.

--- a/docs/user/context-map.md
+++ b/docs/user/context-map.md
@@ -1,0 +1,40 @@
+# Context Map
+
+Context Map is the workspace-level graph feature. It tracks important entities,
+relationships, facts, and evidence for a workspace so AI backends can retrieve
+compact context instead of rereading everything.
+
+## What It Tracks
+
+Context Map can represent:
+
+- people;
+- projects;
+- services;
+- documents;
+- decisions;
+- implementation areas;
+- dependencies and ownership relationships.
+
+Each conclusion is evidence-backed so users can review where it came from.
+
+## How It Works
+
+When enabled, Context Map scans high-signal workspace files and conversation
+history in the background. It proposes graph updates, applies safe updates when
+policy allows, and surfaces review items for user attention.
+
+The active CLI can read the map through read-only MCP tools. It receives compact
+context packs, not the entire graph.
+
+## When To Use It
+
+Use Context Map when a workspace has enough long-lived structure that a normal
+chat history or short memory note is not enough:
+
+- larger software repositories;
+- research or planning folders;
+- client/account workspaces;
+- projects with many decisions and dependencies.
+
+For implementation details, see [spec-context-map.md](../spec-context-map.md).

--- a/docs/user/knowledge-base.md
+++ b/docs/user/knowledge-base.md
@@ -1,0 +1,34 @@
+# Knowledge Base
+
+The Knowledge Base is the long-lived document layer for a workspace. It lets you
+upload source material, process it locally, and make it available to supported
+AI backends during conversations.
+
+## Supported Sources
+
+Agent Cockpit can ingest PDFs, Word documents, PowerPoints, images, CSV/TSV
+files, Markdown, and text-like files. Optional tools such as LibreOffice and
+Pandoc expand conversion coverage for office and document formats.
+
+## What Happens During Ingestion
+
+Agent Cockpit stores the raw file, converts it when needed, extracts structured
+entries, organizes topics, and builds local indexes for retrieval.
+
+The goal is not to dump whole documents into prompts. The goal is to retrieve
+the right source-backed material when a conversation needs it.
+
+## Good Uses
+
+- codebase documentation;
+- research folders;
+- meeting notes;
+- product specs;
+- business or legal reading material;
+- personal study notes.
+
+## Data Ownership
+
+Knowledge Base artifacts live under the local Agent Cockpit data directory for
+the workspace. The model provider only sees content when a selected backend is
+asked to use it during a conversation.

--- a/docs/user/memory.md
+++ b/docs/user/memory.md
@@ -1,0 +1,35 @@
+# Memory
+
+Memory stores durable workspace notes for future conversations. It is separate
+from a single vendor's memory feature and is scoped to the Agent Cockpit
+workspace.
+
+## What Memory Is For
+
+Use Memory for recurring facts, preferences, decisions, and project context that
+should survive conversation resets and backend switches.
+
+Examples:
+
+- project conventions;
+- user preferences;
+- recurring workflow rules;
+- durable decisions from prior conversations;
+- important external references.
+
+## How It Works
+
+Agent Cockpit stores memory files under the workspace data directory. Supported
+backends can read relevant memory through the local context mechanisms Agent
+Cockpit provides, and memory review workflows help keep persistent notes useful
+instead of letting them grow unchecked.
+
+## Relationship To Knowledge Base And Context Map
+
+- **Memory** is for concise durable notes.
+- **Knowledge Base** is for source documents and extracted entries.
+- **Context Map** is for governed entities, relationships, facts, and evidence.
+
+Use the smallest feature that matches the job. A short preference belongs in
+Memory; a PDF belongs in the Knowledge Base; an evidence-backed relationship
+between projects belongs in Context Map.

--- a/docs/user/mobile-pwa.md
+++ b/docs/user/mobile-pwa.md
@@ -1,0 +1,28 @@
+# Mobile PWA
+
+Agent Cockpit's supported mobile client is a Progressive Web App served by the
+same backend as the desktop UI.
+
+## Install
+
+1. Open `https://<your-host>/mobile/` on your phone.
+2. Sign in with the same owner account.
+3. Use the browser's Add to Home Screen flow.
+
+The PWA uses the same authenticated web session as the desktop UI.
+
+## What It Is For
+
+Use the mobile PWA to:
+
+- monitor active conversations;
+- answer interactive questions;
+- review running-state badges;
+- steer work while away from the desktop browser.
+
+## What It Is Not
+
+There is no native iOS, Android, Expo, TestFlight, or App Store distribution
+path. The supported mobile path is `/mobile/` plus Add to Home Screen.
+
+For implementation details, see [spec-mobile-pwa.md](../spec-mobile-pwa.md).

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -1,0 +1,59 @@
+# Quickstart
+
+Agent Cockpit runs on the same machine as your AI CLIs. Install the local
+server, create the first owner account, make sure at least one backend CLI is
+authenticated, then start a conversation from the browser.
+
+## 1. Install Agent Cockpit
+
+Use the production installer for your platform:
+
+- [macOS install](../deploy/macos.md)
+- [Windows install](../deploy/windows.md)
+
+For development from source, see [development setup](../reference/development.md).
+
+## 2. Create The Owner Account
+
+Open the URL printed by the installer, usually `http://localhost:3334`, and
+complete first-run setup at `/auth/setup`.
+
+If you expose the backend before creating the owner account, set
+`AUTH_SETUP_TOKEN` and enter that token during setup so a remote visitor cannot
+claim the empty server.
+
+## 3. Authenticate A Backend CLI
+
+Agent Cockpit uses the vendor CLIs already installed on the same machine. At
+least one of these should be installed and authenticated:
+
+| Backend | Command |
+| --- | --- |
+| Claude Code | `claude` |
+| OpenAI Codex | `codex` |
+| Kiro | `kiro-cli` |
+
+See [Supported Backends](backends.md) for setup notes and feature differences.
+
+## 4. Choose A Workspace
+
+Create or select a workspace directory in the UI. Conversations, memory, KB
+state, Context Map data, and workspace settings are scoped to that directory.
+
+## 5. Send A Message
+
+Pick a backend from the composer, write a prompt, and send it. The response
+streams through the browser while the local CLI works on the server machine.
+
+Generated files and file-delivery references appear as cards in the
+conversation when a backend emits them.
+
+## 6. Add Durable Context
+
+Once the basic chat path works, enable the context features that match your
+workflow:
+
+- [Memory](memory.md) for persistent working notes.
+- [Knowledge Base](knowledge-base.md) for source documents.
+- [Context Map](context-map.md) for governed workspace entities and
+  relationships.


### PR DESCRIPTION
## Summary
- Refactors the README into a public product overview with fit guidance, capability summary, platform quickstarts, and docs routing.
- Adds a positioning reference plus user, deploy, and technical reference guide indexes.
- Adds starter pages for backends, Memory, Knowledge Base, Context Map, mobile PWA, platform installs, remote access, security, updates, Install Doctor, data layout, environment variables, development, and testing.
- Updates the spec index so the public docs layer is discoverable beside implementation specs.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test`
- `npm run adr:lint`
- `npm run maintainability:check`
- `npm run spec:drift`
- changed-doc markdown link check

## Impact
- Mobile PWA impact: documentation-only; added a user-facing mobile PWA guide, no runtime mobile behavior changed.
- Spec impact: updated `docs/SPEC.md` index for the new public docs layer.
- ADR impact: no ADR needed; this is reversible documentation structure and copy.
- AGENTS impact: no recurring workflow or architecture rule changed.
