### PR TITLE
Fix self-update restart script permissions

### DIFF
--- a/docs/spec-backend-services.md
+++ b/docs/spec-backend-services.md
@@ -1230,9 +1230,12 @@ Production-channel sequence:
 - `restart({ hasActiveStreams })` — plain server restart (no git pull / npm install / interpreter verification). Applies the same concurrent + active/pending turn guards as `triggerUpdate()`, then calls `_launchRestartScript()`. Used by the Server tab in Global Settings so users can re-trigger startup-time detection (e.g. pandoc) after installing external binaries. The guard delegates to the stream supervisor's in-flight check and still treats accepted/preparing sends as active even though they now have durable stream jobs; planned/manual restarts should be blocked before work is interrupted.
 - `_launchRestartScript()` (private) — on POSIX writes
   `<dataRoot>/restart.sh` (sets PATH to `node_modules/.bin`, sleeps 2s,
-  `pm2 delete` + `pm2 start` against `ecosystem.config.js`), then launches it
-  via double-fork (`nohup ... &` in subshell) to survive PM2 treekill. On
-  Windows it writes `<dataRoot>/restart.ps1`, sets install-local `PM2_HOME`,
+  `pm2 delete` + `pm2 start` against `ecosystem.config.js`), forces the file
+  mode to `0755` after every write so stale non-executable restart scripts are
+  repaired, then launches it through `sh` via double-fork (`nohup sh ... &` in
+  subshell) to survive PM2 treekill without depending on the script file's
+  executable bit. On Windows it writes `<dataRoot>/restart.ps1`, sets
+  install-local `PM2_HOME`,
   prepends the private runtime path when present, resolves the active release's
   app-local `node_modules\.bin\pm2.cmd`, restarts the app through a checked
   native-command wrapper that deletes the existing PM2 entry before

--- a/docs/spec-deployment.md
+++ b/docs/spec-deployment.md
@@ -89,10 +89,13 @@ Agent Cockpit has two release/update channels:
 Runtime self-update is channel-aware. Production installs read `install.json`,
 check the latest GitHub Release manifest, verify release checksums, stage the
 next release under the platform install root, activate it, and restart through
-PM2 with health-check rollback. macOS and Linux activate releases by switching
-the `current` symlink. Windows activates releases by writing the active
-versioned `appDir` to `install.json` and restarting from that directory. Dev
-installs keep the git/main update behavior described below.
+PM2 with health-check rollback. macOS and Linux write `<dataRoot>/restart.sh`,
+repair its mode to `0755`, and launch it through `nohup sh` so stale
+non-executable restart artifacts cannot block future self-updates. macOS and
+Linux activate releases by switching the `current` symlink. Windows activates
+releases by writing the active versioned `appDir` to `install.json` and
+restarting from that directory. Dev installs keep the git/main update behavior
+described below.
 
 ## Production Release Packaging
 

--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -448,9 +448,10 @@ export class UpdateService {
     const scriptContent = scriptLines.join('\n');
     fs.mkdirSync(this._dataRoot, { recursive: true });
     fs.writeFileSync(scriptFile, scriptContent, { mode: 0o755 });
+    fs.chmodSync(scriptFile, 0o755);
     // Double-fork: subshell backgrounds nohup, then exits immediately.
     // The nohup process gets reparented to init, surviving treekill.
-    spawn('sh', ['-c', `(nohup "${scriptFile}" >> "${logFile}" 2>&1 &)`], {
+    spawn('sh', ['-c', `(nohup sh "${scriptFile}" >> "${logFile}" 2>&1 &)`], {
       cwd: appRoot,
       stdio: 'ignore',
     });

--- a/test/updateService.test.ts
+++ b/test/updateService.test.ts
@@ -40,6 +40,8 @@ function mockWriteFileSyncNoop(...args: Parameters<typeof fs.writeFileSync>) {
   }
 }
 const mockWriteFileSync = jest.spyOn(fs, 'writeFileSync').mockImplementation(mockWriteFileSyncNoop);
+const originalChmodSync = fs.chmodSync.bind(fs);
+const mockChmodSync = jest.spyOn(fs, 'chmodSync').mockImplementation(() => undefined);
 
 import { UpdateService } from '../src/services/updateService';
 
@@ -346,6 +348,8 @@ describe('UpdateService', () => {
     mockSpawnFn.mockClear();
     mockWriteFileSync.mockClear();
     mockWriteFileSync.mockImplementation(mockWriteFileSyncNoop);
+    mockChmodSync.mockClear();
+    mockChmodSync.mockImplementation(() => undefined);
     mockExistsSyncOverrides = {};
     mockReadFileSyncOverrides = {};
     // Default: interpreter exists
@@ -894,6 +898,32 @@ describe('UpdateService', () => {
       expect(shellCmd).toContain('nohup');
       expect(shellCmd).toContain('restart.sh');
       expect(shellCmd).toContain('update-restart.log');
+    });
+
+    test('repairs a stale non-executable restart script before launching it', async () => {
+      mockWriteFileSync.mockImplementation((...args: Parameters<typeof fs.writeFileSync>) => originalWriteFileSync(...args));
+      mockChmodSync.mockImplementation((...args: Parameters<typeof fs.chmodSync>) => originalChmodSync(...args));
+      const dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'update-restart-mode-'));
+      try {
+        const scriptPath = path.join(dataRoot, 'restart.sh');
+        writeText(scriptPath, '#!/bin/sh\nexit 0\n');
+        fs.chmodSync(scriptPath, 0o644);
+        service = new UpdateService(appRoot, {
+          webBuildService: { ensureBuilt: mockWebBuildEnsureBuilt },
+          mobileBuildService: { ensureBuilt: mockMobileBuildEnsureBuilt },
+          dataRoot,
+        });
+
+        const result = await service.restart({ hasActiveStreams: () => false });
+
+        expect(result.success).toBe(true);
+        expect(fs.statSync(scriptPath).mode & 0o777).toBe(0o755);
+        const spawnArgs = mockSpawnFn.mock.calls[0] as unknown[];
+        const shellCmd = (spawnArgs[1] as string[])[1];
+        expect(shellCmd).toContain(`nohup sh "${scriptPath}"`);
+      } finally {
+        fs.rmSync(dataRoot, { recursive: true, force: true });
+      }
     });
 
     test('applies a production GitHub Release update and writes rollback restart script', async () => {


### PR DESCRIPTION
## Summary
- Repair POSIX self-update restart scripts by forcing mode 0755 after every write.
- Launch restart scripts through `nohup sh` so stale file modes cannot block future updates.
- Add regression coverage and update the deployment/backend specs.

## Verification
- `npm test -- --runTestsByPath test/updateService.test.ts test/macosInstallerScript.test.ts test/releasePackage.test.ts`
- `npm test -- --runInBand`
- `npm run maintainability:check`
- `npm run spec:drift`
- `git diff --check`

## Impact
- Mobile PWA impact: none; updater restart handoff only.
- ADR: not needed; this is a narrow bug fix within the existing self-update design.
- AGENTS.md: no recurring workflow or architecture rule changed.