### PR TITLE
Resolve npm audit remediation

### DIFF
--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -40,17 +40,22 @@ developer detail document.
    merged PRs, closed issues, merge commits, `git diff --stat`,
    `git diff --name-status`, and targeted code/spec/test reads for changed
    subsystems.
-4. Generate `docs/releases/v<version>.md` using
+4. Run dependency audit checks for both package roots:
+   `npm audit` and `npm audit --prefix mobile/AgentCockpitPWA`. Do not proceed
+   with undocumented moderate-or-higher findings; either remediate them or link
+   the release notes/prep record to the issue that documents the accepted
+   exposure and follow-up plan.
+5. Generate `docs/releases/v<version>.md` using
    [release-notes-prompt.md](release-notes-prompt.md).
-5. Validate the GitHub Release body locally:
+6. Validate the GitHub Release body locally:
 
 ```bash
 npm run release:notes -- --version <version> --out /tmp/agent-cockpit-release-notes.md
 ```
 
-6. Commit the release document and any release-workflow changes before triggering
+7. Commit the release document and any release-workflow changes before triggering
    the GitHub Actions release workflow.
-7. Share the generated document with the human for review. Apply requested edits
+8. Share the generated document with the human for review. Apply requested edits
    before running the release workflow.
 
 ## Publishing

--- a/docs/spec-deployment.md
+++ b/docs/spec-deployment.md
@@ -188,7 +188,10 @@ The final step creates GitHub Release `v<version>` with title
 requires `docs/releases/v<version>.md` to exist in the checked-out source ref.
 That source-controlled release document is produced during release preparation
 using `docs/release-notes-prompt.md` and reviewed before the manual workflow is
-triggered. The renderer validates that the document has non-empty
+triggered. Release preparation also runs `npm audit` at the repository root and
+`npm audit --prefix mobile/AgentCockpitPWA`; moderate-or-higher findings must be
+fixed before release or linked to a documented exposure analysis and follow-up
+issue. The renderer validates that the document has non-empty
 `## Shipped For Users` and `## Developer Details` sections, rejects TODO/TBD
 placeholder text, requires at least one shipped-user bullet, and writes a GitHub
 Release body that includes the user-facing shipped list plus a link to

--- a/improvements.md
+++ b/improvements.md
@@ -146,6 +146,14 @@ Verification:
 
 Objective: resolve or explicitly document dependency vulnerabilities.
 
+Status: completed for issue #421 on 2026-06-10. `npm audit fix` updated the
+root lockfile for the `qs` advisory by moving Express to `4.22.2`,
+`body-parser` to `1.20.5`, and `qs` to `6.15.2`. The mobile PWA audit still
+reports zero findings. The only remaining root audit findings are the two
+moderate PM2 nested `ws` entries tracked in #346; `pm2@7.0.1` is still the
+latest npm release and still pins `ws@8.20.0`, while npm's available force fix
+is a PM2 7-to-6 downgrade.
+
 Work plan:
 
 1. Run current audit:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3756,9 +3756,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -3769,7 +3769,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -4605,9 +4605,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4820,14 +4820,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -4846,7 +4846,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -5392,9 +5392,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8205,9 +8205,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -8633,14 +8633,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -8652,13 +8652,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"


### PR DESCRIPTION
## Summary

- Updated the root lockfile with the non-force audit remediation for the `qs` advisory, moving Express to `4.22.2`, `body-parser` to `1.20.5`, and `qs` to `6.15.2`.
- Documented the Phase 4 audit remediation outcome and the remaining PM2 nested `ws` exposure tracked in #346.
- Added root and mobile `npm audit` checks to release preparation docs and deployment spec coverage.

## Verification

- `npm audit` exits non-zero only for the documented PM2 nested `ws` advisory tracked in #346.
- `npm audit --prefix mobile/AgentCockpitPWA`
- `npm run typecheck`
- `npm run web:build`
- `npm run mobile:build`
- `npm run maintainability:check`
- `npm run spec:drift`
- `npm test -- --runTestsByPath test/chat.dataMigration.test.ts test/webBuildService.test.ts test/dataMigrationService.test.ts test/graceful-shutdown.test.ts test/chat.cliProfileAuth.test.ts --runInBand`
- `npm test -- --runInBand`

Fixes #421
Refs #346
