### PR TITLE
Add Claude Opus 5 support for Kiro

### DIFF
--- a/docs/spec-backend-services.md
+++ b/docs/spec-backend-services.md
@@ -1103,11 +1103,12 @@ When a `.claude/plans/` write completes in plan mode, the streaming route may em
 
 ### KiroAdapter (`src/services/backends/kiro.ts`)
 
-**Metadata:** `id: 'kiro'`, capabilities: `thinking: true, planMode: false, agents: true, toolActivity: true, userQuestions: false, stdinInput: false, oneShotMediaInput: { image: ['explicit-attachment'] }`. `resumeCapabilities` reports active-turn resume as unsupported and later-session resume as supported via `external_session` + `session/load`. Exposes a hardcoded `models` array so the selector renders immediately on page load (Kiro's ACP `session/new` response also carries a model list, but that's only available after the first message — reading it lazily caused the dropdown to appear empty and then pop in "after the fact"). The hardcoded list mirrors the customer-usable catalog advertised by Kiro CLI 2.13.1 plus the explicitly requested internal `claude-fable-5` preview. `auto` and Claude-family Kiro models declare image input support; GPT and open-weight Kiro models with unconfirmed media behavior declare text-only capabilities so KB image conversion fails closed instead of assuming vision:
+**Metadata:** `id: 'kiro'`, capabilities: `thinking: true, planMode: false, agents: true, toolActivity: true, userQuestions: false, stdinInput: false, oneShotMediaInput: { image: ['explicit-attachment'] }`. `resumeCapabilities` reports active-turn resume as unsupported and later-session resume as supported via `external_session` + `session/load`. Exposes a hardcoded `models` array so the selector renders immediately on page load (Kiro's ACP `session/new` response also carries a model list, but that's only available after the first message — reading it lazily caused the dropdown to appear empty and then pop in "after the fact"). The hardcoded list mirrors the customer-usable catalog advertised by Kiro CLI 2.14.2 plus the explicitly requested internal `claude-fable-5` preview. `auto` and Claude-family Kiro models declare image input support; GPT and open-weight Kiro models with unconfirmed media behavior declare text-only capabilities so KB image conversion fails closed instead of assuming vision:
 
 | ID | Family | Cost Tier | Default |
 |---|---|---|---|
 | `auto` | router | medium | ✓ |
+| `claude-opus-5` | opus | high | — |
 | `claude-sonnet-5` | sonnet | medium | — |
 | `claude-opus-4.8` | opus | high | — |
 | `gpt-5.6-sol` | gpt | high | — |

--- a/src/services/backends/kiro.ts
+++ b/src/services/backends/kiro.ts
@@ -478,6 +478,14 @@ export class KiroAdapter extends BaseBackendAdapter {
           capabilities: TEXT_IMAGE_MODEL_CAPABILITIES,
         },
         {
+          id: 'claude-opus-5',
+          label: 'claude-opus-5',
+          family: 'opus',
+          description: 'Experimental preview of Claude Opus 5 with a 1M context window',
+          costTier: 'high',
+          capabilities: TEXT_IMAGE_MODEL_CAPABILITIES,
+        },
+        {
           id: 'claude-sonnet-5',
           label: 'claude-sonnet-5',
           family: 'sonnet',

--- a/test/kiroBackend.test.ts
+++ b/test/kiroBackend.test.ts
@@ -36,7 +36,7 @@ describe('KiroAdapter', () => {
     const adapter = new KiroAdapter({ workingDir: '/tmp' });
     const models = adapter.metadata.models;
     expect(models).toBeDefined();
-    expect(models!.length).toBe(19); // auto + fable + 4 opus + 4 sonnet + haiku + 3 GPT + 5 open-weight
+    expect(models!.length).toBe(20); // auto + fable + 5 opus + 4 sonnet + haiku + 3 GPT + 5 open-weight
 
     const auto = models!.find(m => m.id === 'auto');
     expect(auto).toBeDefined();
@@ -47,6 +47,12 @@ describe('KiroAdapter', () => {
 
     // auto is the only default
     expect(models!.filter(m => m.default).length).toBe(1);
+
+    const opus5 = models!.find(m => m.id === 'claude-opus-5');
+    expect(opus5).toBeDefined();
+    expect(opus5!.family).toBe('opus');
+    expect(opus5!.costTier).toBe('high');
+    expect(opus5!.capabilities?.input?.image).toBe(true);
 
     const sonnet5 = models!.find(m => m.id === 'claude-sonnet-5');
     expect(sonnet5).toBeDefined();


### PR DESCRIPTION
## Summary

- add `claude-opus-5` to the Kiro model catalog
- expose Opus-family, high-cost-tier, and image-input metadata
- update the Kiro catalog test and backend specification for Kiro CLI 2.14.2

## Why

Kiro CLI 2.14.2 advertises `claude-opus-5`, but Agent Cockpit's hardcoded Kiro catalog still reflected the earlier 2.13.1 model list. This prevented the model from appearing in Agent Cockpit's Kiro model selectors.

## Impact

Kiro users can select Claude Opus 5 anywhere Agent Cockpit projects the shared backend model metadata. The `auto` model remains the default, and the internal `agi-nova-beta-1m` model remains excluded.

## Validation

- `npm test -- --runInBand` — 123 suites passed, 2,463 tests passed
- `npm test -- --runInBand test/kiroBackend.test.ts` — 76 tests passed
- `npm run lint`
- `npm run maintainability:check`
- `npm run spec:drift`
- `git diff --check`
